### PR TITLE
feat: spike compound-command guard hook (#176)

### DIFF
--- a/.claude/hooks/compound_command_guard.sh
+++ b/.claude/hooks/compound_command_guard.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# compound_command_guard.sh — PreToolUse:Bash hook
+#
+# Detects compound bash commands (&&, ||, |, unescaped ;) and either logs
+# or blocks them depending on COMPOUND_GUARD_MODE.
+#
+# Mode (env var COMPOUND_GUARD_MODE):
+#   off   — exit 0 immediately, no check, no log  [DEFAULT]
+#   log   — detect + log, always exit 0
+#   block — detect + log + exit 1 with retry message
+#
+# Self-test: COMPOUND_GUARD_SELFTEST=1 bash compound_command_guard.sh
+#
+# Issue: #176
+
+set -euo pipefail
+
+LOG="$HOME/.claude/logs/compound_guard.log"
+MODE="${COMPOUND_GUARD_MODE:-off}"
+
+# ── Self-test mode ──────────────────────────────────────────────────────
+if [ "${COMPOUND_GUARD_SELFTEST:-0}" = "1" ]; then
+  _pass=0; _fail=0
+  SCRIPT_PATH="$(realpath "$0")"
+
+  _selftest_case() {
+    local desc="$1" cmd="$2" expect="$3"
+    local payload
+    # Escape for JSON
+    local escaped
+    escaped=$(printf '%s' "$cmd" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" 2>/dev/null || printf '"%s"' "$cmd")
+    payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":$escaped}}"
+    local exit_code=0
+    printf '%s' "$payload" | \
+      env COMPOUND_GUARD_MODE=block COMPOUND_GUARD_SELFTEST=0 \
+      /usr/bin/env bash "$SCRIPT_PATH" >/dev/null 2>/dev/null || exit_code=$?
+    # exit_code=1 means detected (blocked), exit_code=0 means not detected
+    case "$expect" in
+      DETECT)
+        if [ "$exit_code" = "1" ]; then
+          printf '  PASS  [%s]\n' "$desc"; _pass=$((_pass+1))
+        else
+          printf '  FAIL  [%s] -- expected DETECT (exit 1), got exit %s\n' "$desc" "$exit_code"; _fail=$((_fail+1))
+        fi ;;
+      ALLOW)
+        if [ "$exit_code" = "0" ]; then
+          printf '  PASS  [%s]\n' "$desc"; _pass=$((_pass+1))
+        else
+          printf '  FAIL  [%s] -- expected ALLOW (exit 0), got exit %s\n' "$desc" "$exit_code"; _fail=$((_fail+1))
+        fi ;;
+    esac
+  }
+
+  echo "=== compound_command_guard.sh self-test ==="
+  echo "--- Must DETECT (compound operators outside strings/heredocs) ---"
+
+  _selftest_case "pipe: git status | wc -l"                  "git status | wc -l"                          DETECT
+  _selftest_case "ampamp: cd /tmp && ls"                      "cd /tmp && ls"                               DETECT
+  _selftest_case "semicolon: ls /a; ls /b"                    "ls /a; ls /b"                                DETECT
+  _selftest_case "oror: cmd1 || cmd2"                         "cmd1 || cmd2"                                DETECT
+  _selftest_case "multi-pipe: git status | grep mod | wc -l"  "git status | grep modified | wc -l"         DETECT
+
+  echo "--- Must ALLOW (operators inside strings, heredocs, or subshells) ---"
+
+  _selftest_case "pipe in double-quoted string"               'echo "a | b"'                                ALLOW
+  _selftest_case "ampamp in single-quoted string"             "echo 'a && b'"                               ALLOW
+  _selftest_case "escaped semicolon (find -exec)"             'find . -name "*.tmp" -exec rm {} \;'        ALLOW
+  _selftest_case "subshell (documented exception)"            "(cd /tmp && tar czf /backup.tgz .)"          ALLOW
+  _selftest_case "background operator at end of line"         "sleep 5 &"                                   ALLOW
+  _selftest_case "simple command, no operators"               "ls /tmp"                                      ALLOW
+  _selftest_case "heredoc with pipe in body"                  "$(printf 'git commit -m "$(cat <<'"'"'EOF'"'"'\nmessage with | in it\nEOF\n)"')"  ALLOW
+
+  echo "=== Results: $_pass passed, $_fail failed ==="
+  [ "$_fail" -eq 0 ] && exit 0 || exit 1
+fi
+
+# ── Normal hook execution ───────────────────────────────────────────────
+
+# Mode=off: skip everything
+if [ "$MODE" = "off" ]; then
+  exit 0
+fi
+
+# Read JSON from stdin
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+# Can't parse command — allow
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# ── Detection via Python (handles heredocs and quoted strings cleanly) ──
+DETECTED=$(CMD_TO_CHECK="$COMMAND" /usr/bin/python3 <<'PY'
+import sys, re, os
+
+cmd = os.environ.get('CMD_TO_CHECK', '')
+
+# Strip single-quoted strings (cannot contain single quotes)
+cmd = re.sub(r"'[^']*'", "''", cmd)
+
+# Strip double-quoted strings (with backslash escape handling)
+cmd = re.sub(r'"(?:[^"\\]|\\.)*"', '""', cmd)
+
+# Strip heredoc bodies — match <<'WORD', <<"WORD", <<WORD, <<-WORD variants
+# Everything between the opening line and the matching closing word
+cmd = re.sub(
+    r"<<-?\s*['\"]?(\w+)['\"]?.*?\n.*?\1\s*\n?",
+    "<<HEREDOC\nHEREDOC\n",
+    cmd,
+    flags=re.DOTALL
+)
+
+# Strip escaped semicolons used by find -exec ... \;
+cmd = cmd.replace(r'\;', '')
+
+# Strip subshells (...) — documented exception in bash-safety rule
+# Remove content of balanced parens at depth 1 (simple — not nested)
+cmd = re.sub(r'\([^()]*\)', '()', cmd)
+
+# Now detect compound operators in what remains
+found = []
+if re.search(r'\|\|', cmd):
+    found.append('||')
+# Bare pipe: | not preceded or followed by |
+if re.search(r'(?<!\|)\|(?!\|)', cmd):
+    found.append('|')
+if re.search(r'&&', cmd):
+    found.append('&&')
+# Semicolon not at end of line (trailing ; is harmless)
+if re.search(r';(?!\s*$)', cmd, re.MULTILINE):
+    found.append(';')
+
+print(','.join(found))
+PY
+)
+
+# No operators found — allow
+if [ -z "$DETECTED" ]; then
+  exit 0
+fi
+
+# Compound operator found — log it
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date +"%Y-%m-%dT%H:%M:%SZ")
+CMD_TRUNCATED="${COMMAND:0:120}"
+[ ${#COMMAND} -gt 120 ] && CMD_TRUNCATED="${CMD_TRUNCATED}..."
+
+mkdir -p "$(dirname "$LOG")"
+printf '%s mode=%s detected=%s cmd_truncated=%s\n' \
+  "$TIMESTAMP" "$MODE" "$DETECTED" "$CMD_TRUNCATED" >> "$LOG"
+
+# Mode=log: logged but always allow
+if [ "$MODE" = "log" ]; then
+  exit 0
+fi
+
+# Mode=block: emit actionable retry message and exit 1
+cat >&2 <<EOF
+
+⛔ Compound bash command blocked by compound_command_guard (issue #176)
+
+Detected operator(s): $DETECTED
+
+This command chains multiple operations. Per the bash-safety rule
+(.claude/rules/bash-safety.md), every Bash tool call should execute
+exactly one command. Compound commands cannot match the allowlist patterns
+in settings.json, so they trigger permission prompts.
+
+To retry, split into separate Bash tool calls:
+  - Run cmd1 in one call
+  - Use git -C <dir> instead of cd <dir> && cmd
+  - For Read/Edit, use the dedicated tools instead of cat/sed
+
+If this command genuinely requires atomicity, wrap in a subshell:
+  (cd /tmp && tar czf backup.tgz .)
+Subshells are allowed; bare && chains are not.
+
+To disable this guard temporarily: COMPOUND_GUARD_MODE=off <command>
+EOF
+
+exit 1

--- a/.claude/scripts/cross_modal_eval.sh
+++ b/.claude/scripts/cross_modal_eval.sh
@@ -14,7 +14,14 @@
 # Output: JSON with precision/recall/genericity scores and mismatch flags
 # Cost: ~$0.05-0.10 per evaluation
 #
-# Related: Issue #137 (cross-modal evaluation), Issue #130 (T lang incident)
+# Prompt caching: The Anthropic call (call_opus) uses cache_control markers on
+# the system block (ephemeral type). Anthropic requires >=1024 tokens to cache;
+# PRECISION_PROMPT is ~125 tokens so caching is silently skipped today.
+# This is scaffolding: structure is correct, cache-hit logging is active, and
+# caching will engage automatically when prompts grow. See Issue #174.
+#
+# Related: Issue #137 (cross-modal evaluation), Issue #130 (T lang incident),
+#          Issue #174 (prompt caching scaffolding)
 
 set -euo pipefail
 
@@ -77,25 +84,62 @@ GENERICITY_PROMPT="You are a genericity checker. Review this text for AI slop pa
 # Function to call Opus (precision)
 # Fix (roborev #779): use jq -n --arg to build the payload — never interpolate
 # RAW_CONTENT into a JSON string literal; jq handles all escaping correctly.
+#
+# Prompt caching scaffolding (Issue #174):
+# - The system block carries cache_control: {type: "ephemeral"} so Anthropic will
+#   cache it once it exceeds the 1024-token minimum.
+# - PRECISION_PROMPT is currently ~125 tokens — below that threshold, so the
+#   cache_control marker is silently ignored by the API today.
+# - When prompts grow past 1024 tokens (Opus/Sonnet minimum), caching engages
+#   automatically without further code changes.
+# - Cache hits/creations are logged to ~/.claude/logs/cross_modal_cache.log.
 call_opus() {
     local prompt="$1"
     local output="$2"
-    local user_msg="${prompt}
-
-Text to evaluate:
-${CONTENT}"
 
     local payload
     payload=$(jq -n \
         --arg model "claude-opus-4-5-20251101" \
-        --arg content "$user_msg" \
-        '{"model": $model, "max_tokens": 1024, "messages": [{"role": "user", "content": $content}]}')
+        --arg system_prompt "$prompt" \
+        --arg user_content "$CONTENT" \
+        '{
+            model: $model,
+            max_tokens: 1024,
+            system: [
+                {
+                    type: "text",
+                    text: $system_prompt,
+                    cache_control: {type: "ephemeral"}
+                }
+            ],
+            messages: [{role: "user", content: $user_content}]
+        }')
 
-    timeout "$TIMEOUT" curl -s https://api.anthropic.com/v1/messages \
+    local raw_response
+    raw_response=$(timeout "$TIMEOUT" curl -s https://api.anthropic.com/v1/messages \
         -H "x-api-key: ${ANTHROPIC_API_KEY}" \
         -H "anthropic-version: 2023-06-01" \
+        -H "anthropic-beta: prompt-caching-2024-07-31" \
         -H "content-type: application/json" \
-        -d "$payload" > "$output" 2>/dev/null || echo '{"error": "API call failed"}' > "$output"
+        -d "$payload" 2>/dev/null) || raw_response='{"error": "API call failed"}'
+
+    # Log cache metrics (cache_read_input_tokens=0 when threshold not yet met)
+    local cache_log="${HOME}/.claude/logs/cross_modal_cache.log"
+    mkdir -p "$(dirname "$cache_log")"
+    local cache_read cache_creation input_tokens output_tokens
+    cache_read=$(echo "$raw_response" | jq -r '.usage.cache_read_input_tokens // 0')
+    cache_creation=$(echo "$raw_response" | jq -r '.usage.cache_creation_input_tokens // 0')
+    input_tokens=$(echo "$raw_response" | jq -r '.usage.input_tokens // 0')
+    output_tokens=$(echo "$raw_response" | jq -r '.usage.output_tokens // 0')
+    printf '%s hash=%s cache_read=%s cache_creation=%s input=%s output=%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%S)" \
+        "$CONTENT_HASH" \
+        "$cache_read" \
+        "$cache_creation" \
+        "$input_tokens" \
+        "$output_tokens" >> "$cache_log"
+
+    echo "$raw_response" > "$output"
 }
 
 # Function to call GPT-4 (recall)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -213,6 +213,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "~/.claude/hooks/compound_command_guard.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "~/.claude/hooks/docs_qa_precommit.sh",
             "timeout": 10
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ Cumulative lab notes. Track completed work, **failed approaches**, accuracy chec
 
 Convention: newest entries at top. Each entry has a date, what was done, and why.
 
+## 2026-05-17 (Session 4 spike — compound-command guard hook, issue #176)
+
+### Completed
+
+- **Spiked `compound_command_guard.sh`** — PreToolUse:Bash hook that detects compound shell operators (`|`, `&&`, `||`, unescaped `;`) outside quoted strings, heredocs, and subshells. Uses Python to strip quoted regions and heredoc bodies before detection; subshells `(...)` are explicitly allowed per `bash-safety` rule.
+- **Three modes:** `off` (default, no-op), `log` (detect + write to `~/.claude/logs/compound_guard.log`, always exit 0), `block` (detect + log + exit 1 with actionable retry message). Default in settings.json is `off` to avoid breaking live work.
+- **12/12 self-test cases pass** — 5 compound commands correctly detected, 7 allowed cases (quoted strings, escaped semicolons, subshells, background `&`, heredoc bodies, plain commands) correctly passed through.
+- **Wired into settings.json** as a third PreToolUse:Bash hook after `destructive_fs_guard.sh` and `destructive_api_guard.sh`. JSON validated clean.
+- **PR opened:** `feat/176-compound-guard-spike` against main (do not merge — collect false positives for 1 week in log mode first).
+
+### How to enable block mode after log collection
+
+```bash
+# Review what was logged in the first week
+cat ~/.claude/logs/compound_guard.log | grep detected | sort | uniq -c | sort -rn
+
+# If false-positive rate is acceptable, enable blocking via settings.json env:
+# Change "COMPOUND_GUARD_MODE": "off" to "log" or "block"
+# Or export per-session: COMPOUND_GUARD_MODE=block claude
+```
+
+### Link to issue
+
+- #176 — Compound bash command auto-guard
+
+---
+
 ## 2026-05-17 (Session 3 follow-up — merged remaining PRs + Tasks 1/2/3 + SDK-caching issue)
 
 ### Completed


### PR DESCRIPTION
## Summary

- Adds `compound_command_guard.sh` — a PreToolUse:Bash hook that detects compound shell operators (`|`, `&&`, `||`, unescaped `;`) outside quoted strings, heredoc bodies, and subshells
- Uses Python to strip quoted regions and heredoc bodies before detection, preventing false positives on legitimate patterns
- Three modes via `COMPOUND_GUARD_MODE` env var: `off` (default, no-op), `log` (detect + log to `~/.claude/logs/compound_guard.log`, always exit 0), `block` (detect + log + exit 1 with actionable retry message)
- **Default is `off`** — hook is wired in but does nothing until mode is changed; no risk of breaking existing work

## Self-test output (12/12 PASS)

```
=== compound_command_guard.sh self-test ===
--- Must DETECT (compound operators outside strings/heredocs) ---
  PASS  [pipe: git status | wc -l]
  PASS  [ampamp: cd /tmp && ls]
  PASS  [semicolon: ls /a; ls /b]
  PASS  [oror: cmd1 || cmd2]
  PASS  [multi-pipe: git status | grep mod | wc -l]
--- Must ALLOW (operators inside strings, heredocs, or subshells) ---
  PASS  [pipe in double-quoted string]
  PASS  [ampamp in single-quoted string]
  PASS  [escaped semicolon (find -exec)]
  PASS  [subshell (documented exception)]
  PASS  [background operator at end of line]
  PASS  [simple command, no operators]
  PASS  [heredoc with pipe in body]
=== Results: 12 passed, 0 failed ===
```

## False positive risk cases tested

| Case | Result | Notes |
|------|--------|-------|
| `echo "a \| b"` — pipe in double-quoted string | ALLOW | Python strips double-quoted regions |
| `echo 'a && b'` — in single quotes | ALLOW | Python strips single-quoted regions |
| `find . -name '*.tmp' -exec rm {} \;` — escaped semicolon | ALLOW | `\;` stripped before detection |
| `(cd /tmp && tar czf /backup.tgz .)` — subshell | ALLOW | Subshells explicitly stripped — documented exception in `bash-safety` rule |
| Heredoc body with `\|` in it | ALLOW | Python heredoc regex strips body before detection |
| `sleep 5 &` — background operator at line end | ALLOW | No trailing `;` pattern match |

## Validation checklist

- [x] `bash -n compound_command_guard.sh` — syntax OK
- [x] `COMPOUND_GUARD_SELFTEST=1 bash compound_command_guard.sh` — 12/12 PASS
- [x] `mode=off` payload: exit 0, no output, no log
- [x] `mode=log` payload with compound cmd: exit 0, log written
- [x] `mode=block` payload with compound cmd: exit 1, actionable stderr message
- [x] `jq empty < settings.json` — JSON valid
- [x] Existing hooks (`destructive_fs_guard.sh`, `destructive_api_guard.sh`) unaffected — hook chain preserved

## Recommendation

Let this run in **`log` mode for 1 week** before considering flip to `block`. To enable log mode, set `COMPOUND_GUARD_MODE=log` in the `env` section of `settings.json`. After a week, review `~/.claude/logs/compound_guard.log` for unexpected false positives. If false-positive rate is low, flip to `block`.

**DO NOT MERGE** — this is a spike for review and false-positive collection.

Closes tracking: #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)