### PR TITLE
fix(hooks): gate pattern detection to /bye only — Stop fires every reply

### DIFF
--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -4,6 +4,16 @@
 
 Run the end-of-session checklist from AGENTS.md Section 6.
 
+## First: Write the /bye sentinel
+
+Before any other step, run this shell command so the session_stop.sh hook
+knows this Stop event comes from /bye (not a normal reply). The hook gates
+the paid pattern-detection block on this sentinel file and deletes it after use.
+
+```bash
+touch ~/.claude/.bye-requested
+```
+
 ## Steps
 
 1. Check for uncommitted changes

--- a/.claude/hooks/session_stop.sh
+++ b/.claude/hooks/session_stop.sh
@@ -141,7 +141,15 @@ for p in pending:
 fi
 
 # ── Pattern Detection (Phase 1 Validation, Option 4 Hybrid) ──────────────
-if [ -f "${HOME}/.claude/scripts/detect_patterns.sh" ]; then
+# IMPORTANT: The Stop hook fires after EVERY Claude response, not only /bye.
+# Running pattern detection (paid Opus API call) on every response would be
+# a massive cost regression. We gate on a sentinel file that /bye writes
+# before invoking the Stop hook. Non-/bye stops skip this block entirely.
+# The sentinel (~/.claude/.bye-requested) is deleted immediately after use
+# so a crash or abort does not leave a stale sentinel.
+_BYE_SENTINEL="${HOME}/.claude/.bye-requested"
+if [ -f "$_BYE_SENTINEL" ] && [ -f "${HOME}/.claude/scripts/detect_patterns.sh" ]; then
+  rm -f "$_BYE_SENTINEL"  # consume sentinel immediately — one-shot
   TRANSCRIPT=$(ls -t "${HOME}/.claude/projects/"*/*.jsonl 2>/dev/null | head -1)
   if [ -n "$TRANSCRIPT" ]; then
     PATTERNS=$(timeout 30 "${HOME}/.claude/scripts/detect_patterns.sh" "$TRANSCRIPT" 2>&1) || PATTERNS=""
@@ -149,13 +157,9 @@ if [ -f "${HOME}/.claude/scripts/detect_patterns.sh" ]; then
       echo ""
       echo "$PATTERNS"
       echo ""
-      echo "▶ Run /skillify next session? [Y/n, 15s timeout]"
-      read -t 15 -n 1 -r REPLY 2>/dev/null || REPLY="n"
-      echo ""
-      if [[ "${REPLY:-n}" =~ ^[Yy]$ ]]; then
-        echo "$TRANSCRIPT" > "${HOME}/.claude/.pending_skillify"
-        echo "✓ Will auto-run /skillify on next session start"
-      fi
+      # No interactive read — hooks run non-interactively; auto-schedule skillify.
+      echo "$TRANSCRIPT" > "${HOME}/.claude/.pending_skillify"
+      echo "✓ Patterns detected — /skillify will run at next session start."
     fi
   fi
 fi

--- a/PATTERN_DETECTION_SETUP.md
+++ b/PATTERN_DETECTION_SETUP.md
@@ -1,18 +1,25 @@
 # Pattern Detection Setup (Option 4: Hybrid)
 
 **Created**: 2026-05-11
-**Status**: Ready to integrate
-**Cost**: ~$0.01-0.03 per session
+**Status**: Integrated
+**Cost**: ~$0.01-0.03 per /bye invocation (zero cost on normal replies)
 
 ## What This Does
 
-Automatically detects repeated workflows at session end and prompts you to run `/skillify` in the next session.
+Automatically detects repeated workflows when you run `/bye` and schedules `/skillify`
+for the next session if patterns are found.
 
 **Flow**:
-1. At `/bye`, system analyzes tool call patterns using Opus API
-2. Presents detected workflows with confidence levels
-3. You decide whether to skillify in next session
-4. If yes, `/hi` in next session auto-runs skillify
+1. You run `/bye` — the command writes `~/.claude/.bye-requested` (sentinel file)
+2. The Stop hook fires; it checks for the sentinel and deletes it (one-shot)
+3. Pattern detection runs (Opus API call) only because the sentinel was present
+4. If patterns found, `/hi` in next session auto-runs skillify
+
+**IMPORTANT — Stop fires on every reply, not only /bye.**
+The sentinel-file gate is mandatory: without it, pattern detection (a paid Opus
+API call) would run after every single Claude response, causing massive cost
+regression. Only the `/bye` command writes the sentinel, so only /bye triggers
+detection.
 
 ## Files Created
 
@@ -24,38 +31,46 @@ Automatically detects repeated workflows at session end and prompts you to run `
 
 ## Integration Steps
 
-### Step 1: Add to `~/.claude/hooks/session_stop.sh`
+### Step 1: session_stop.sh — already integrated with sentinel gate
 
-Add this block **before the final "Session ended"** message:
+The block below is already in `~/.claude/hooks/session_stop.sh`. Do **not** use
+the old pattern (bare `if detect_patterns.sh` without sentinel check) — that runs
+on every reply and incurs an Opus API call each time.
 
 ```bash
-# === Pattern Detection (Phase 1 Validation) ===
-if [ -f "${HOME}/.claude/scripts/detect_patterns.sh" ]; then
-    echo ""
-    PATTERNS=$(${HOME}/.claude/scripts/detect_patterns.sh "$TRANSCRIPT" 2>&1)
-
-    if echo "$PATTERNS" | grep -q "🔍 Detected workflow patterns"; then
-        echo "$PATTERNS"
-        echo ""
-        read -p "Run /skillify in next session for these patterns? [Y/n] " -t 30 -n 1 -r || REPLY="n"
-        echo ""
-
-        if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
-            # Store transcript path and patterns
-            echo "$TRANSCRIPT" > "${HOME}/.claude/.pending_skillify"
-            echo "<!-- PATTERNS:" >> "${HOME}/.claude/.pending_skillify"
-            echo "$PATTERNS" | sed -n '/<!-- JSON_START/,/JSON_END -->/p' >> "${HOME}/.claude/.pending_skillify"
-            echo "-->" >> "${HOME}/.claude/.pending_skillify"
-
-            echo "✓ Will run /skillify on next session start"
-        else
-            echo "⊘ Skipped pattern capture"
-        fi
-    else
-        echo "$PATTERNS"
+# === Pattern Detection — gated on /bye sentinel ===
+# The Stop hook fires after every Claude response, not only /bye.
+# We gate on ~/.claude/.bye-requested written by the /bye command.
+# The sentinel is deleted immediately (one-shot) to avoid stale triggers.
+_BYE_SENTINEL="${HOME}/.claude/.bye-requested"
+if [ -f "$_BYE_SENTINEL" ] && [ -f "${HOME}/.claude/scripts/detect_patterns.sh" ]; then
+  rm -f "$_BYE_SENTINEL"  # consume sentinel immediately — one-shot
+  TRANSCRIPT=$(ls -t "${HOME}/.claude/projects/"*/*.jsonl 2>/dev/null | head -1)
+  if [ -n "$TRANSCRIPT" ]; then
+    PATTERNS=$(timeout 30 "${HOME}/.claude/scripts/detect_patterns.sh" "$TRANSCRIPT" 2>&1) || PATTERNS=""
+    if echo "$PATTERNS" | grep -q "Detected workflow patterns"; then
+      echo ""
+      echo "$PATTERNS"
+      echo ""
+      # No interactive read — hooks run non-interactively; auto-schedule skillify.
+      echo "$TRANSCRIPT" > "${HOME}/.claude/.pending_skillify"
+      echo "✓ Patterns detected — /skillify will run at next session start."
     fi
+  fi
 fi
 ```
+
+### Step 1b: /bye command — already integrated
+
+The `/bye` (session-end) command writes the sentinel before the hook fires.
+This is already in `~/.claude/commands/session-end.md`:
+
+```bash
+# Written by /bye before doing anything else:
+touch ~/.claude/.bye-requested
+```
+
+If you add a new alias for /bye, add the same `touch` to that alias's first step.
 
 ### Step 2: Add to `~/.claude/hooks/session_init.sh`
 
@@ -84,17 +99,20 @@ echo "export ANTHROPIC_API_KEY=your_key_here" >> ~/.claude/.env
 
 ```bash
 # Start a session, do some repetitive work (3+ tool calls repeated 2+ times)
-# At session end, run /bye
-# Should see pattern detection output
+# At session end, run /bye (NOT just ending the session — must run the /bye command)
+# Should see pattern detection output only when /bye was used
 
-# Example output:
+# Expected output when patterns found:
 # 🔍 Detected workflow patterns:
 #
 #   3× git-pr-workflow [HIGH confidence]
 #      Steps: Bash → Edit → Bash → Bash
 #      → Consistent git branch → edit → commit → push sequence
 #
-# Run /skillify in next session for these patterns? [Y/n]
+# ✓ Patterns detected — /skillify will run at next session start.
+
+# Verify no output on normal replies (sentinel absent):
+# ls ~/.claude/.bye-requested  # should NOT exist between /bye invocations
 ```
 
 ## Configuration


### PR DESCRIPTION
## Summary

- `session_stop.sh` ran `detect_patterns.sh` (paid Opus API call) and blocked on `read` after **every** Claude response, not only on `/bye`. The `Stop` hook fires on every reply.
- Fixed with a sentinel-file gate: `/bye` writes `~/.claude/.bye-requested`; the hook checks for it, deletes it immediately (one-shot), then runs detection. All other Stop events skip the block.
- Removed the interactive `read` unconditionally — hooks are non-interactive. Patterns now auto-schedule skillify.
- `PATTERN_DETECTION_SETUP.md` updated to document correct wiring and the sentinel approach.

## Files changed

| File | Change |
|------|--------|
| `.claude/hooks/session_stop.sh` | Replace bare detect block with sentinel-gated version; remove `read` |
| `.claude/commands/session-end.md` | Add `touch ~/.claude/.bye-requested` as first step |
| `PATTERN_DETECTION_SETUP.md` | Correct the event description and code example |

## Test plan

- [ ] Run `/bye` — verify pattern detection output appears (sentinel present)
- [ ] Send a normal reply — verify no pattern detection runs (sentinel absent)
- [ ] `bash -n .claude/hooks/session_stop.sh` — syntax OK (verified in PR)
- [ ] Confirm `~/.claude/.bye-requested` is absent between /bye invocations

Closes roborev findings for `session_stop.sh:143-156` and `PATTERN_DETECTION_SETUP.md:27-58`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)