### PR TITLE
fix(roborev-scripts): Bash 3.2 portability + WAL-safe DB access + timestamp normalization

### DIFF
--- a/.claude/scripts/qa_vignette_tabs.sh
+++ b/.claude/scripts/qa_vignette_tabs.sh
@@ -41,7 +41,11 @@ echo
 
 # Collect HTML files recursively (covers vignettes/articles/ and docs/articles/).
 # Reuse this list for all checks to ensure consistency (fixes roborev #679).
-mapfile -t HTML_FILES < <(find "$DOCS_DIR" -name "*.html" 2>/dev/null)
+# Portable while-read loop instead of mapfile (Bash 3.2 compat — macOS ships Bash 3.2).
+HTML_FILES=()
+while IFS= read -r _line; do
+  HTML_FILES+=("$_line")
+done < <(find "$DOCS_DIR" -name "*.html" 2>/dev/null)
 HTML_COUNT="${#HTML_FILES[@]}"
 if [ "$HTML_COUNT" -eq 0 ]; then
   echo "ERROR: No .html files found under $DOCS_DIR"

--- a/.claude/scripts/roborev_agent_health.sh
+++ b/.claude/scripts/roborev_agent_health.sh
@@ -74,7 +74,7 @@ SELECT COUNT(*)
 FROM review_jobs
 WHERE agent = 'codex'
   AND status = 'failed'
-  AND enqueued_at > datetime('now', '-${FAILURE_WINDOW_MIN} minute');
+  AND datetime(enqueued_at) > datetime('now', '-${FAILURE_WINDOW_MIN} minute');
 SQL
 }
 

--- a/.claude/scripts/roborev_autoclose.sh
+++ b/.claude/scripts/roborev_autoclose.sh
@@ -66,8 +66,12 @@ fi
 CUTOFF=$(date -u -v "-${THRESHOLD_DAYS}d" +%s 2>/dev/null \
        || date -u -d "${THRESHOLD_DAYS} days ago" +%s)
 
-# Fetch open jobs, filter by enqueued_at < cutoff, emit ids
-mapfile -t STALE_IDS < <(
+# Fetch open jobs, filter by enqueued_at < cutoff, emit ids.
+# Portable while-read loop instead of mapfile (Bash 3.2 compat — macOS ships Bash 3.2).
+STALE_IDS=()
+while IFS= read -r _line; do
+  STALE_IDS+=("$_line")
+done < <(
   "$ROBOREV" list --json --open --limit 1000 2>/dev/null \
     | python3 -c "
 import json, sys
@@ -146,11 +150,20 @@ fi
 
 echo "roborev phase2: $PHASE2_N stale failed jobs (repo=$ROBOREV_REPO, no review attached) — cancelling via DB"
 
-# Backup BEFORE mutating (daemon may be running — SQLite WAL handles concurrent
-# read; we use busy_timeout for the write).
+# Backup BEFORE mutating using Python's sqlite3.backup() — this is WAL-safe because
+# it uses the SQLite Online Backup API which snapshots committed state including any
+# un-checkpointed WAL pages. A plain `cp reviews.db` would miss those pages.
+# We use /usr/bin/python3 to avoid depending on sqlite3 CLI being on PATH inside nix.
 BACKUP="$ROBOREV_DB.bak-$(date +%Y%m%d_%H%M%S)"
-if ! cp "$ROBOREV_DB" "$BACKUP"; then
-  log "phase2 abort: backup to $BACKUP failed"
+if ! /usr/bin/python3 -c "
+import sqlite3, sys
+src = sqlite3.connect(sys.argv[1])
+dst = sqlite3.connect(sys.argv[2])
+src.backup(dst)
+src.close()
+dst.close()
+" "$ROBOREV_DB" "$BACKUP"; then
+  log "phase2 abort: WAL-safe backup to $BACKUP failed"
   echo "roborev phase2: backup failed"
   exit 1
 fi

--- a/.claude/scripts/roborev_handoff.sh
+++ b/.claude/scripts/roborev_handoff.sh
@@ -115,7 +115,7 @@ for r in repos:
         JOIN reviews rv ON rv.job_id = rj.id
         WHERE repo.id = ?
           AND rj.status = 'done'
-          AND (julianday('now') - julianday(rj.enqueued_at)) > ?
+          AND (julianday('now') - julianday(COALESCE(rj.finished_at, rj.enqueued_at))) > ?
         ORDER BY rj.enqueued_at ASC
     """, (r["id"], threshold_days)).fetchall()
 


### PR DESCRIPTION
## Summary

- **Cluster A — Bash 3.2 portability (4 roborev findings):** `mapfile -t` is a Bash 4+ builtin; macOS ships Bash 3.2. Replaced with portable `while IFS= read -r _line; do arr+=("$_line"); done < <(cmd)` in `qa_vignette_tabs.sh` and `roborev_autoclose.sh`.
- **Cluster B — WAL-safe backup:** `roborev_autoclose.sh` phase-2 backup was a plain `cp reviews.db`; in SQLite WAL mode recent commits live in `-wal` sidecar. Fixed to use `python3 sqlite3.backup()` (SQLite Online Backup API), which atomically snapshots all committed state.
- **Cluster B — Staleness filter uses completion time:** `roborev_handoff.sh` measured staleness from `rj.enqueued_at`; a job queued long ago but completed today triggered hand-off immediately. Fixed to `COALESCE(rj.finished_at, rj.enqueued_at)`.
- **Cluster B — ISO timestamp normalization:** `roborev_agent_health.sh` compared raw `enqueued_at` text to `datetime('now', ...)`. ISO-8601 format with trailing `Z` breaks lexicographic comparison. Fixed by wrapping `enqueued_at` in `datetime()` on both sides.

## Test plan

- [x] `bash -n` passes on all four touched scripts
- [ ] Smoke-test `qa_vignette_tabs.sh` against a rendered docs/ dir on macOS (Bash 3.2)
- [ ] Smoke-test `roborev_autoclose.sh --dry-run` (no mutation, exercises the while-read path)
- [ ] Confirm `roborev_agent_health.sh --status` returns correct failure count with mixed-format timestamps

## Files changed

| File | Changes |
|------|---------|
| `.claude/scripts/qa_vignette_tabs.sh` | mapfile → while-read |
| `.claude/scripts/roborev_autoclose.sh` | mapfile → while-read; cp → python3 sqlite3.backup() |
| `.claude/scripts/roborev_handoff.sh` | enqueued_at → COALESCE(finished_at, enqueued_at) |
| `.claude/scripts/roborev_agent_health.sh` | enqueued_at → datetime(enqueued_at) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)