### PR TITLE
fix: drift_check normalization + per-row hash example + dedup quarto workflow + BSD-grep portability

### DIFF
--- a/.claude/scripts/drift_check.py
+++ b/.claude/scripts/drift_check.py
@@ -138,6 +138,15 @@ def rebuild_baseline(embed) -> None:
         return
     vecs = np.stack([embed(s) for s in subjects])
     centroid = vecs.mean(axis=0)
+    # Normalize centroid to unit length so cosine-distance formula is valid.
+    # The mean of unit vectors is NOT itself unit-length; normalization is
+    # mandatory before using the dot-product shortcut (1 - v·c) for cosine dist.
+    centroid_norm = np.linalg.norm(centroid)
+    if centroid_norm < 1e-10:
+        log("ERROR: centroid is a zero vector — baseline is degenerate")
+        return
+    centroid = centroid / centroid_norm
+    assert abs(np.linalg.norm(centroid) - 1.0) < 1e-9, "centroid not unit-normalized"
     # Distance of each baseline item to the centroid → distribution
     dists = 1.0 - vecs @ centroid           # cosine distance for unit vectors
     np.save(BASELINE_NPY, centroid)

--- a/.claude/scripts/entity_propagate.sh
+++ b/.claude/scripts/entity_propagate.sh
@@ -19,8 +19,12 @@
 set -o pipefail  # no -e — single project lookup must not kill the pass
                   # no -u either — interacts badly with some snapshot/init scripts
 
-# Use BSD grep explicitly: the nix shell's PATH puts toybox grep first,
-# and toybox grep does not support `\b` word boundaries.
+# Grep configuration.
+# BSD grep (/usr/bin/grep on macOS) does NOT support \b word-boundary
+# assertions in ERE mode (-E). We use POSIX character-class anchors instead:
+#   (^|[^[:alnum:]_])PATTERN([^[:alnum:]_]|$)
+# This is portable across BSD grep, GNU grep, and toybox grep.
+# Do NOT use \b — it silently matches nothing on BSD grep with -E.
 GREP="${GREP:-/usr/bin/grep}"
 SESSION_ID="${1:-${CLAUDE_CODE_SESSION_ID:-}}"
 KNOWLEDGE_ROOT="${KNOWLEDGE_ROOT:-$HOME/docs_gh/llm/knowledge}"
@@ -63,7 +67,13 @@ for project in "${PROJECTS[@]}"; do
   # Word-boundary match on the project name. Lowercase compare via grep -i.
   # Count occurrences in the JSONL — each line is a JSON event.
   # `grep -c` exits 1 with output "0" when nothing matches; coerce to int safely.
-  count=$("$GREP" -ciE "\\b${project}\\b" "$JSONL" 2>/dev/null)
+  #
+  # PORTABILITY: \b is NOT supported by BSD grep (macOS /usr/bin/grep) in ERE
+  # mode. Use POSIX character-class boundary instead:
+  #   (^|[^[:alnum:]_])  = start of string OR non-word char before match
+  #   ([^[:alnum:]_]|$)  = non-word char after match OR end of string
+  # This correctly matches "llm" in " llm " but not in "llmtelemetry".
+  count=$("$GREP" -ciE "(^|[^[:alnum:]_])${project}([^[:alnum:]_]|$)" "$JSONL" 2>/dev/null)
   count=${count:-0}
   [ "$count" -gt 0 ] || continue
 
@@ -82,5 +92,43 @@ HEADER
 
   echo "${LOG_PREFIX}  count=${count}" >> "$target"
 done
+
+# ── Self-test (run with ENTITY_PROPAGATE_SELFTEST=1) ─────────────────────────
+# Tests the POSIX word-boundary regex pattern on known inputs.
+# Usage: ENTITY_PROPAGATE_SELFTEST=1 bash entity_propagate.sh
+# NOTE: placed before "exit 0" so the env-var gate can actually be reached.
+if [ "${ENTITY_PROPAGATE_SELFTEST:-0}" = "1" ]; then
+  echo "=== entity_propagate.sh self-test ===" >&2
+  TMPF=$(mktemp)
+  printf 'mention of llm project here\n' >> "$TMPF"
+  printf 'llmtelemetry is a different project\n' >> "$TMPF"
+  printf '"project":"llm","action":"test"\n' >> "$TMPF"
+  printf 'no match in this line\n' >> "$TMPF"
+
+  # "llm" should match lines 1 and 3 (count=2); NOT line 2 (llmtelemetry)
+  c=$("$GREP" -ciE "(^|[^[:alnum:]_])llm([^[:alnum:]_]|$)" "$TMPF" 2>/dev/null || true)
+  c=${c:-0}
+  if [ "$c" = "2" ]; then
+    echo "PASS: 'llm' matched $c/2 expected lines (not llmtelemetry)" >&2
+  else
+    echo "FAIL: 'llm' matched $c lines (expected 2)" >&2
+    rm -f "$TMPF"
+    exit 1
+  fi
+
+  # "llmtelemetry" should match line 2 only (count=1)
+  c2=$("$GREP" -ciE "(^|[^[:alnum:]_])llmtelemetry([^[:alnum:]_]|$)" "$TMPF" 2>/dev/null || true)
+  c2=${c2:-0}
+  if [ "$c2" = "1" ]; then
+    echo "PASS: 'llmtelemetry' matched $c2/1 expected lines" >&2
+  else
+    echo "FAIL: 'llmtelemetry' matched $c2 lines (expected 1)" >&2
+    rm -f "$TMPF"
+    exit 1
+  fi
+
+  rm -f "$TMPF"
+  echo "=== all self-tests passed ===" >&2
+fi
 
 exit 0

--- a/.claude/skills/targets-pipeline-spec/SKILL.md
+++ b/.claude/skills/targets-pipeline-spec/SKILL.md
@@ -281,12 +281,15 @@ When data arrives in append-only batches (e.g., daily API pulls, CSV exports), u
 
 ```r
 tar_target(stg_transactions_deduped, {
-  # Generate surrogate key from identifying columns
+  # Generate surrogate key from identifying columns — one hash per ROW.
+  # digest::digest() is NOT vectorized: wrapping the paste() vector hashes
+  # the entire vector as one object, producing the SAME id for every row.
+  # Use purrr::pmap_chr() to apply digest() element-wise instead.
   stg_transactions |>
     dplyr::mutate(
-      row_id = digest::digest(
-        paste(date, description, amount, sep = "_"),
-        algo = "md5"
+      row_id = purrr::pmap_chr(
+        list(date, description, amount),
+        \(d, x, a) digest::digest(paste(d, x, a, sep = "_"), algo = "md5")
       )
     ) |>
     # Deduplicate: keep first occurrence of each row_id

--- a/.github/workflows/quarto-publish.yaml
+++ b/.github/workflows/quarto-publish.yaml
@@ -1,5 +1,9 @@
 # Build and deploy Quarto website to GitHub Pages
 # Uses r-lib/actions (Native R) - NOT Nix - per CI skill Decision Matrix
+#
+# SOLE quarto publisher for this repo. Other workflows in .github/workflows/:
+#   vignette-validation.yml  — workflow_call (reusable, NOT push-triggered)
+#   wiki-sync-check.yaml     — wiki drift check, does NOT deploy Pages
 
 name: Quarto Publish
 


### PR DESCRIPTION
## Summary

- **drift_check.py**: Normalize centroid after `vecs.mean(axis=0)` before using it in cosine-distance formula. The mean of unit vectors is NOT unit-length; the un-normalized centroid made both baseline dist stats and per-session z-scores wrong. Added zero-vector guard + `assert` for ongoing correctness.
- **targets-pipeline-spec/SKILL.md**: Fix incremental deduplication example to use `purrr::pmap_chr()` for per-row MD5 hashes. `digest::digest()` is not vectorized — the old example passed the entire `paste()` result vector as one object, producing the same hash for every row and collapsing all rows to one after `distinct()`.
- **.github/workflows/quarto-publish.yaml**: Audit confirmed no second Quarto publisher exists. Added header comment documenting the three workflow files and their roles to prevent future confusion.
- **entity_propagate.sh**: Replace `\b` word-boundary assertions with POSIX character-class anchors `(^|[^[:alnum:]_])PATTERN([^[:alnum:]_]|$)`. BSD grep (`/usr/bin/grep` on macOS) does not support `\b` in ERE mode and silently matched nothing. Added self-test gated behind `ENTITY_PROPAGATE_SELFTEST=1`.

## Test plan

- [ ] `drift_check.py`: Python assertion `abs(np.linalg.norm(centroid) - 1.0) < 1e-9` fires at runtime on every baseline rebuild — PASS verified in PR
- [ ] SKILL.md hash example: `Rscript` with 3-row df confirms 3 distinct MD5s — PASS
- [ ] quarto-publish.yaml: only one `name: Quarto Publish` workflow in repo — PASS
- [ ] entity_propagate.sh: `ENTITY_PROPAGATE_SELFTEST=1 bash entity_propagate.sh` — PASS (llm matches 2/2, llmtelemetry matches 1/1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)