### PR TITLE
fix(docs): derive scrolly vignette scope from scrolly_scan_specs metadata

### DIFF
--- a/R/tar_plans/plan_scrolly_config.R
+++ b/R/tar_plans/plan_scrolly_config.R
@@ -5,55 +5,91 @@
 # hooks (.sh), memory (.md), commands (.md), scripts (.sh).
 # Other .claude/ paths (e.g. worktrees/, logs/) are intentionally excluded.
 
+# Internal helper: derive human-readable scope text from scan_specs.
+# scan_specs: named list of lists with fields $pattern and $recurse.
+# n_files: integer — total files in vig_scrolly_config after exclusions.
+# Returns a list with two character(1) elements:
+#   $prose — for methodology section prose
+#   $alt   — shorter string for fig-alt attributes
+.build_scrolly_scope <- function(scan_specs, n_files) {
+  cat_desc <- vapply(names(scan_specs), function(cat) {
+    spec     <- scan_specs[[cat]]
+    pat      <- spec$pattern
+    rec      <- isTRUE(spec$recurse)
+    pat_desc <- if (grepl("^SKILL\\.md\\$", pat, ignore.case = FALSE)) {
+      "SKILL.md only"
+    } else if (grepl("^\\.md\\$", pat)) {
+      if (rec) "*.md (recursive)" else "*.md (top-level)"
+    } else if (grepl("^\\.sh\\$", pat)) {
+      if (rec) "*.sh (recursive)" else "*.sh (top-level)"
+    } else {
+      pat
+    }
+    paste0(cat, " (", pat_desc, ")")
+  }, character(1L))
+
+  cat_list <- paste(cat_desc, collapse = ", ")
+
+  prose <- paste0(
+    "Tracked files scanned from `.claude/` using per-category specs: ",
+    cat_list,
+    ". Paths under `archive/` and `worktrees/` subtrees are excluded. ",
+    n_files, " files total."
+  )
+
+  alt <- paste0(
+    "Config files from `.claude/` across ",
+    length(scan_specs), " categories (",
+    paste(names(scan_specs), collapse = ", "),
+    "). Skills match SKILL.md only; rules use recursive *.md; all other categories ",
+    "use top-level glob. archive/ and worktrees/ excluded."
+  )
+
+  list(prose = prose, alt = alt)
+}
+
 plan_scrolly_config <- function() {
   list(
+    # scrolly_scan_specs: canonical per-category scan configuration.
+    # Both vig_scrolly_config and scrolly_scope_text derive from this target
+    # so prose and data stay in sync when specs change.
+    tar_target(
+      scrolly_scan_specs,
+      list(
+        rules    = list(pattern = "\\.md$",      recurse = TRUE),
+        skills   = list(pattern = "SKILL\\.md$", recurse = TRUE),
+        agents   = list(pattern = "\\.md$",      recurse = FALSE),
+        hooks    = list(pattern = "\\.sh$",      recurse = FALSE),
+        memory   = list(pattern = "\\.md$",      recurse = FALSE),
+        commands = list(pattern = "\\.md$",      recurse = FALSE),
+        scripts  = list(pattern = "\\.sh$",      recurse = FALSE)
+      ),
+      packages = character(0)
+    ),
+    # scrolly_scope_text: human-readable scope description derived from
+    # scrolly_scan_specs. Referenced in vignette prose and fig-alt attributes
+    # via safe_tar_read("scrolly_scope_text") — satisfies dynamic-prose-values rule.
+    tar_target(
+      scrolly_scope_text,
+      .build_scrolly_scope(scrolly_scan_specs, nrow(vig_scrolly_config)),
+      packages = character(0)
+    ),
     tar_target(
       vig_scrolly_config,
       {
         claude_dir <- here::here(".claude")
 
-        # File patterns to scan per category
-        scan_specs <- list(
-          rules    = list(
-            path    = file.path(claude_dir, "rules"),
-            pattern = "\\.md$",
-            recurse = TRUE
-          ),
-          skills   = list(
-            path    = file.path(claude_dir, "skills"),
-            pattern = "SKILL\\.md$",
-            recurse = TRUE
-          ),
-          agents   = list(
-            path    = file.path(claude_dir, "agents"),
-            pattern = "\\.md$",
-            recurse = FALSE
-          ),
-          hooks    = list(
-            path    = file.path(claude_dir, "hooks"),
-            pattern = "\\.sh$",
-            recurse = FALSE
-          ),
-          memory   = list(
-            path    = file.path(claude_dir, "memory"),
-            pattern = "\\.md$",
-            recurse = FALSE
-          ),
-          commands = list(
-            path    = file.path(claude_dir, "commands"),
-            pattern = "\\.md$",
-            recurse = FALSE
-          ),
-          scripts  = list(
-            path    = file.path(claude_dir, "scripts"),
-            pattern = "\\.sh$",
-            recurse = FALSE
-          )
-        )
+        # Build full scan_specs (with path) from the canonical spec target
+        full_specs <- lapply(names(scrolly_scan_specs), function(cat) {
+          s <- scrolly_scan_specs[[cat]]
+          s$path <- file.path(claude_dir, cat)
+          s
+        })
+        names(full_specs) <- names(scrolly_scan_specs)
 
         # Collect files per category
-        rows <- lapply(names(scan_specs), function(cat) {
-          spec  <- scan_specs[[cat]]
+        rows <- lapply(names(full_specs), function(cat) {
+          spec  <- full_specs[[cat]]
           if (!dir.exists(spec$path)) return(tibble::tibble())
           files <- list.files(
             spec$path,
@@ -117,9 +153,7 @@ plan_scrolly_config <- function() {
         dplyr::mutate(
           all_files,
           path         = as.character(fs::path_rel(abs_path, repo_root)),
-          category     = factor(category,
-                                levels = c("rules", "skills", "agents", "hooks",
-                                           "memory", "commands", "scripts")),
+          category     = factor(category, levels = names(scrolly_scan_specs)),
           n_lines      = vapply(abs_path, count_lines, integer(1L)),
           n_bytes      = as.integer(file.info(abs_path)$size),
           git_age_days = vapply(abs_path, get_git_age, numeric(1L))

--- a/vignettes/articles/scrolly-config-evolution.qmd
+++ b/vignettes/articles/scrolly-config-evolution.qmd
@@ -37,8 +37,29 @@ safe_tar_read <- function(name) {
 cfg <- safe_tar_read("vig_scrolly_config")
 if (is.null(cfg)) {
   cfg <- tibble::tibble(
-    path = character(0), category = factor(character(0), levels = c("rules","skills","agents","hooks","memory","commands","scripts")),
+    path = character(0),
+    category = factor(character(0),
+      levels = c("rules", "skills", "agents", "hooks", "memory", "commands", "scripts")),
     n_lines = integer(0), n_bytes = integer(0), git_age_days = numeric(0)
+  )
+}
+
+scope <- safe_tar_read("scrolly_scope_text")
+if (is.null(scope)) {
+  scope <- list(
+    prose = paste0(
+      "Tracked files scanned from `.claude/` across seven categories: ",
+      "rules (*.md, recursive), skills (SKILL.md only), agents (*.md, top-level), ",
+      "hooks (*.sh, top-level), memory (*.md, top-level), commands (*.md, top-level), ",
+      "scripts (*.sh, top-level). ",
+      "archive/ and worktrees/ subtrees excluded."
+    ),
+    alt = paste0(
+      "Config files from `.claude/` across seven categories ",
+      "(rules, skills, agents, hooks, memory, commands, scripts). ",
+      "Skills match SKILL.md only; rules use recursive *.md; all others use top-level glob. ",
+      "archive/ and worktrees/ excluded."
+    )
   )
 }
 
@@ -68,7 +89,7 @@ base_theme <- theme_minimal(base_size = 13) +
 
 :::{#cr-scene1 .sticky}
 ```{r scene1-plot}
-#| fig-alt: "Each dot represents one tracked config file across seven .claude/ subdirectories (rules, skills, agents, hooks, memory, commands, scripts). All dots are shown in the same grey colour with no additional encoding, establishing the full dataset baseline before any categorical breakdown."
+#| fig-alt: !expr scope$alt
 ggplot(cfg, aes(x = n_bytes, y = n_lines)) +
   geom_point(colour = "#888888", alpha = 0.6, size = 2) +
   scale_x_continuous(labels = scales::label_number(suffix = " B")) +
@@ -239,12 +260,13 @@ Commands sit in the middle: a slash command needs enough prose to explain the wo
 
 ### What this vignette computes
 
-This vignette inspects a tracked subset of `.claude/` configuration files — seven subdirectories: rules, skills, agents, hooks, memory, commands, and scripts. Paths like `worktrees/`, `logs/`, and `data/` are intentionally excluded. The `r n_files`-row dataset is re-encoded across five progressive-disclosure scenes with stable colours per category.
+`r scope$prose` The `r n_files`-row dataset is re-encoded across five progressive-disclosure scenes with stable colours per category.
 
 ### Data sources
 
 - `vig_scrolly_config` target (built from `R/tar_plans/plan_scrolly_config.R`), pre-computed RDS at `inst/extdata/vignettes/vig_scrolly_config.rds`
-- Underlying file system: `.claude/rules/**`, `.claude/skills/**`, `.claude/agents/*`, `.claude/hooks/*`, `.claude/memory/*`, `.claude/commands/*`, `.claude/scripts/*`
+- `scrolly_scope_text` target (built from `R/tar_plans/plan_scrolly_config.R`), derives scope description from `scrolly_scan_specs` metadata
+- Underlying file system: `.claude/rules/**` (*.md recursive), `.claude/skills/**` (SKILL.md only), `.claude/agents/*` (*.md top-level), `.claude/hooks/*` (*.sh top-level), `.claude/memory/*` (*.md top-level), `.claude/commands/*` (*.md top-level), `.claude/scripts/*` (*.sh top-level); `archive/` and `worktrees/` subtrees excluded
 - `git_age_days` from `git log -1 --format=%ct -- <file>` per file
 
 ### AI disclosure


### PR DESCRIPTION
## Summary

Resolves the **highest-volume roborev cluster** — 67 open reviews all flagging the same single root-cause issue.

| Roborev | Severity | File | Fix |
|---|---|---|---|
| #3803 (+66 duplicate findings) | Medium×67 | `vignettes/articles/scrolly-config-evolution.qmd:71,242` | Derive scope prose from `scrolly_scan_specs` metadata per the `dynamic-prose-values` rule. |

## Root cause

The fig-alt and methodology claimed "tracked files across seven `.claude/` subdirectories" wholesale, but `plan_scrolly_config.R` does NOT do a recursive scan. Skills includes only `SKILL.md`; several categories are top-level only; extra exclusions are applied. Every commit touching the vignette re-fired the same review.

## Changes

- `R/tar_plans/plan_scrolly_config.R`: add `scrolly_scan_specs` metadata object encoding per-category scan mode (recursive vs top-level + glob pattern) and exclusions. Add `scrolly_scope_text` target that derives both prose and alt-text from `scrolly_scan_specs`.
- `vignettes/articles/scrolly-config-evolution.qmd`: replace hardcoded scope prose (line 242) and `fig-alt` (line 71) with dynamic \`safe_tar_read("scrolly_scope_text")\` values. Methodology now lists exact scan modes per category and notes \`archive/\` + \`worktrees/\` exclusions.

Drift is now structurally prevented: if \`scrolly_scan_specs\` changes, the rendered prose changes with it.

## Roborev resolution

- closes review #3803 (and collapses ~66 duplicate findings across the queue)

## Test plan

- [ ] \`tar_make()\` builds the new \`scrolly_scope_text\` target
- [ ] Render the vignette; grep rendered HTML to confirm fig-alt and methodology no longer contain the literal "seven .claude/ subdirectories" wholesale claim
- [ ] Spot-check: rendered prose matches \`scrolly_scan_specs\` reality (skills = SKILL.md only, rules = recursive, others = top-level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)