### PR TITLE
fix(launchd): pass wiki_dir to health-pulse + portable shebang on roborev_poll_merges

### DIFF
--- a/.claude/launchd/com.claude.wiki-health-pulse.plist
+++ b/.claude/launchd/com.claude.wiki-health-pulse.plist
@@ -7,6 +7,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/wiki_health_check.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/knowledge/wiki</string>
     </array>
     <key>StartCalendarInterval</key>
     <dict>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Cumulative lab notes. Track completed work, **failed approaches**, accuracy chec
 
 Convention: newest entries at top. Each entry has a date, what was done, and why.
 
+## 2026-05-17 (fixer — launchd Phase 4 bug fixes)
+
+### Completed
+
+- **wiki-health-pulse plist fixed** — `com.claude.wiki-health-pulse.plist` was missing the required `<wiki_dir>` argument to `wiki_health_check.sh`. Script exits with usage error when no directory is provided, so the T4 cron job never ran the health check. Added `/Users/johngavin/docs_gh/llm/knowledge/wiki` as the second `<string>` in `ProgramArguments`. Verified with `plutil -lint`.
+- **Note on 2026-05-16 Phase 4 count** — the "5 jobs/day" count in the May 16 entry included `wiki-health-pulse` but the plist was broken at time of shipping. Count is now accurate.
+- **roborev_poll_merges.sh shebang** — already corrected to `#!/usr/bin/env bash` in a prior session (per 2026-05-16 "Option B" entry); no change needed in this PR.
+
 ## 2026-05-16 (Session 2 — roborev evaluation + closure-loop automation Phase 1)
 
 ### Completed


### PR DESCRIPTION
## Summary

- **plist bug fixed**: `com.claude.wiki-health-pulse.plist` was calling `wiki_health_check.sh` with no arguments. The script exits 2 with a usage error when `WIKI_DIR` is empty, so the T4 daily wiki health check never ran. Added `/Users/johngavin/docs_gh/llm/knowledge/wiki` as the second `ProgramArguments` entry. Verified with `plutil -lint`.
- **shebang already fixed**: `roborev_poll_merges.sh` shebang was corrected to `#!/usr/bin/env bash` in a prior session (2026-05-16 "Option B"); no change needed.
- **CHANGELOG updated**: new 2026-05-17 entry at top documents both findings; notes that the May 16 "5 jobs/day" count is now accurate.

## Test plan

- [ ] `plutil -lint .claude/launchd/com.claude.wiki-health-pulse.plist` exits 0
- [ ] `bash -n .claude/scripts/roborev_poll_merges.sh` exits 0
- [ ] After `launchctl load`, `launchctl start com.claude.wiki-health-pulse` produces output in `~/.claude/logs/wiki_health_pulse.out` (not the usage error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)