### PR TITLE
docs(rules): block-mode enforcement + mandatory worktree isolation for Agent dispatches

### DIFF
--- a/.claude/rules/auto-delegation.md
+++ b/.claude/rules/auto-delegation.md
@@ -110,6 +110,55 @@ When `burn_rate_check.sh` reports WARN or CRITICAL:
 | WARN | Prefer sonnet agents. Use haiku for all single-file edits. Defer speculative exploration. |
 | CRITICAL | Opus for user dialogue only. ALL code work via sonnet/haiku agents. Suggest worktree: `git worktree add ../<repo>-sonnet feat/<task> && cd ../<repo>-sonnet && claude --model sonnet` |
 
+## Mandatory: isolation:"worktree" for Agent Dispatches with Bash
+
+Per the `permission-discipline` rule, `bypassPermissions` is safe ONLY inside
+worktrees and `/tmp/*`. It is NEVER safe in the main checkout, where live API
+tokens and credentials sit. An agent running `bypassPermissions` in the main
+checkout can silently overwrite `.Renviron`, `default.nix`, or any other
+file without a confirmation prompt.
+
+**Therefore:** ANY Agent dispatch where the agent may invoke Bash MUST be
+called with `isolation: "worktree"`. This includes:
+
+| Agent | Bash? | Worktree required? |
+|-------|-------|--------------------|
+| `fixer` | Yes | **Yes** |
+| `r-debugger` | Yes | **Yes** |
+| `targets-runner` | Yes | **Yes** |
+| `nix-env` | Yes | **Yes** |
+| `shiny-async-debugger` | Yes | **Yes** |
+| `data-quality-guardian` | Yes | **Yes** |
+| `data-engineer` | Yes | **Yes** |
+| `shinylive-builder` | Yes | **Yes** |
+| `wiki-curator` | Yes | **Yes** |
+| `quick-fix` (haiku) | No | Optional |
+| `critic` (read-only) | No | Optional |
+
+### Right vs Wrong
+
+```
+# WRONG: fixer runs in main checkout — live tokens exposed
+Agent(subagent_type="fixer",
+      prompt="Fix R/foo.R line 42 — add NA check before division.")
+
+# RIGHT: fixer isolated to a fresh worktree
+Agent(subagent_type="fixer",
+      isolation="worktree",
+      prompt="""**CRITICAL — Bash discipline:** Compound bash commands
+(`&&`/`||`/`;`/`|`) are HOOK-REJECTED in block mode. Every Bash tool call
+must contain exactly ONE command. The ONLY exception is subshell `(cd dir && cmd)`
+for atomic cd+cmd. Use `git -C <path>` for git operations. For multi-step
+shell logic, write a script file and run it.
+
+Fix R/foo.R line 42 — add NA check before division.""")
+```
+
+Note that the Agent Dispatch Template (from `bash-safety.md` Part 1) is
+included verbatim at the top of the right example above. Both `isolation:
+"worktree"` AND the Bash discipline prefix are required for every Bash-capable
+agent dispatch.
+
 ## Parallel Worktree Sessions
 
 For independent tasks, spawn a sonnet-only worktree session:

--- a/.claude/rules/bash-safety.md
+++ b/.claude/rules/bash-safety.md
@@ -14,6 +14,31 @@ Every Bash tool call, without exception.
 
 ## Part 1: No Compound Commands (Universal `&&` Ban)
 
+> **Status: ENFORCED (block mode)**
+> `COMPOUND_GUARD_MODE=block` is active in `settings.json`. Any Bash call
+> containing `&&`, `||`, `;` (outside a subshell), or `|` between independent
+> commands is rejected by the pre-tool hook with a retry message. The command
+> never reaches the shell. Fix the call and retry — do not attempt to work
+> around the guard.
+
+### Agent Dispatch Template
+
+Every Agent dispatch that involves Bash MUST include the following prefix
+**verbatim** at the top of the agent prompt. Orchestrators are responsible for
+pasting this prefix before any other instructions:
+
+```
+**CRITICAL — Bash discipline:** Compound bash commands (`&&`/`||`/`;`/`|`) are
+HOOK-REJECTED in block mode. Every Bash tool call must contain exactly ONE
+command. The ONLY exception is subshell `(cd dir && cmd)` for atomic cd+cmd.
+Use `git -C <path>` for git operations. For multi-step shell logic, write a
+script file and run it.
+```
+
+This is not optional. An agent that receives a prompt without this prefix will
+default to compound commands and have its calls rejected. The orchestrator owns
+the responsibility for injecting this prefix.
+
 ### CRITICAL: Never Use `&&` in Bash Commands
 
 Compound commands with `&&` trigger confirmation prompts that interrupt workflow.


### PR DESCRIPTION
## Summary

- **bash-safety.md (A1):** Added a `> Status: ENFORCED (block mode)` blockquote at the top of Part 1 declaring `COMPOUND_GUARD_MODE=block` is active and any compound Bash call is hook-rejected. Added an **Agent Dispatch Template** subsection with the verbatim prefix that orchestrators must inject at the top of every Agent prompt involving Bash.

- **auto-delegation.md (B1):** Added a new **Mandatory: isolation:"worktree" for Agent dispatches with Bash** section (before the existing Parallel Worktree Sessions section). Documents that `bypassPermissions` is safe only in worktrees and `/tmp`, never in the main checkout. Includes a per-agent table (9 agents require isolation, `quick-fix`/`critic` are optional) and a right-vs-wrong invocation example with the Bash discipline prefix embedded.

## Test plan

- [ ] Read `bash-safety.md` — confirm Status callout and Agent Dispatch Template subsection present; existing content unchanged
- [ ] Read `auto-delegation.md` — confirm new section is between Burn-Rate-Aware Escalation and Parallel Worktree Sessions; existing content unchanged
- [ ] Verify no lines were removed from either file (25 + 49 insertions, 0 deletions per git)

🤖 Generated with [Claude Code](https://claude.com/claude-code)