### PR TITLE
feat: add jarl 0.5.0 as R idiom linter alongside ast-grep (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Cumulative lab notes. Track completed work, **failed approaches**, accuracy chec
 
 Convention: newest entries at top. Each entry has a date, what was done, and why.
 
+## 2026-05-03
+
+### Completed
+- **llm#93: jarl 0.5.0 evaluation** — `explorations/2026-05-03_jarl-eval/`
+  - Installed jarl 0.5.0 binary (aarch64-apple-darwin; not available via `cargo install jarl`)
+  - Ran ast-grep (8 rules) on R/: **0 violations** (codebase clean)
+  - Ran jarl (default rules) on R/: **10 issues** — 6 `redundant_equals` (auto-fixable), 2 `unused_function`, 2 `unreachable_code`
+  - Ran jarl (ALL rules, R from nix shell): **17 real issues** + ~50 `quotes` false positives (Mermaid strings need single quotes)
+  - Performance: jarl 19ms vs ast-grep ~1.5s (both exclude nix shell startup)
+  - **Recommendation: Option A** — complement ast-grep (banned patterns) with jarl (R idioms)
+  - Drafted `jarl.toml` with `quotes` disabled
+  - Gaps remaining: DPLYR rules, .qmd scanning, multi-project comparison
+
 ## 2026-05-01 to 2026-05-03
 
 ### Completed

--- a/R/dev/issues/fix_issue_7.R
+++ b/R/dev/issues/fix_issue_7.R
@@ -3,6 +3,7 @@
 # Issue: https://github.com/JohnGavin/llm/issues/7
 
 # 1. Create issue (already done)
+# jarl-ignore unreachable_code: if (FALSE) is standard R idiom for dev scripts
 if (FALSE) {
   gh::gh(
     "POST /repos/JohnGavin/llm/issues",
@@ -12,6 +13,7 @@ if (FALSE) {
 }
 
 # 2. Create dev branch (already done)
+# jarl-ignore unreachable_code: if (FALSE) is standard R idiom for dev scripts
 if (FALSE) {
   options(rlang_interactive = TRUE)
   env <- asNamespace("usethis")

--- a/R/dev/wiki/sync_wiki.R
+++ b/R/dev/wiki/sync_wiki.R
@@ -86,7 +86,7 @@ read_summary <- function(path) {
 
 wiki_page_name_from_source <- function(src_path) {
   base <- sub("\\.md$", "", basename(src_path))
-  gsub("_", "-", base)
+  gsub("_", "-", base, fixed = TRUE)
 }
 
 wiki_page_url <- function(page_name) paste0(wiki_base_url, "/", page_name)

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -134,6 +134,7 @@ load_all_predictions <- function(dir = "~/.claude/predictions") {
 #' @param db_path Path to DuckDB file
 #' @return Invisible row count
 #' @noRd
+# jarl-ignore unused_function: internal helper, wired in future calibration targets
 store_cross_project_predictions <- function(predictions, db_path) {
   if (is.null(predictions) || nrow(predictions) == 0) return(invisible(0L))
 
@@ -161,6 +162,7 @@ store_cross_project_predictions <- function(predictions, db_path) {
 #' @return List with brier_score, accuracy, calibration_by_bucket,
 #'   rolling_brier, n_total, n_resolved
 #' @noRd
+# jarl-ignore unused_function: internal helper, wired in future calibration targets
 compute_calibration_metrics <- function(predictions) {
   empty_result <- list(
     brier_score = NA_real_,
@@ -192,7 +194,7 @@ compute_calibration_metrics <- function(predictions) {
   }
 
   resolved <- resolved |>
-    dplyr::mutate(outcome_binary = dplyr::if_else(outcome == TRUE, 1, 0))
+    dplyr::mutate(outcome_binary = dplyr::if_else(outcome, 1, 0))
 
   brier_score <- mean((resolved$p_success - resolved$outcome_binary)^2)
   accuracy <- mean((resolved$p_success >= 0.5) == (resolved$outcome_binary == 1))

--- a/R/tar_plans/plan_pkgdown.R
+++ b/R/tar_plans/plan_pkgdown.R
@@ -57,7 +57,7 @@ plan_pkgdown <- function() {
         force(pkgdown_build)
         gert::git_add("docs")
         staged <- gert::git_status()
-        staged <- staged[staged$staged == TRUE, , drop = FALSE]
+        staged <- staged[staged$staged, , drop = FALSE]
         n <- nrow(staged)
 
         if (n > 0) {

--- a/R/tar_plans/plan_predictions.R
+++ b/R/tar_plans/plan_predictions.R
@@ -52,12 +52,12 @@ plan_predictions <- function() {
             n_predictions = dplyr::n(),
             n_resolved = sum(!is.na(outcome)),
             success_rate = if (sum(!is.na(outcome)) > 0) {
-              mean(outcome[!is.na(outcome)] == TRUE)
+              mean(outcome[!is.na(outcome)])
             } else {
               NA_real_
             },
             brier_score = if (sum(!is.na(outcome)) > 0) {
-              outcome_bin <- as.integer(outcome[!is.na(outcome)] == TRUE)
+              outcome_bin <- as.integer(outcome[!is.na(outcome)])
               p_sub <- p_success[!is.na(outcome)]
               mean((p_sub - outcome_bin)^2)
             } else {
@@ -87,7 +87,7 @@ plan_predictions <- function() {
 
         resolved |>
           dplyr::mutate(
-            outcome_binary = dplyr::if_else(outcome == TRUE, 1, 0)
+            outcome_binary = dplyr::if_else(outcome, 1, 0)
           ) |>
           dplyr::arrange(recorded_at) |>
           dplyr::mutate(
@@ -195,7 +195,7 @@ plan_predictions <- function() {
         # Create long format for actual vs predicted comparison
         plot_data <- pred_all_raw |>
           dplyr::filter(!is.na(outcome)) |>
-          dplyr::mutate(outcome_binary = dplyr::if_else(outcome == TRUE, 1, 0)) |>
+          dplyr::mutate(outcome_binary = dplyr::if_else(outcome, 1, 0)) |>
           dplyr::group_by(project_name) |>
           dplyr::summarise(
             `Mean Predicted` = mean(p_success),

--- a/R/tar_plans/plan_vignette_outputs.R
+++ b/R/tar_plans/plan_vignette_outputs.R
@@ -252,7 +252,7 @@ plan_vignette_outputs <- function() {
           model_usage <- vig_session_metrics |>
             dplyr::select(date, duration_mins, cost_per_min, models) |>
             tidyr::unnest(models) |>
-            dplyr::mutate(model_clean = gsub("claude-", "", models))
+            dplyr::mutate(model_clean = gsub("claude-", "", models, fixed = TRUE))
 
           ggplot2::ggplot(model_usage, ggplot2::aes(x = date, y = cost_per_min)) +
             ggplot2::geom_point(alpha = 0.4, color = "steelblue") +
@@ -649,7 +649,7 @@ plan_vignette_outputs <- function() {
       {
         tryCatch({
           r_files <- list.files("R", pattern = "\\.R$", full.names = TRUE, recursive = TRUE)
-          r_files <- r_files[!grepl("R/dev/", r_files)]
+          r_files <- r_files[!grepl("R/dev/", r_files, fixed = TRUE)]
           test_files <- list.files("tests/testthat", pattern = "^test-.*\\.R$")
           vignette_files <- list.files("vignettes", pattern = "\\.(qmd|Rmd)$")
           plan_files <- list.files("R/tar_plans", pattern = "^plan_.*\\.R$")

--- a/jarl.toml
+++ b/jarl.toml
@@ -1,0 +1,5 @@
+[lint]
+ignore = ["quotes"]
+
+[lint.assignment]
+operator = "<-"


### PR DESCRIPTION
## Summary

- Add `jarl.toml` to project root — disables `quotes` rule (Mermaid false positives), enforces `<-` assignment
- Apply 9 auto-fixes from `jarl check --fix`: 7× `redundant_equals`, 2× `fixed_regex`  
- Add 4 targeted `# jarl-ignore` suppressions for expected warnings (dev script `if (FALSE)` idiom, unexported internal helpers)

## What this changes

**R code (auto-fixed):**
- `dplyr::if_else(outcome == TRUE, ...)` → `dplyr::if_else(outcome, ...)` (5 locations in plan_predictions.R, plan_pkgdown.R)
- `gsub("_", "-", x)` → `gsub("_", "-", x, fixed = TRUE)` (sync_wiki.R, plan_vignette_outputs.R)

**Tooling:**
- `r_code_check.sh` — fixed early-exit bug (was exiting 0 when ast-grep clean, skipping jarl); added jarl integration block
- `/check` command doc — updated to show combined ast-grep + jarl sweep

## Why not replace ast-grep

ast-grep catches project-specific banned patterns (`DBI::dbGetQuery`, `stop()`, `suppressWarnings(as.*)`) via custom YAML rules. jarl catches general R idioms. Zero overlap — both stay.

## Test plan

- [x] `jarl check R/` → exit 0
- [x] `jarl check vignettes/` → exit 0
- [x] `~/.claude/scripts/r_code_check.sh R/` → exit 0 (jarl section runs)
- [x] DPLYR rules inside nix shell → 0 violations

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)