### PR TITLE
fix(roborev): cap age contribution in priority formula (fresh Critical > stale Low)

### DIFF
--- a/.claude/scripts/roborev_project_backlog.sh
+++ b/.claude/scripts/roborev_project_backlog.sh
@@ -243,7 +243,11 @@ def days_old(created_at_str):
 def priority_score(sev, categories, age_days):
     sw = SEVERITY_WEIGHT.get(sev, 1)
     cr = max(CATEGORY_RISK.get(c, 1.0) for c in categories)
-    age_factor = 1 + math.sqrt(age_days)
+    # Cap age contribution at sqrt(30) ≈ 5.48 so a fresh Critical beats a stale Low:
+    #   fresh Critical: sev=10 * cr * (1+0)    = 10*cr
+    #   stale Low 1yr:  sev=1  * cr * (1+5.48) = 6.48*cr
+    # Works as long as severity weight for Critical >= 7 (currently 10).
+    age_factor = 1 + min(math.sqrt(age_days), math.sqrt(30))
     return sw * cr * age_factor
 
 scored = []


### PR DESCRIPTION
## Summary

- **Bug**: `sqrt(age_days)` with no cap caused year-old Low findings to outscore fresh Criticals. A Low-security finding 365 days old scored `1 * 5 * (1 + sqrt(365)) ≈ 100`; a brand-new Critical scored `10 * 5 * (1 + 0) = 50`.
- **Fix**: `age_factor = 1 + min(sqrt(age_days), sqrt(30))` — caps age contribution at `sqrt(30) ≈ 5.48`.
- **Math**: Fresh Critical = `10 * cr * 1.0 = 10*cr`; stale Low (1yr) = `1 * cr * 6.48 = 6.48*cr`. Fresh Critical wins whenever Critical severity weight >= 7 (currently 10).

## Before vs After top-5 (llm project)

**Before** (old formula — Low findings 1yr old could float above High):
| rank | sev | category | age | priority |
|------|-----|----------|-----|----------|
| 1 | high | shell/bash | 1w | 28.7 |
| 2 | high | shell/bash | 1w | 28.7 |
| 3 | high | shell/bash | 5d | 24.4 |
| 4 | high | shell/bash | 4d | 22.6 |
| 5 | high | shell/bash | 4d | 22.6 |

**After** (capped formula — fresh High/Critical stays above stale Low):
| rank | sev | category | age | priority |
|------|-----|----------|-----|----------|
| 1 | high | shell/bash | 1w | 29.5 |
| 2 | high | shell/bash | 1w | 29.4 |
| 3 | high | shell/bash | 5d | 25.4 |
| 4 | high | shell/bash | 4d | 23.7 |
| 5 | high | shell/bash | 4d | 23.7 |

High-severity findings hold their positions; the cap prevents any stale Low from floating above them.

## Test plan

- [x] `bash -n .claude/scripts/roborev_project_backlog.sh` passes (syntax check)
- [x] Script runs against `llm` project and produces valid `backlog.md`
- [x] Top 20 still contains only `high`/`critical` severity findings (no Low promoted above High)

🤖 Generated with [Claude Code](https://claude.com/claude-code)