### PR TITLE
feat(roborev): bounded session-end refine on /bye

### DIFF
--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -5,7 +5,9 @@
 
 set -euo pipefail
 
-CLAUDE_DIR="$HOME/.claude"
+CLAUDE_RUNTIME_ROOT="${CLAUDE_RUNTIME_ROOT:-$HOME/.claude}"
+CLAUDE_CONTROL_PLANE_ROOT="${CLAUDE_CONTROL_PLANE_ROOT:-$CLAUDE_RUNTIME_ROOT}"
+CLAUDE_DIR="$CLAUDE_CONTROL_PLANE_ROOT"
 CLAUDE_MD="$CLAUDE_DIR/CLAUDE.md"
 SKILLS_DIR="$CLAUDE_DIR/skills"
 RULES_DIR="$CLAUDE_DIR/rules"
@@ -25,6 +27,12 @@ phase_env() {
   else
     echo "Nix Shell: WARNING — not in nix shell"
   fi
+}
+
+as_int_or_zero() {
+  local value="${1:-0}"
+  value=$(printf '%s\n' "$value" | grep -E '^[0-9]+$' | head -1 || true)
+  printf '%s\n' "${value:-0}"
 }
 
 # ── Phase 1b: Permission Mode Advisory ────────────────────────────────
@@ -58,7 +66,7 @@ phase_perm_mode() {
     main)             expected="default" ;;
     *)                expected="default" ;;
   esac
-  settings="$HOME/.claude/settings.json"
+  settings="$SETTINGS_JSON"
   current="unknown"
   if [ -f "$settings" ]; then
     current=$(grep -oE '"defaultMode"[[:space:]]*:[[:space:]]*"[^"]+"' "$settings" \
@@ -528,7 +536,7 @@ phase_roborev() {
 
 # ── Phase 9: Weekly Burn Rate ─────────────────────────────────────────
 phase_burn_rate() {
-  local script="$HOME/.claude/scripts/burn_rate_check.sh"
+  local script="$CLAUDE_DIR/scripts/burn_rate_check.sh"
   if [ -x "$script" ]; then
     timeout 45 "$script" full 2>/dev/null || echo "Burn rate: check failed"
   fi
@@ -648,8 +656,10 @@ if command -v /usr/local/bin/roborev >/dev/null 2>&1; then
   rv_output=$(/usr/local/bin/roborev status 2>/dev/null) || true
   if echo "$rv_output" | grep -qE "running" 2>/dev/null; then
     # Count high-severity failures specifically
-    n_high=$(/usr/local/bin/roborev list --status failed --min-severity high --limit 100 2>/dev/null | grep -cE "^Job" || echo 0) || true
-    n_total=$(/usr/local/bin/roborev list --status failed --limit 100 2>/dev/null | grep -cE "^Job" || echo 0) || true
+    n_high=$(/usr/local/bin/roborev list --status failed --min-severity high --limit 100 2>/dev/null | grep -cE "^Job" || true)
+    n_total=$(/usr/local/bin/roborev list --status failed --limit 100 2>/dev/null | grep -cE "^Job" || true)
+    n_high=$(as_int_or_zero "$n_high")
+    n_total=$(as_int_or_zero "$n_total")
     if [ "${n_high:-0}" -gt 0 ]; then
       roborev_status="roborev:${n_high}high/${n_total}total"
     elif [ "${n_total:-0}" -gt 0 ]; then
@@ -668,7 +678,7 @@ fi
 
 # Phase 9: Burn rate (run in background, use cache if available)
 burn_output=""
-burn_script="$HOME/.claude/scripts/burn_rate_check.sh"
+burn_script="$CLAUDE_DIR/scripts/burn_rate_check.sh"
 if [ -x "$burn_script" ]; then
   burn_output=$(timeout 45 "$burn_script" compact 2>/dev/null) || burn_output="burn:err"
 fi
@@ -690,7 +700,7 @@ fi
 
 # Phase 11: AGENTS.md audit
 audit_output=""
-audit_script="$HOME/.claude/scripts/agents_md_audit.sh"
+audit_script="$CLAUDE_DIR/scripts/agents_md_audit.sh"
 if [ -x "$audit_script" ]; then
   audit_output=$("$audit_script" 2>/dev/null) || true
   if echo "$audit_output" | grep -q "DRIFT"; then
@@ -752,16 +762,16 @@ if [ -x "$_lc" ]; then
 fi
 
 # ── Phase 12: Log session start to unified DuckDB ──
-_log_script="$HOME/.claude/scripts/log_session.sh"
+_log_script="$CLAUDE_DIR/scripts/log_session.sh"
 _session_id="${CLAUDE_SESSION_ID:-$(uuidgen 2>/dev/null || echo unknown)}"
 if [ -x "$_log_script" ]; then
   "$_log_script" start "$_session_id" "$(basename "$(pwd)")" "" 2>/dev/null || true
 fi
 # Record session start time for session_stop braindump sweep
-date '+%Y-%m-%d %H:%M:%S' > "$HOME/.claude/logs/.session_start_time"
+date '+%Y-%m-%d %H:%M:%S' > "$CLAUDE_RUNTIME_ROOT/logs/.session_start_time"
 
 # ── Phase 13: Surface unprocessed braindumps for Claude to act on ──
-_bd_db="$HOME/.claude/logs/unified.duckdb"
+_bd_db="$CLAUDE_RUNTIME_ROOT/logs/unified.duckdb"
 if [ -f "$_bd_db" ]; then
   _bd_output=$(duckdb "$_bd_db" -c "
     SELECT id, source, captured_at::VARCHAR as captured,
@@ -827,6 +837,7 @@ fi
 # Background ctx_sync if missing packages detected
 if [ -f "DESCRIPTION" ]; then
   ctx_miss=$(echo "$ctx_part" | cut -d: -f2 | cut -d/ -f3)
+  ctx_miss=$(as_int_or_zero "$ctx_miss")
   if [ "${ctx_miss:-0}" -gt 0 ]; then
     nohup timeout 600 Rscript -e 'source("~/docs_gh/llm/R/tar_plans/plan_pkgctx.R"); ctx_sync("DESCRIPTION")' \
       > /tmp/ctx_sync_$$.log 2>&1 &
@@ -841,5 +852,23 @@ fi
 echo ""
 echo "TIP: Check active loops with: /btw 'Show running loops via /schedule list'"
 echo "     Auto-loop suggestions: /loop 1h /check | /loop 30m /ctx-check"
+
+# ── Phase 14: Record session-start SHA (for session-end refine) ───────────────
+# Writes HEAD SHA to ~/.claude/.session_start_sha_<project> so that
+# session_end_refine.sh can bound a roborev refine to commits from this session.
+# One state file per project — concurrent sessions for the same project
+# overwrite each other (latest start wins, which is fine).
+# No dependency on other phases; safe to run unconditionally.
+_sha_project_root=$(git rev-parse --show-toplevel 2>/dev/null) || _sha_project_root=""
+if [ -n "$_sha_project_root" ]; then
+  _sha_project_name=$(basename "$_sha_project_root")
+  _sha_slug=$(echo "$_sha_project_name" | tr '/ ' '__' | sed 's/^_*//')
+  _sha_state_file="$CLAUDE_RUNTIME_ROOT/.session_start_sha_${_sha_slug}"
+  _sha_head=$(git -C "$_sha_project_root" rev-parse HEAD 2>/dev/null) || _sha_head=""
+  if [ -n "$_sha_head" ]; then
+    echo "$_sha_head" > "$_sha_state_file"
+    # No console output — this is infrastructure, not user-facing info
+  fi
+fi
 
 exit 0

--- a/.claude/hooks/session_stop.sh
+++ b/.claude/hooks/session_stop.sh
@@ -5,7 +5,9 @@
 
 set -euo pipefail
 
-CLAUDE_DIR="$HOME/.claude"
+CLAUDE_RUNTIME_ROOT="${CLAUDE_RUNTIME_ROOT:-$HOME/.claude}"
+CLAUDE_CONTROL_PLANE_ROOT="${CLAUDE_CONTROL_PLANE_ROOT:-$CLAUDE_RUNTIME_ROOT}"
+CLAUDE_DIR="$CLAUDE_CONTROL_PLANE_ROOT"
 CURRENT_WORK="${CLAUDE_PROJECT_DIR:-.}/.claude/CURRENT_WORK.md"
 TODAY=$(date +%Y-%m-%d)
 
@@ -40,26 +42,26 @@ if [ -d "$CLAUDE_DIR/.git" ] || git -C "$CLAUDE_DIR" rev-parse --git-dir >/dev/n
   changes=$(git -C "$CLAUDE_DIR" status -s 2>/dev/null | head -5)
   if [ -n "$changes" ]; then
     n_changes=$(echo "$changes" | wc -l | tr -d ' ')
-    echo "Config: $n_changes uncommitted changes in ~/.claude/"
+    echo "Config: $n_changes uncommitted changes in $CLAUDE_DIR/"
   fi
 fi
 
 # ── Skill audit (only if skills changed) ─────────────────────────────
-AUDIT_WRAPPER="$HOME/docs_gh/llm/.claude/scripts/audit_skills_if_changed.sh"
+AUDIT_WRAPPER="$CLAUDE_DIR/scripts/audit_skills_if_changed.sh"
 if [ -x "$AUDIT_WRAPPER" ]; then
   timeout 15 "$AUDIT_WRAPPER" 2>/dev/null || true
 fi
 
 # ── Model mix log ────────────────────────────────────────────────────
-MIX_SCRIPT="$HOME/.claude/scripts/model_mix_log.sh"
+MIX_SCRIPT="$CLAUDE_DIR/scripts/model_mix_log.sh"
 if [ -x "$MIX_SCRIPT" ]; then
   timeout 35 "$MIX_SCRIPT" >/dev/null 2>&1 || true
 fi
 
 # ── Log session stop to unified DuckDB ───────────────────────────────
-_log_script="$HOME/.claude/scripts/log_session.sh"
-if [ -x "$_log_script" ] && [ -f "$HOME/.claude/logs/.current_session" ]; then
-  _sid=$(cat "$HOME/.claude/logs/.current_session" 2>/dev/null || echo "")
+_log_script="$CLAUDE_DIR/scripts/log_session.sh"
+if [ -x "$_log_script" ] && [ -f "$CLAUDE_RUNTIME_ROOT/logs/.current_session" ]; then
+  _sid=$(cat "$CLAUDE_RUNTIME_ROOT/logs/.current_session" 2>/dev/null || echo "")
   "$_log_script" stop "$_sid" "$(basename "$(pwd)")" "" 2>/dev/null || true
 fi
 
@@ -74,7 +76,7 @@ fi
 
 # ── Braindump closed-loop check ─────────────────────────────────────
 # Safety net: warn if braindumps were surfaced but not processed this session.
-_bd_db="$HOME/.claude/logs/unified.duckdb"
+_bd_db="$CLAUDE_RUNTIME_ROOT/logs/unified.duckdb"
 if [ -f "$_bd_db" ]; then
   _unprocessed=$(duckdb -list -noheader "$_bd_db" -c "
     SELECT COUNT(*) FROM braindumps WHERE processed_prompt IS NULL;
@@ -82,11 +84,11 @@ if [ -f "$_bd_db" ]; then
 
   if [ "${_unprocessed:-0}" -gt 0 ]; then
     echo "BRAINDUMP: $_unprocessed unprocessed braindump(s) — these were surfaced but not acted on."
-    echo "  Run: ~/.claude/scripts/braindump_act.sh pending"
+    echo "  Run: $CLAUDE_DIR/scripts/braindump_act.sh pending"
   fi
 
   # Check for commits this session that aren't linked to any braindump action
-  _session_start_file="$HOME/.claude/logs/.session_start_time"
+  _session_start_file="$CLAUDE_RUNTIME_ROOT/logs/.session_start_time"
   if [ -f "$_session_start_file" ]; then
     _start_time=$(cat "$_session_start_file" 2>/dev/null || echo "")
     if [ -n "$_start_time" ]; then
@@ -106,13 +108,13 @@ fi
 
 # ── Telemetry data export + deploy (Calibration + Sessions tabs) ────
 # Auto-runs export_and_deploy_data.sh (was orphaned — header claimed it ran here).
-EXPORT_SCRIPT="$HOME/.claude/scripts/export_and_deploy_data.sh"
+EXPORT_SCRIPT="$CLAUDE_DIR/scripts/export_and_deploy_data.sh"
 if [ -x "$EXPORT_SCRIPT" ]; then
   timeout 180 "$EXPORT_SCRIPT" 2>&1 | tail -3 || true
 fi
 
 # --- Prediction calibration: remind about unresolved predictions ---
-PRED_DIR="$HOME/.claude/predictions"
+PRED_DIR="$CLAUDE_RUNTIME_ROOT/predictions"
 if [ -d "$PRED_DIR" ]; then
   PROJECT_SLUG=$(echo "${CLAUDE_PROJECT_DIR:-.}" | sed 's|/|-|g; s|^-||')
   PRED_FILE="$PRED_DIR/${PROJECT_SLUG}.jsonl"
@@ -147,31 +149,40 @@ fi
 # before invoking the Stop hook. Non-/bye stops skip this block entirely.
 # The sentinel (~/.claude/.bye-requested) is deleted immediately after use
 # so a crash or abort does not leave a stale sentinel.
-_BYE_SENTINEL="${HOME}/.claude/.bye-requested"
-if [ -f "$_BYE_SENTINEL" ] && [ -f "${HOME}/.claude/scripts/detect_patterns.sh" ]; then
+_BYE_SENTINEL="${CLAUDE_RUNTIME_ROOT}/.bye-requested"
+if [ -f "$_BYE_SENTINEL" ] && [ -f "${CLAUDE_DIR}/scripts/detect_patterns.sh" ]; then
   rm -f "$_BYE_SENTINEL"  # consume sentinel immediately — one-shot
-  TRANSCRIPT=$(ls -t "${HOME}/.claude/projects/"*/*.jsonl 2>/dev/null | head -1)
+  TRANSCRIPT=$(ls -t "${CLAUDE_RUNTIME_ROOT}/projects/"*/*.jsonl 2>/dev/null | head -1)
   if [ -n "$TRANSCRIPT" ]; then
-    PATTERNS=$(timeout 30 "${HOME}/.claude/scripts/detect_patterns.sh" "$TRANSCRIPT" 2>&1) || PATTERNS=""
+    PATTERNS=$(timeout 30 "${CLAUDE_DIR}/scripts/detect_patterns.sh" "$TRANSCRIPT" 2>&1) || PATTERNS=""
     if echo "$PATTERNS" | grep -q "Detected workflow patterns"; then
       echo ""
       echo "$PATTERNS"
       echo ""
       # No interactive read — hooks run non-interactively; auto-schedule skillify.
-      echo "$TRANSCRIPT" > "${HOME}/.claude/.pending_skillify"
+      echo "$TRANSCRIPT" > "${CLAUDE_RUNTIME_ROOT}/.pending_skillify"
       echo "✓ Patterns detected — /skillify will run at next session start."
     fi
   fi
 fi
 
+# ── Bounded session-end roborev refine (fire-and-forget) ─────────────────────
+# Runs a bounded `roborev refine --since <session-start-sha>` in the background.
+# Never blocks /bye. Opt-out: SKIP_SESSION_END_REFINE=1 or .roborev.toml flag.
+# Logs: ~/.claude/logs/session_end_refine.log
+_REFINE_SCRIPT="$CLAUDE_DIR/scripts/session_end_refine.sh"
+if [ -x "$_REFINE_SCRIPT" ]; then
+  nohup "$_REFINE_SCRIPT" >/dev/null 2>&1 &
+fi
+
 # ── Entity propagation (projects only) — #137 Phase 3 minimal cut ─────
-PROPAGATE="$HOME/docs_gh/llm/.claude/scripts/entity_propagate.sh"
+PROPAGATE="$CLAUDE_DIR/scripts/entity_propagate.sh"
 if [ -x "$PROPAGATE" ] && [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
   timeout 10 "$PROPAGATE" 2>/dev/null || true
 fi
 
 # ── Semantic drift logger (passive) — #125 Phase 1 ────────────────────
-DRIFT="$HOME/docs_gh/llm/.claude/scripts/drift_check.py"
+DRIFT="$CLAUDE_DIR/scripts/drift_check.py"
 DRIFT_PY="$HOME/.venvs/drift/bin/python3"
 [ -x "$DRIFT_PY" ] || DRIFT_PY=python3   # graceful fallback to system python
 if [ -x "$DRIFT" ] && [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then

--- a/.claude/hooks/session_stop.sh
+++ b/.claude/hooks/session_stop.sh
@@ -172,7 +172,9 @@ fi
 # Logs: ~/.claude/logs/session_end_refine.log
 _REFINE_SCRIPT="$CLAUDE_DIR/scripts/session_end_refine.sh"
 if [ -x "$_REFINE_SCRIPT" ]; then
-  nohup "$_REFINE_SCRIPT" >/dev/null 2>&1 &
+  # Default SKIP=1 for the first 7 days of soak — per #196 rollout plan.
+  # After 7 days of clean dry-run-equivalent logs, remove the env-var prefix.
+  SKIP_SESSION_END_REFINE=1 nohup "$_REFINE_SCRIPT" >/dev/null 2>&1 &
 fi
 
 # ── Entity propagation (projects only) — #137 Phase 3 minimal cut ─────

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -112,6 +112,13 @@
 - Non-llm sessions MUST NOT edit files outside their own tree, dispatch agents to other trees, or run roborev on other repos
 - See ~/docs_gh/llm/.claude/rules/cross-project-scope.md
 
+## Roborev Session-End Automation (2026-05-20)
+- session_init.sh Phase 14 records HEAD SHA → ~/.claude/.session_start_sha_<project>
+- session_stop.sh fires session_end_refine.sh in background (nohup, never blocks /bye)
+- Bounds: timeout 120s + --max-iterations 3 + --min-severity high
+- Opt-out: SKIP_SESSION_END_REFINE=1 or .roborev.toml `session_end_refine = false`
+- Log: ~/.claude/logs/session_end_refine.log
+
 ## Config Migration (2026-03-09)
 - All rules, scripts, CLAUDE.md now git-backed via symlinks
 - CLAUDE.md → AGENTS.md (merged, <200 lines)

--- a/.claude/rules/roborev-resolution.md
+++ b/.claude/rules/roborev-resolution.md
@@ -136,6 +136,52 @@ Long-term fix: a periodic poller (tracked in #148) that fetches each watched rep
 - `core.hooksPath` shared across repos (e.g., `llm/git-hooks/`) — `roborev install-hook` writes to the shared path, so one install covers many repos but a misconfigured one breaks many at once
 - **`.roborev.toml` is gitignored in some projects** (e.g., micromort line 52) but tracked in others (coMMpass, llm). Edits in gitignored projects are LOCAL-only and silently disappear if `roborev init` regenerates. Check `git check-ignore .roborev.toml` before editing; if ignored, add a top-of-file comment recording the manual value (since the comment is the only durable signal that survives regeneration in the file's own context).
 
+## Session-End Refine (Automated)
+
+The session-end refine runs automatically when the user types `/bye`.
+
+### What runs
+
+`~/.claude/scripts/session_end_refine.sh` is invoked by `session_stop.sh` in the background via `nohup`. It reads the session-start SHA recorded by `session_init.sh` (Phase 14) and calls:
+
+```bash
+timeout 120 roborev refine \
+  --since <session-start-sha> \
+  --max-iterations 3 \
+  --min-severity high \
+  --quiet \
+  --agent codex
+```
+
+### Bounds
+
+| Bound | Value | Effect |
+|-------|-------|--------|
+| `timeout 120` | 2 minutes | Hard wall-clock kill |
+| `--max-iterations 3` | 3 iterations | roborev internal cap |
+| `--min-severity high` | High+ only | Skips low/medium noise |
+| `nohup ... &` | Background | Never blocks `/bye` |
+
+### Opt-out mechanisms
+
+| Mechanism | How to set | Scope |
+|-----------|------------|-------|
+| Env var | `SKIP_SESSION_END_REFINE=1` before `/bye` | Session-level |
+| TOML flag | `session_end_refine = false` in `.roborev.toml` | Per-project |
+
+### Log location
+
+`~/.claude/logs/session_end_refine.log` — one line per session:
+```
+2026-05-20 14:32:01 project=llm start-sha=abc1234 result=ok
+```
+
+Result values: `ok`, `timeout`, `error`, `skipped`.
+
+### State file
+
+`~/.claude/.session_start_sha_<sanitized-project-name>` — written by `session_init.sh` Phase 14 at session start.
+
 ## Related
 
 - `auto-delegation` — model selection for Claude Code agents (separate from roborev agents)

--- a/.claude/rules/roborev-resolution.md
+++ b/.claude/rules/roborev-resolution.md
@@ -140,6 +140,17 @@ Long-term fix: a periodic poller (tracked in #148) that fetches each watched rep
 
 The session-end refine runs automatically when the user types `/bye`.
 
+### Rollout: SKIP defaulted ON (7-day soak)
+
+For the first 7 days after deployment, `session_stop.sh` invokes `session_end_refine.sh` with `SKIP_SESSION_END_REFINE=1` prefixed, so each call exits early with `result=skipped` and only the bookkeeping logs are written. This lets us observe:
+
+- That `session_init.sh` Phase 14 wrote the start-SHA file
+- That `session_stop.sh` actually fires the script at /bye
+- That the cwd-detection / project-name sanitisation logic finds the right project
+- That nothing else in `/bye` got slower
+
+After 7 clean days, **remove the `SKIP_SESSION_END_REFINE=1` prefix from session_stop.sh** in a follow-up commit. The opt-out env var remains available per-session (set in shell rc files or one-off).
+
 ### What runs
 
 `~/.claude/scripts/session_end_refine.sh` is invoked by `session_stop.sh` in the background via `nohup`. It reads the session-start SHA recorded by `session_init.sh` (Phase 14) and calls:

--- a/.claude/scripts/session_end_refine.sh
+++ b/.claude/scripts/session_end_refine.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# session_end_refine.sh — Bounded session-end roborev refine runner
+#
+# Called by session_stop.sh in the background (fire-and-forget, never blocks /bye).
+# Reads the session-start SHA recorded by session_init.sh and runs a
+# bounded roborev refine on commits made since that SHA.
+#
+# Controls:
+#   SKIP_SESSION_END_REFINE=1          — skip entirely (env opt-out)
+#   SESSION_END_REFINE_DRYRUN=1        — print what would run, no actual roborev call
+#   .roborev.toml session_end_refine = false — per-project opt-out
+#
+# Bounded by:
+#   timeout 120 — hard wall-clock limit
+#   --max-iterations 3 — roborev iteration cap
+#   --min-severity high — only high+ findings
+#
+# Log: ~/.claude/logs/session_end_refine.log
+
+set -uo pipefail   # -u: unset vars are errors; no -e: we exit 0 on all errors
+
+ROBOREV="/usr/local/bin/roborev"
+LOGFILE="$HOME/.claude/logs/session_end_refine.log"
+mkdir -p "$(dirname "$LOGFILE")"
+
+log() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$LOGFILE"
+}
+
+# Sanitise a string for use as a filename component.
+# Replaces slashes and spaces with underscores, strips leading underscores.
+sanitize() {
+  echo "$1" | tr '/ ' '__' | sed 's/^_*//'
+}
+
+# ── Env opt-out ───────────────────────────────────────────────────────────────
+if [ "${SKIP_SESSION_END_REFINE:-}" = "1" ]; then
+  log "result=skipped reason=SKIP_SESSION_END_REFINE"
+  echo "skipping (opt-out env var)"
+  exit 0
+fi
+
+# ── Determine project root ────────────────────────────────────────────────────
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || PROJECT_ROOT=""
+if [ -z "$PROJECT_ROOT" ]; then
+  log "result=skipped reason=not-a-git-repo"
+  if [ "${SESSION_END_REFINE_DRYRUN:-}" = "1" ]; then
+    echo "skipping (cwd not a git repo)"
+  fi
+  exit 0
+fi
+PROJECT_NAME=$(basename "$PROJECT_ROOT")
+
+# ── Per-project TOML opt-out ──────────────────────────────────────────────────
+TOML="$PROJECT_ROOT/.roborev.toml"
+if [ -f "$TOML" ]; then
+  if grep -qE '^\s*session_end_refine\s*=\s*false' "$TOML" 2>/dev/null; then
+    log "project=$PROJECT_NAME result=skipped reason=toml-opt-out"
+    if [ "${SESSION_END_REFINE_DRYRUN:-}" = "1" ]; then
+      echo "skipping (project opted out via .roborev.toml: session_end_refine = false)"
+    fi
+    exit 0
+  fi
+fi
+
+# ── Read session-start SHA ────────────────────────────────────────────────────
+SLUG=$(sanitize "$PROJECT_NAME")
+STATE_FILE="$HOME/.claude/.session_start_sha_${SLUG}"
+
+if [ ! -f "$STATE_FILE" ]; then
+  log "project=$PROJECT_NAME result=skipped reason=no-session-start-sha"
+  if [ "${SESSION_END_REFINE_DRYRUN:-}" = "1" ]; then
+    echo "skipping (no session-start SHA)"
+  fi
+  exit 0
+fi
+
+START_SHA=$(cat "$STATE_FILE" 2>/dev/null | head -1 | tr -d '[:space:]')
+if [ -z "$START_SHA" ]; then
+  log "project=$PROJECT_NAME result=skipped reason=empty-state-file"
+  if [ "${SESSION_END_REFINE_DRYRUN:-}" = "1" ]; then
+    echo "skipping (session-start SHA file is empty)"
+  fi
+  exit 0
+fi
+
+# ── Verify SHA exists in this repo ───────────────────────────────────────────
+if ! git -C "$PROJECT_ROOT" cat-file -e "${START_SHA}^{commit}" 2>/dev/null; then
+  log "project=$PROJECT_NAME start-sha=$START_SHA result=skipped reason=sha-not-in-repo"
+  if [ "${SESSION_END_REFINE_DRYRUN:-}" = "1" ]; then
+    echo "skipping (start SHA $START_SHA not found in repo $PROJECT_NAME)"
+  fi
+  exit 0
+fi
+
+# ── Check if roborev is available ────────────────────────────────────────────
+if [ ! -x "$ROBOREV" ]; then
+  log "project=$PROJECT_NAME result=skipped reason=roborev-not-installed"
+  if [ "${SESSION_END_REFINE_DRYRUN:-}" = "1" ]; then
+    echo "skipping (roborev not installed at $ROBOREV)"
+  fi
+  exit 0
+fi
+
+# ── Dry-run mode ──────────────────────────────────────────────────────────────
+if [ "${SESSION_END_REFINE_DRYRUN:-}" = "1" ]; then
+  echo "would run: roborev refine --since $START_SHA --max-iterations 3 --min-severity high --quiet --agent codex"
+  echo "  project:   $PROJECT_NAME"
+  echo "  root:      $PROJECT_ROOT"
+  echo "  state:     $STATE_FILE"
+  echo "  log:       $LOGFILE"
+  exit 0
+fi
+
+# ── Execute bounded refine ────────────────────────────────────────────────────
+log "project=$PROJECT_NAME start-sha=$START_SHA starting"
+
+TMPLOG=$(mktemp /tmp/session_end_refine_XXXXXX.log)
+# timeout + roborev: one command, no compound
+timeout 120 \
+  "$ROBOREV" refine \
+    --since "$START_SHA" \
+    --max-iterations 3 \
+    --min-severity high \
+    --quiet \
+    --agent codex \
+  > "$TMPLOG" 2>&1
+EXIT_CODE=$?
+
+if [ "$EXIT_CODE" -eq 124 ]; then
+  log "project=$PROJECT_NAME start-sha=$START_SHA result=timeout duration=120s"
+  echo "TIMEOUT after 120s" >> "$LOGFILE"
+elif [ "$EXIT_CODE" -ne 0 ]; then
+  log "project=$PROJECT_NAME start-sha=$START_SHA result=error exit=$EXIT_CODE"
+else
+  log "project=$PROJECT_NAME start-sha=$START_SHA result=ok"
+fi
+
+# Append roborev output to log
+cat "$TMPLOG" >> "$LOGFILE" 2>/dev/null || true
+rm -f "$TMPLOG"
+
+exit 0


### PR DESCRIPTION
## Summary

- **NEW script** `~/.claude/scripts/session_end_refine.sh` — bounded, fire-and-forget roborev refine runner invoked on every `/bye`. Reads session-start SHA, calls `timeout 120 roborev refine --since <sha> --max-iterations 3 --min-severity high --quiet --agent codex`, logs to `~/.claude/logs/session_end_refine.log`.
- **session_init.sh Phase 14** — records `git rev-parse HEAD` to `~/.claude/.session_start_sha_<project>` at session start, bounding the refine to commits from this session only.
- **session_stop.sh** — fires the script via `nohup ... &` (never blocks `/bye`).
- **roborev-resolution.md** — documents the Session-End Refine (Automated) section.
- **MEMORY.md** — one-line entry for the automation.

Also refactors both hook files to use `CLAUDE_RUNTIME_ROOT` / `CLAUDE_CONTROL_PLANE_ROOT` env vars instead of hardcoded `$HOME/.claude` paths.

## Opt-out mechanisms

| Mechanism | How | Scope |
|-----------|-----|-------|
| Env var | `SKIP_SESSION_END_REFINE=1` before `/bye` | Session-level |
| TOML flag | `session_end_refine = false` in `.roborev.toml` | Per-project |

## Test plan

- [x] `bash -n` syntax OK on all 3 touched scripts
- [x] `chmod +x` set on `session_end_refine.sh`
- [x] 4/4 dry-run scenarios PASS:

```
Scenario 1 — missing state file:
  SESSION_END_REFINE_DRYRUN=1 session_end_refine.sh (from worktree cwd)
  → skipping (no session-start SHA)  ✓

Scenario 2 — cwd not a git repo:
  (cd /tmp/not_a_git_dir && SESSION_END_REFINE_DRYRUN=1 session_end_refine.sh)
  → skipping (cwd not a git repo)  ✓

Scenario 3 — state file present, in git repo:
  (cd ~/docs_gh/llm && SESSION_END_REFINE_DRYRUN=1 session_end_refine.sh)
  → would run: roborev refine --since d7f58d9... --max-iterations 3 --min-severity high --quiet --agent codex
    project:   llm
    root:      /Users/johngavin/docs_gh/llm
    state:     /Users/johngavin/.claude/.session_start_sha_llm
    log:       /Users/johngavin/.claude/logs/session_end_refine.log  ✓

Scenario 4 — opt-out env var:
  SKIP_SESSION_END_REFINE=1 SESSION_END_REFINE_DRYRUN=1 session_end_refine.sh
  → skipping (opt-out env var)  ✓
```

- [x] Feature branch verified != main before push
- [x] Script symlinked/copied to `~/docs_gh/llm/.claude/scripts/session_end_refine.sh` for version control

## Bounds (never blocks /bye)

| Bound | Value | Effect |
|-------|-------|--------|
| `timeout 120` | 2 minutes | Hard wall-clock kill |
| `--max-iterations 3` | 3 iterations | roborev internal cap |
| `--min-severity high` | High+ only | Skips low/medium noise |
| `nohup ... &` | Background | Fire-and-forget |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
