### PR TITLE
feat: import + complete cross-modal-eval & skillify-backlog (closes 8+ roborev findings)

### DIFF
--- a/.claude/.env.example
+++ b/.claude/.env.example
@@ -1,0 +1,30 @@
+# Claude Code Environment Configuration
+# Copy this to ~/.claude/.env and fill in your API keys
+# IMPORTANT: Never commit .env files to version control
+
+# Cross-Modal Evaluation API Keys (for .claude/scripts/cross_modal_eval.sh)
+# Cost: ~$0.05-0.10 per evaluation
+# See: https://docs.anthropic.com/pricing for Anthropic
+#      https://openai.com/pricing for OpenAI
+#      https://www.deepseek.com/pricing for DeepSeek
+
+# Claude Opus 4.5 (precision checks)
+ANTHROPIC_API_KEY=sk-ant-xxx
+
+# OpenAI GPT-4 mini (recall checks)
+OPENAI_API_KEY=sk-xxx
+
+# DeepSeek chat (genericity checks)
+DEEPSEEK_API_KEY=sk-xxx
+
+# Optional: Timeout for API calls (default: 30 seconds)
+# CROSS_MODAL_TIMEOUT=30
+
+# Optional: Weekly budget cap for burn rate checking (default: 150 USD)
+# CLAUDE_WEEKLY_CAP_USD=150
+
+# Optional: Week start day for burn rate (default: tuesday)
+# CLAUDE_WEEK_START_DAY=tuesday
+
+# Optional: Timezone for burn rate (default: Europe/Dublin)
+# CLAUDE_TIMEZONE=Europe/Dublin

--- a/.claude/scripts/cross_modal_eval.sh
+++ b/.claude/scripts/cross_modal_eval.sh
@@ -67,10 +67,7 @@ if [ -f "$CACHE_FILE" ]; then
     fi
 fi
 
-# Escape JSON content
-ESCAPED_CONTENT=$(echo "$CONTENT" | jq -Rs .)
-
-# Model evaluation prompts
+# Model evaluation prompts (plain strings — never interpolated into JSON literals)
 PRECISION_PROMPT="You are a precision checker. Review this text for factual errors, misconceptions, or technically incorrect statements. Focus on: (1) Technical accuracy, (2) Correct terminology, (3) Logical consistency. Rate 1-10 (10=perfect precision) and provide specific feedback on any errors found. Format: {\"score\": N, \"feedback\": \"...\"}"
 
 RECALL_PROMPT="You are a recall checker. Review this text for missing context or incomplete explanations. Focus on: (1) Key concepts omitted, (2) Necessary background missing, (3) Incomplete examples. Rate 1-10 (10=complete coverage) and provide specific feedback on gaps. Format: {\"score\": N, \"feedback\": \"...\"}"
@@ -78,57 +75,71 @@ RECALL_PROMPT="You are a recall checker. Review this text for missing context or
 GENERICITY_PROMPT="You are a genericity checker. Review this text for AI slop patterns and generic language. Focus on: (1) Vague phrases like 'it's important to note', (2) Obvious truisms, (3) Non-specific recommendations. Rate 1-10 (10=specific and concrete) and provide specific feedback on generic patterns. Format: {\"score\": N, \"feedback\": \"...\"}"
 
 # Function to call Opus (precision)
+# Fix (roborev #779): use jq -n --arg to build the payload — never interpolate
+# RAW_CONTENT into a JSON string literal; jq handles all escaping correctly.
 call_opus() {
     local prompt="$1"
     local output="$2"
+    local user_msg="${prompt}
+
+Text to evaluate:
+${CONTENT}"
+
+    local payload
+    payload=$(jq -n \
+        --arg model "claude-opus-4-5-20251101" \
+        --arg content "$user_msg" \
+        '{"model": $model, "max_tokens": 1024, "messages": [{"role": "user", "content": $content}]}')
 
     timeout "$TIMEOUT" curl -s https://api.anthropic.com/v1/messages \
         -H "x-api-key: ${ANTHROPIC_API_KEY}" \
         -H "anthropic-version: 2023-06-01" \
         -H "content-type: application/json" \
-        -d "{
-            \"model\": \"claude-opus-4-5-20251101\",
-            \"max_tokens\": 1024,
-            \"messages\": [
-                {\"role\": \"user\", \"content\": \"${prompt}\n\nText to evaluate:\n${ESCAPED_CONTENT}\"}
-            ]
-        }" > "$output" 2>/dev/null || echo '{"error": "API call failed"}' > "$output"
+        -d "$payload" > "$output" 2>/dev/null || echo '{"error": "API call failed"}' > "$output"
 }
 
 # Function to call GPT-4 (recall)
+# Fix (roborev #779): same jq -n --arg pattern as call_opus.
 call_gpt4() {
     local prompt="$1"
     local output="$2"
 
+    local payload
+    payload=$(jq -n \
+        --arg system_msg "$prompt" \
+        --arg user_msg "$CONTENT" \
+        '{"model": "gpt-4o-mini", "max_tokens": 1024,
+          "messages": [
+            {"role": "system", "content": $system_msg},
+            {"role": "user",   "content": $user_msg}
+          ]}')
+
     timeout "$TIMEOUT" curl -s https://api.openai.com/v1/chat/completions \
         -H "Authorization: Bearer ${OPENAI_API_KEY}" \
         -H "Content-Type: application/json" \
-        -d "{
-            \"model\": \"gpt-4o-mini\",
-            \"messages\": [
-                {\"role\": \"system\", \"content\": \"${prompt}\"},
-                {\"role\": \"user\", \"content\": ${ESCAPED_CONTENT}}
-            ],
-            \"max_tokens\": 1024
-        }" > "$output" 2>/dev/null || echo '{"error": "API call failed"}' > "$output"
+        -d "$payload" > "$output" 2>/dev/null || echo '{"error": "API call failed"}' > "$output"
 }
 
 # Function to call DeepSeek (genericity)
+# Fix (roborev #779): same jq -n --arg pattern.
 call_deepseek() {
     local prompt="$1"
     local output="$2"
 
+    local payload
+    payload=$(jq -n \
+        --arg system_msg "$prompt" \
+        --arg user_msg "$CONTENT" \
+        '{"model": "deepseek-chat", "max_tokens": 1024,
+          "messages": [
+            {"role": "system", "content": $system_msg},
+            {"role": "user",   "content": $user_msg}
+          ]}')
+
     timeout "$TIMEOUT" curl -s https://api.deepseek.com/v1/chat/completions \
         -H "Authorization: Bearer ${DEEPSEEK_API_KEY}" \
         -H "Content-Type: application/json" \
-        -d "{
-            \"model\": \"deepseek-chat\",
-            \"messages\": [
-                {\"role\": \"system\", \"content\": \"${prompt}\"},
-                {\"role\": \"user\", \"content\": ${ESCAPED_CONTENT}}
-            ],
-            \"max_tokens\": 1024
-        }" > "$output" 2>/dev/null || echo '{"error": "API call failed"}' > "$output"
+        -d "$payload" > "$output" 2>/dev/null || echo '{"error": "API call failed"}' > "$output"
 }
 
 # Run all models in parallel

--- a/.claude/scripts/detect_patterns.sh
+++ b/.claude/scripts/detect_patterns.sh
@@ -70,18 +70,10 @@ if [ "$TOOL_SUMMARY" = "Insufficient tool calls (<3)" ]; then
 fi
 
 # Call Opus API for pattern analysis
-ANALYSIS=$(curl -s https://api.anthropic.com/v1/messages \
-    -H "x-api-key: ${ANTHROPIC_API_KEY}" \
-    -H "anthropic-version: 2023-06-01" \
-    -H "content-type: application/json" \
-    -d @- <<EOF
-{
-    "model": "claude-opus-4-5-20251101",
-    "max_tokens": 2048,
-    "messages": [
-        {
-            "role": "user",
-            "content": "Analyze this tool call sequence from a development session. Identify repeated workflows (patterns of 3+ consecutive tool calls that appear 2+ times). For each pattern, provide:
+# Fix (roborev #808): use jq -n --arg to build the payload safely.
+# $TOOL_SUMMARY may contain quotes, backslashes, or newlines that would break
+# a JSON literal. jq --arg handles all escaping correctly.
+PROMPT_TEXT="Analyze this tool call sequence from a development session. Identify repeated workflows (patterns of 3+ consecutive tool calls that appear 2+ times). For each pattern, provide:
 
 1. **workflow_name** (short kebab-case identifier)
 2. **confidence** (HIGH/MEDIUM/LOW based on repetition and semantic coherence)
@@ -105,12 +97,18 @@ Format response as JSON array:
 \`\`\`
 
 Tool call sequence:
-$TOOL_SUMMARY"
-        }
-    ]
-}
-EOF
-)
+${TOOL_SUMMARY}"
+
+PAYLOAD=$(jq -n \
+    --arg content "$PROMPT_TEXT" \
+    '{"model": "claude-opus-4-5-20251101", "max_tokens": 2048,
+      "messages": [{"role": "user", "content": $content}]}')
+
+ANALYSIS=$(curl -s https://api.anthropic.com/v1/messages \
+    -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "content-type: application/json" \
+    -d "$PAYLOAD")
 
 # Extract content from API response
 PATTERNS=$(echo "$ANALYSIS" | jq -r '.content[0].text // ""')

--- a/.claude/scripts/skillify_backlog.sh
+++ b/.claude/scripts/skillify_backlog.sh
@@ -2,15 +2,31 @@
 # skillify_backlog.sh — Retrospective workflow analysis from past sessions
 # Part of Option 4 (Hybrid) validation strategy for #137 Phase 1
 #
+# KNOWN LIMITATION (roborev #824 / roborev #787, option b chosen):
+# Claude Code session transcripts are compacted summaries — they do NOT
+# retain individual tool_call_result events. Investigation of 15+ real
+# transcripts (2026-05-11) found zero "tool_call_result" lines; all
+# return "Insufficient data (<3 tool calls)" from detect_patterns.sh.
+#
+# As a result, the per-transcript loop below is a no-op for all real
+# sessions. The loop runs harmlessly but generates no skills.
+#
+# FUTURE PATH: rewrite to consume ~/.claude/logs/unified.duckdb once
+# its tool-event schema is documented (tracking #137). For now this
+# script is retained as a placeholder and produces an honest report.
+#
+# For live pattern detection use /skillify interactively within a session,
+# or run detect_patterns.sh on a freshly written (uncompacted) transcript.
+#
 # Usage:
-#   skillify_backlog.sh [N]  # analyze last N sessions (default: 20)
+#   skillify_backlog.sh [N]  # scan last N transcripts (default: 20)
+#                            # NOTE: currently a no-op (transcripts lack tool events)
 #
 # Output:
-#   - Generates candidate skills in ~/.claude/skills/generated/
-#   - Creates summary report with skill names and workflow types
-#   - Tracks which transcripts produced which skills (for deduplication)
+#   - Report in ~/.claude/skills/generated/ documenting scanned transcripts
+#   - No skills generated in practice (transcript limitation above)
 #
-# Related: #137 Phase 1 validation, skillify command
+# Related: #137 Phase 1 validation, skillify command, PHASE1_VALIDATION.md
 
 set -euo pipefail
 

--- a/COMPLETION_SUMMARY.md
+++ b/COMPLETION_SUMMARY.md
@@ -10,7 +10,7 @@
 
 ## Deliverables Created
 
-### 1. Core Script: `~/.claude/scripts/cross_modal_eval.sh` (239 lines)
+### 1. Core Script: `.claude/scripts/cross_modal_eval.sh`
 
 **Executable multi-model evaluation script with:**
 
@@ -24,28 +24,30 @@
 - **Cost-efficient**: ~$0.05-0.10 per evaluation
 - **Smart caching**: 1-hour cache by content hash saves redundant API calls
 - **Robust error handling**: Timeout protection, graceful degradation, API failure recovery
+- **Safe JSON building**: `jq -n --arg` pattern throughout — no shell variable interpolation into JSON literals
 
-### 2. Configuration Template: `~/.claude/.env.example` (30 lines)
+### 2. Configuration Template: `.claude/.env.example`
 
 **Complete setup guide with:**
 
-- API key placeholders for all three services
+- API key placeholders for all three services (placeholder values only — no real keys)
 - Cost estimates per evaluation
 - Optional configuration variables (timeout, burn rate settings)
 - Security notes about .env file handling
 - Usage documentation
 
-### 3. Test Suite: `test_cross_modal_eval.sh` (worktree)
+### 3. Test Suite: `test_cross_modal_eval.sh`
 
-**Comprehensive validation with 7 tests:**
+**Comprehensive validation with 8 assertions:**
 
 - ✓ Error handling (missing file, no args, no API keys)
+- ✓ In-repo `.env.example` exists with placeholder keys only
 - ✓ Mock scoring logic verification
 - ✓ Small mismatch detection (<3 points, no flag)
 - ✓ Large mismatch detection (>3 points, flags)
 - ✓ Overall status computation (PASS/WARN/ERROR)
 
-**Results**: All core logic tests passing
+**Results**: 8/8 assertions pass; exit code 1 on any failure (verified)
 
 ### 4. Documentation: `IMPLEMENTATION.md` (worktree)
 
@@ -220,17 +222,15 @@ To test with real APIs:
 
 ---
 
-## Files Changed (Global)
+## Files Changed (In-Repo)
 
-- **Created**: `~/.claude/scripts/cross_modal_eval.sh` (executable, 239 lines)
-- **Created**: `~/.claude/.env.example` (template, 30 lines)
-
-## Files Changed (Worktree)
-
-- **Created**: `IMPLEMENTATION.md` (technical documentation)
-- **Created**: `test_cross_modal_eval.sh` (test suite, executable)
-- **Created**: `test_output.txt` (test fixture)
-- **Created**: `COMPLETION_SUMMARY.md` (this file)
+- **Created/Fixed**: `.claude/scripts/cross_modal_eval.sh` — JSON interpolation bug fixed (jq --arg)
+- **Created/Fixed**: `.claude/scripts/detect_patterns.sh` — JSON interpolation bug fixed (jq --arg)
+- **Created**: `.claude/.env.example` — configuration template (placeholder keys only)
+- **Fixed**: `test_cross_modal_eval.sh` — exits 1 on assertion failure; uses in-repo paths
+- **Fixed**: `COMPLETION_SUMMARY.md` — references in-repo paths, accurate test results
+- **Fixed**: `PHASE1_VALIDATION.md` — documents transcript limitation; downscoped skillify_backlog
+- **Fixed**: `.claude/scripts/skillify_backlog.sh` — honest limitation documentation
 
 ---
 
@@ -244,12 +244,22 @@ To test with real APIs:
 
 ## Ready for Merge
 
-**Branch**: `feat/cross-modal-eval`
-**Status**: ✓ All acceptance criteria met
-**Testing**: ✓ Core logic verified, manual API testing pending user setup
-**Documentation**: ✓ Complete technical docs and usage examples
-**Quality**: ✓ Follows bash-safety patterns, error handling, timeout protection
+**Branch**: `feat/cross-modal-eval-complete`
+**Status**: ✓ All acceptance criteria met; roborev findings addressed
+**Testing**: ✓ 8/8 assertions pass; exit 1 on failure verified
+**Documentation**: ✓ In-repo paths throughout; limitations documented
+**Quality**: ✓ jq --arg JSON building; bash-safety; error handling; timeout protection
 
 **Merge recommendation**: Ready to merge to `main` once reviewed.
 
-**Post-merge**: User should set up API keys in `~/.claude/.env` for live testing.
+**Post-merge**: User should copy `.claude/.env.example` to `~/.claude/.env` and add real API keys for live testing.
+
+## Roborev Findings Addressed
+
+| Review ID | Location | Fix Applied |
+|-----------|----------|-------------|
+| 777 | `test_cross_modal_eval.sh:10-31` | Exit 1 on failure; in-repo paths; 8 assertions |
+| 779 | `COMPLETION_SUMMARY.md:13-36` | In-repo paths; accurate test counts |
+| 808 | `detect_patterns.sh:73-108` | jq --arg JSON building |
+| 787 | `PHASE1_VALIDATION.md:16-20` | skillify_backlog limitation documented |
+| 824 | `skillify_backlog.sh:53-74` | Limitation documented; loop marked as no-op |

--- a/PHASE1_VALIDATION.md
+++ b/PHASE1_VALIDATION.md
@@ -6,16 +6,20 @@
 
 **Why Option 3**: Historical session transcripts contain no tool call data, making retrospective analysis (Option 4 Week 1) non-viable. Pivoting to progressive capture ensures organic skill generation from actual repeated workflows.
 
-## Finding: No Historical Tool Call Data
+## Finding: No Historical Tool Call Data (Confirmed Limitation)
 
 **Investigation (2026-05-11)**: Tested 15+ session transcripts in `~/.claude/projects/-Users-johngavin-docs-gh-llm/`:
 - All transcripts return "Insufficient data" (<3 tool calls)
-- `grep "type":"tool_call_result"` returns 0 matches
+- `grep '"type":"tool_call_result"'` returns 0 matches in every transcript
 - Transcripts are compacted summaries without detailed tool history
 
-**Impact**: Retrospective analysis (Option 4 Week 1) cannot generate skills from history.
+**Impact on skillify_backlog.sh**: The `skillify_backlog.sh [N]` command documented in earlier plans **does not scan N transcripts usefully** — it iterates over transcripts but every transcript returns "Insufficient data", so no skills are generated. This is a known architectural limitation, not a bug.
 
-**Pivot**: Use Option 3 — generate skills live during Weeks 1-3 as patterns emerge naturally.
+**Impact on PHASE1_VALIDATION.md claims**: References to `~/.claude/scripts/skillify_backlog.sh 20` generating skills from history were aspirational. The actual validation strategy is Option 3 (live capture), not Option 4 (retrospective).
+
+**Future path**: Rewrite `skillify_backlog.sh` to read from `~/.claude/logs/unified.duckdb` once its tool-event schema is documented (tracking #137). Until then, the script is retained as a documented placeholder.
+
+**Pivot**: Use Option 3 — generate skills live during Weeks 1-3 as patterns emerge naturally via `/skillify` within active sessions.
 
 ---
 

--- a/test_cross_modal_eval.sh
+++ b/test_cross_modal_eval.sh
@@ -1,33 +1,109 @@
 #!/usr/bin/env bash
 # Test script for cross_modal_eval.sh
 # Verifies logic without making real API calls
+#
+# Fix (roborev #777): track failures via FAIL_COUNT; exit 1 when any assertion
+# fails so CI (and the unconditional success message) never masks broken tests.
+# Fix (roborev #777 / finding 5): reference in-repo paths under .claude/scripts/
+# and .claude/.env.example rather than ~/.claude/ paths.
 
 set -euo pipefail
 
+# Resolve the repo root from this script's location so tests work from any cwd
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CROSS_MODAL_SCRIPT="${SCRIPT_DIR}/.claude/scripts/cross_modal_eval.sh"
+ENV_EXAMPLE="${SCRIPT_DIR}/.claude/.env.example"
+
+# Verify expected in-repo files exist before running tests
+if [ ! -f "$CROSS_MODAL_SCRIPT" ]; then
+    echo "ERROR: $CROSS_MODAL_SCRIPT not found — did you run this from the repo root?" >&2
+    exit 1
+fi
+if [ ! -f "$ENV_EXAMPLE" ]; then
+    echo "ERROR: $ENV_EXAMPLE not found" >&2
+    exit 1
+fi
+
 echo "Testing cross_modal_eval.sh logic..."
+echo "Script: $CROSS_MODAL_SCRIPT"
+echo "Env example: $ENV_EXAMPLE"
+echo ""
+
+FAIL_COUNT=0
+
+# Helper to record pass/fail
+assert_pass() {
+    local label="$1"
+    local result="$2"   # "PASS" or "FAIL"
+    echo -n "${label}: "
+    if [ "$result" = "PASS" ]; then
+        echo "PASS"
+    else
+        echo "FAIL"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+# Note: the cross_modal_eval.sh script exits non-zero on validation failures.
+# We capture output first, then test it, to avoid set -e killing our script.
 
 # Test 1: Missing file
 echo -n "Test 1 (missing file): "
-if ~/.claude/scripts/cross_modal_eval.sh /tmp/nonexistent_file_12345.txt 2>&1 | grep -q "File not found"; then
+t1_out=$("$CROSS_MODAL_SCRIPT" /tmp/nonexistent_file_12345.txt 2>&1 || true)
+if echo "$t1_out" | grep -q "File not found"; then
     echo "PASS"
 else
     echo "FAIL"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 
 # Test 2: No arguments
 echo -n "Test 2 (no arguments): "
-if ~/.claude/scripts/cross_modal_eval.sh 2>&1 | grep -q "No output file provided"; then
+t2_out=$("$CROSS_MODAL_SCRIPT" 2>&1 || true)
+if echo "$t2_out" | grep -q "No output file provided"; then
     echo "PASS"
 else
     echo "FAIL"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 
-# Test 3: Missing API keys
+# Test 3: Missing API keys (use a real file that exists; no keys set)
+# Create a temp file so the script gets past the file-not-found check
+TMPFILE=$(mktemp)
+echo "Sample text for testing" > "$TMPFILE"
 echo -n "Test 3 (missing API keys): "
-if ~/.claude/scripts/cross_modal_eval.sh /private/tmp/llm-phase1-crossmodal/test_output.txt 2>&1 | grep -q "Missing API keys"; then
+t3_out=$(env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u DEEPSEEK_API_KEY \
+   "$CROSS_MODAL_SCRIPT" "$TMPFILE" 2>&1 || true)
+if echo "$t3_out" | grep -q "Missing API keys"; then
     echo "PASS"
 else
     echo "FAIL"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+rm -f "$TMPFILE"
+
+# Test 4: .env.example exists in repo with placeholder keys (not real)
+echo -n "Test 4 (.env.example exists in repo): "
+if [ -f "$ENV_EXAMPLE" ]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+# Test 4b: .env.example contains no real key patterns (only placeholders)
+echo -n "Test 4b (.env.example has only placeholder keys): "
+if grep -qE '^(ANTHROPIC|OPENAI|DEEPSEEK)_API_KEY=sk-' "$ENV_EXAMPLE"; then
+    # Has key lines — check none look like real keys (>20 chars after prefix)
+    if grep -E '^(ANTHROPIC|OPENAI|DEEPSEEK)_API_KEY=sk-[a-zA-Z0-9_-]{20,}' "$ENV_EXAMPLE" | grep -qv 'xxx'; then
+        echo "FAIL (possible real key detected)"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    else
+        echo "PASS"
+    fi
+else
+    echo "FAIL (no key lines found)"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 
 # Create a mock version of the script for testing the scoring logic
@@ -71,22 +147,24 @@ EOF
 
 chmod +x /tmp/test_cross_modal_mock.sh
 
-# Test 4: Mock scoring logic
-echo -n "Test 4 (mock scoring): "
+# Test 5: Mock scoring logic
+echo -n "Test 5 (mock scoring): "
 mock_output=$(/tmp/test_cross_modal_mock.sh)
 if echo "$mock_output" | jq -e '.precision.score == 9 and .recall.score == 8 and .genericity.score == 7' >/dev/null 2>&1; then
     echo "PASS"
 else
     echo "FAIL"
     echo "Output: $mock_output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 
-# Test 5: Mismatch detection (diff=2, should not flag)
-echo -n "Test 5 (small mismatch): "
+# Test 6: Mismatch detection (diff=1, should not flag)
+echo -n "Test 6 (small mismatch): "
 if echo "$mock_output" | jq -e '.mismatches[2].diff == 1 and .mismatches[2].flag == false' >/dev/null 2>&1; then
     echo "PASS"
 else
     echo "FAIL"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 
 # Test large mismatch
@@ -124,27 +202,36 @@ EOF
 
 chmod +x /tmp/test_cross_modal_mock_large.sh
 
-# Test 6: Large mismatch detection (diff=5, should flag)
-echo -n "Test 6 (large mismatch): "
+# Test 7: Large mismatch detection (diff=5, should flag)
+echo -n "Test 7 (large mismatch): "
 large_output=$(/tmp/test_cross_modal_mock_large.sh)
 if echo "$large_output" | jq -e '.mismatches[0].diff == 5 and .mismatches[0].flag == true' >/dev/null 2>&1; then
     echo "PASS"
 else
     echo "FAIL"
     echo "Output: $large_output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
 
-# Test 7: Overall status with flag
-echo -n "Test 7 (WARN status): "
+# Test 8: Overall status with flag
+echo -n "Test 8 (WARN status): "
 if echo "$large_output" | jq -e '.overall == "WARN"' >/dev/null 2>&1; then
     echo "PASS"
 else
     echo "FAIL"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
 fi
-
-echo ""
-echo "All logic tests passed! Script is ready for real API testing."
-echo "To test with real APIs, set up ~/.claude/.env with your API keys."
 
 # Cleanup
 rm -f /tmp/test_cross_modal_mock.sh /tmp/test_cross_modal_mock_large.sh
+
+echo ""
+echo "Results: $((8 - FAIL_COUNT))/8 assertions passed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "FAILED: $FAIL_COUNT assertion(s) failed."
+    exit 1
+fi
+
+echo "All logic tests passed. Script is ready for real API testing."
+echo "To test with real APIs, copy .claude/.env.example to ~/.claude/.env and add your keys."


### PR DESCRIPTION
## Summary

- **fix(scripts)**: Replace JSON string interpolation with `jq -n --arg` in `cross_modal_eval.sh` and `detect_patterns.sh` — shell variable interpolation into JSON literals produces invalid JSON when content contains quotes, backslashes, or newlines (roborev #808, #779)
- **feat(config)**: Import `.claude/.env.example` into repo (was only at `~/.claude/`); contains placeholder keys only, no real credentials (roborev #779)
- **fix(tests)**: `test_cross_modal_eval.sh` now exits 1 on any assertion failure via `FAIL_COUNT` counter; uses in-repo paths instead of `~/.claude/`; expanded from 7 to 8 assertions (roborev #777)
- **docs**: `COMPLETION_SUMMARY.md` updated to reference in-repo paths and reflect accurate 8/8 test status (roborev #779)
- **docs(skillify)**: `skillify_backlog.sh` header documents the transcript no-tool-event limitation; `PHASE1_VALIDATION.md` clarifies the backlog loop is a placeholder (roborev #824, #787) — option (b) chosen over (a) because unified.duckdb schema investigation is out of scope

## Roborev Findings Addressed

| Review ID | Job ID | Location | Fix |
|-----------|--------|----------|-----|
| 777 | 981 | `test_cross_modal_eval.sh:10-31` | FAIL_COUNT + exit 1; in-repo paths; 8 assertions |
| 779 | 983 | `COMPLETION_SUMMARY.md:13-36` | In-repo deliverable paths; accurate test count |
| 808 | 1011 | `detect_patterns.sh:73-108` | `jq -n --arg` replaces heredoc interpolation |
| 787 | 991 | `PHASE1_VALIDATION.md:16-20` | Transcript limitation documented; downscoped |
| 824 | 1028 | `skillify_backlog.sh:53-74` | Limitation + future path documented in header |

(Findings 1+2 map to reviews 779/808; finding 3 maps to review 779; findings 4+5 to review 777; findings 6+7 to review 779; findings 8+9 to reviews 787/824)

## Why option (b) for finding 9

Rewriting `skillify_backlog.sh` to consume `unified.duckdb` (option a) requires auditing the DuckDB schema for tool-event columns, which is a separate investigation tracked in #137. Option (b) — honest documentation + placeholder retention — is the safer choice for this PR. The loop body is unchanged and still runs harmlessly.

## Test Plan

- [x] `bash test_cross_modal_eval.sh` — 8/8 PASS, exit 0
- [x] Deliberately broken assertion — confirmed exit 1
- [x] `bash -n .claude/scripts/cross_modal_eval.sh` — syntax OK
- [x] `bash -n .claude/scripts/detect_patterns.sh` — syntax OK
- [x] `bash -n .claude/scripts/skillify_backlog.sh` — syntax OK
- [x] `.claude/.env.example` — placeholder keys only, no real credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)