### PR TITLE
fix(vignettes/qa): scope corrections + duplicate qr-footer label cleanup

### DIFF
--- a/R/tar_plans/plan_qa_gates.R
+++ b/R/tar_plans/plan_qa_gates.R
@@ -123,21 +123,28 @@ scan_html_for_errors <- function(html_dir       = "docs",
 #'   Calls `cli::cli_abort()` if any rendered vignette is missing any of the
 #'   three required subsections.
 check_methodology_blocks <- function(vignettes_dir = "docs/articles",
-                                     docs_dir       = "docs") {
-  # Collect all rendered vignette HTML files
-  html_files <- c(
-    list.files(vignettes_dir, pattern = "\\.html$", full.names = TRUE, recursive = FALSE),
-    list.files(docs_dir, pattern = "\\.html$", full.names = TRUE, recursive = FALSE)
-  )
+                                     docs_dir       = "docs",
+                                     src_vignettes  = "vignettes") {
+  # Derive the set of HTML files to check from the vignette SOURCE files.
+  # This prevents non-vignette pages (authors.html, AGENTS.html, etc.) from
+  # being flagged for missing methodology blocks.
+  #
+  # Mapping: vignettes/<name>.qmd   -> docs/<name>.html
+  #          vignettes/articles/<name>.qmd -> docs/articles/<name>.html
+  src_top      <- list.files(src_vignettes, pattern = "\\.qmd$",
+                              full.names = FALSE, recursive = FALSE)
+  src_articles <- list.files(file.path(src_vignettes, "articles"),
+                              pattern = "\\.qmd$",
+                              full.names = FALSE, recursive = FALSE)
 
-  # Skip changelog, news, index, and reference pages
-  skip_basenames <- c("CHANGELOG.html", "NEWS.html", "news.html", "index.html",
-                      "404.html", "reference.html")
-  skip_paths <- c("/news/", "/reference/", "/pkgdown-")
-  html_files <- html_files[
-    !basename(html_files) %in% skip_basenames &
-    !Reduce(`|`, lapply(skip_paths, function(p) grepl(p, html_files, fixed = TRUE)))
-  ]
+  html_top      <- file.path(docs_dir,
+                              sub("\\.qmd$", ".html", src_top))
+  html_articles <- file.path(vignettes_dir,
+                              sub("\\.qmd$", ".html", src_articles))
+
+  html_files <- c(html_top, html_articles)
+  # Keep only files that actually exist (skip if docs not yet rendered)
+  html_files <- html_files[file.exists(html_files)]
 
   if (length(html_files) == 0L) {
     cli::cli_alert_warning(

--- a/R/tar_plans/plan_scrolly_config.R
+++ b/R/tar_plans/plan_scrolly_config.R
@@ -1,6 +1,9 @@
 # R/tar_plans/plan_scrolly_config.R
 # Targets for scrolly-config-evolution vignette
-# Scans .claude/ files and builds a per-file tibble with metadata
+# Scans a subset of .claude/ config artifacts and builds a per-file tibble
+# with metadata. Coverage: rules (.md), skills (SKILL.md only), agents (.md),
+# hooks (.sh), memory (.md), commands (.md), scripts (.sh).
+# Other .claude/ paths (e.g. worktrees/, logs/) are intentionally excluded.
 
 plan_scrolly_config <- function() {
   list(

--- a/vignettes/articles/closeread-config.qmd
+++ b/vignettes/articles/closeread-config.qmd
@@ -13,9 +13,6 @@ execute:
   message: false
 ---
 
-{{< include ../../_includes/qr-footer.qmd >}}
-
-
 <style>
 .cr-section.sidebar-left .cr-sidebar-col { flex: 0 0 55% !important; max-width: 55% !important; }
 .cr-section.sidebar-left .cr-narrative-col { flex: 0 0 45% !important; max-width: 45% !important; }

--- a/vignettes/articles/llm-assisted-tips.qmd
+++ b/vignettes/articles/llm-assisted-tips.qmd
@@ -7,9 +7,6 @@ format:
     code-summary: "Show code"
 ---
 
-{{< include ../../_includes/qr-footer.qmd >}}
-
-
 A short set of working principles I've converged on after a stretch of building R packages, dashboards, and analyses with Claude Code as a daily collaborator. None of these are novel — they're cribbed and consolidated from people much further along — but they're the ones that actually changed how I work.
 
 ## Three load-bearing principles

--- a/vignettes/articles/scrolly-config-evolution.qmd
+++ b/vignettes/articles/scrolly-config-evolution.qmd
@@ -11,8 +11,6 @@ execute:
   message: false
 ---
 
-{{< include ../../_includes/qr-footer.qmd >}}
-
 ```{r setup}
 #| include: false
 library(ggplot2)

--- a/vignettes/closeread-infrastructure.qmd
+++ b/vignettes/closeread-infrastructure.qmd
@@ -12,8 +12,6 @@ execute:
   message: false
 ---
 
-{{< include ../_includes/qr-footer.qmd >}}
-
 ```{r setup}
 #| include: false
 

--- a/vignettes/config-evolution.qmd
+++ b/vignettes/config-evolution.qmd
@@ -9,9 +9,6 @@ execute:
   warning: false
 ---
 
-{{< include ../_includes/qr-footer.qmd >}}
-
-
 ```{r setup}
 #| include: false
 library(dplyr)
@@ -53,9 +50,12 @@ if (length(parquet_files) > 0 && requireNamespace("DBI", quietly = TRUE) && requ
 # Probe in priority order so this also works locally where ~/.claude has the
 # same content via symlinks.
 if (is.null(config_data)) {
-  .candidates <- c(here::here(".claude"), path.expand("~/.claude"))
+  # Probe repo-relative path first (works in CI and locally via symlink).
+  # The user-level ~/.claude path is excluded: vignettes must be reproducible
+  # from the checked-in source tree alone, not from reviewer-local state.
+  .candidates <- c(here::here(".claude"))
   claude_dir <- Find(dir.exists, .candidates)
-  if (is.null(claude_dir)) claude_dir <- .candidates[1]  # last-resort string
+  if (is.null(claude_dir)) claude_dir <- here::here(".claude")  # last-resort string
 
   # Count rules
   rules_dir <- file.path(claude_dir, "rules")

--- a/vignettes/knowledge-evolution.qmd
+++ b/vignettes/knowledge-evolution.qmd
@@ -9,9 +9,6 @@ execute:
   warning: false
 ---
 
-{{< include ../_includes/qr-footer.qmd >}}
-
-
 ```{r setup}
 #| include: false
 library(dplyr)

--- a/vignettes/telemetry.qmd
+++ b/vignettes/telemetry.qmd
@@ -13,9 +13,6 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-{{< include ../_includes/qr-footer.qmd >}}
-
-
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,


### PR DESCRIPTION
## Summary

- **#1 plan_scrolly_config.R**: Updated header comment to accurately describe the scanned subset (`.claude/{rules,skills,agents,hooks,memory,commands,scripts}`) rather than claiming full `.claude/` coverage.
- **#2 plan_qa_gates.R**: Narrowed `check_methodology_blocks()` to derive HTML file list from vignette source `.qmd` files instead of a `docs/*.html` glob — prevents non-vignette pages (authors.html, AGENTS.html) from failing the methodology-block gate.
- **#4 config-evolution.qmd**: Removed `~/.claude` fallback in the live-count branch; vignette now only probes `here::here(".claude")` so output is reproducible in CI.
- **#6 All 7 vignettes**: Removed duplicate top-of-file `{{< include qr-footer.qmd >}}` from every vignette that included the partial twice. The partial defines a knitr chunk; a second include on the same page creates duplicate auto-generated chunk labels that break knitr.

**Not fixed (with reasons):**
- **#3 ccusage naming**: `ccusage_daily_all.json` / `ccusage_session_all.json` already match what `load_cached_ccusage()` resolves — no mismatch exists.
- **#5 tar_target prose**: Lines 89–103 in `llm-assisted-tips.qmd` already correctly document that a quoted string is a character constant, not evaluated code.

## Test plan

- [ ] `quarto render vignettes/articles/llm-assisted-tips.qmd` — passes (verified: "Output created")
- [ ] `quarto render vignettes/config-evolution.qmd` — passes (verified: "Output created")
- [ ] `R/tar_plans/plan_qa_gates.R` parses cleanly — verified via `parse()`
- [ ] `R/tar_plans/plan_scrolly_config.R` parses cleanly — verified via `parse()`
- [ ] `pkgload::load_all()` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)