### PR TITLE
fix(branch-cherry-check): implement closing-PR detection + dynamic search paths

### DIFF
--- a/.claude/rules/branch-salvage-workflow.md
+++ b/.claude/rules/branch-salvage-workflow.md
@@ -1,5 +1,7 @@
 ---
+name: branch-salvage-workflow
 description: Three-step pre-salvage check before rebasing or cherry-picking stale branches; prevents dispatching subagents to no-op work
+type: rule
 ---
 
 # Rule: Branch Salvage Workflow

--- a/.claude/scripts/branch-cherry-check.sh
+++ b/.claude/scripts/branch-cherry-check.sh
@@ -61,6 +61,9 @@ if [ -z "$issue_num" ]; then
     issue_num=$(echo "$BRANCH" | grep -oE 'issue[-_]?([0-9]+)' | grep -oE '[0-9]+' | head -1 || true)
 fi
 
+STEP2_DISCARD=0
+STEP2_CLOSING_PR=""
+
 if [ -n "$issue_num" ]; then
     echo "Branch references issue #$issue_num"
     if command -v gh >/dev/null 2>&1; then
@@ -68,9 +71,66 @@ if [ -n "$issue_num" ]; then
         if [ -n "$repo_slug" ]; then
             state=$(gh issue view "$issue_num" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
             echo "Issue #$issue_num state: $state"
-            if [ "$state" = "CLOSED" ]; then
-                echo "WARNING: issue closed — branch's work may have shipped via different PR (squash-merge case)"
-                echo "Recommend: gh issue view $issue_num --repo $repo_slug --comments | tail -30"
+            if [ "$state" = "CLOSED" ] || [ "$state" = "MERGED" ]; then
+                echo "Issue closed — checking for merged PRs that close issue #$issue_num..."
+                # Look for merged PRs linked to this issue
+                closed_prs=$(gh pr list --repo "$repo_slug" \
+                    --search "is:merged closes:#$issue_num" \
+                    --json number,mergeCommit,headRefName \
+                    --limit 5 2>/dev/null || echo "")
+                if [ -z "$closed_prs" ] || [ "$closed_prs" = "[]" ]; then
+                    # Fallback: search by issue reference in PR body/title
+                    closed_prs=$(gh pr list --repo "$repo_slug" \
+                        --search "is:merged #$issue_num" \
+                        --json number,mergeCommit,headRefName \
+                        --limit 5 2>/dev/null || echo "")
+                fi
+                if [ -n "$closed_prs" ] && [ "$closed_prs" != "[]" ]; then
+                    echo "Found merged PR(s) linked to issue #$issue_num:"
+                    echo "$closed_prs" | python3 -c "
+import sys, json
+prs = json.load(sys.stdin)
+for pr in prs:
+    mc = pr.get('mergeCommit') or {}
+    oid = mc.get('oid', 'unknown')[:12]
+    print(f\"  PR #{pr['number']} ({pr['headRefName']}) merge-commit: {oid}\")
+" 2>/dev/null || echo "$closed_prs"
+                    # Get branch diff paths to check for overlap with merged PR
+                    branch_diff_files=$(git -C "$REPO" diff --no-ext-diff "main...$BRANCH" --name-only 2>/dev/null | grep -vE '\.(png|pdf|lock|duckdb|rds|RDS|Rds)$' | head -20)
+                    if [ -n "$branch_diff_files" ]; then
+                        # For each merged PR, check if it touches overlapping files
+                        pr_numbers=$(echo "$closed_prs" | python3 -c "
+import sys, json
+prs = json.load(sys.stdin)
+for pr in prs:
+    print(pr['number'])
+" 2>/dev/null || true)
+                        for pr_num in $pr_numbers; do
+                            pr_files=$(gh pr view "$pr_num" --repo "$repo_slug" --json files --jq '.files[].path' 2>/dev/null || echo "")
+                            if [ -n "$pr_files" ]; then
+                                # Check for file overlap
+                                overlap=0
+                                while IFS= read -r bfile; do
+                                    if echo "$pr_files" | grep -qxF "$bfile" 2>/dev/null; then
+                                        overlap=$((overlap + 1))
+                                    fi
+                                done <<< "$branch_diff_files"
+                                if [ "$overlap" -gt 0 ]; then
+                                    echo "  PR #$pr_num overlaps $overlap file(s) with candidate branch — likely squash-merged"
+                                    STEP2_DISCARD=1
+                                    STEP2_CLOSING_PR="$pr_num"
+                                    break
+                                fi
+                            fi
+                        done
+                    fi
+                    if [ "$STEP2_DISCARD" -eq 0 ]; then
+                        echo "  No file overlap detected; proceeding to Step 3 for confirmation"
+                    fi
+                else
+                    echo "No merged PRs found linked to issue #$issue_num"
+                    echo "WARNING: issue closed but no closing PR found — branch may still have unique work"
+                fi
             fi
         fi
     else
@@ -81,10 +141,26 @@ else
 fi
 echo
 
+if [ "$STEP2_DISCARD" -eq 1 ]; then
+    echo "VERDICT: DISCARD"
+    echo "Reason: issue #$issue_num is closed and PR #$STEP2_CLOSING_PR touches overlapping files — likely squash-merged."
+    exit 0
+fi
+
 # -------- Step 3: unique-strings check --------
 echo "--- Step 3: unique-strings check ---"
-# Take 5 distinctive added strings from the branch diff
-added_lines=$(git -C "$REPO" diff "main...$BRANCH" 2>/dev/null | grep -E '^\+[^+]' | grep -vE '^\+\s*$|^\+\s*(#|//|--|\*)' | head -20)
+# Derive search paths from the branch diff itself (only text files the branch touches)
+diff_paths=$(git -C "$REPO" diff --no-ext-diff "main...$BRANCH" --name-only 2>/dev/null \
+    | grep -vE '\.(png|jpg|jpeg|gif|svg|pdf|lock|duckdb|rds|RDS|Rds|parquet|zip|tar|gz|bin|so|dylib)$' \
+    | tr '\n' ' ')
+
+if [ -z "$diff_paths" ]; then
+    diff_paths="."
+fi
+
+# Take 5 distinctive added strings from the branch diff (limit to text paths)
+# shellcheck disable=SC2086
+added_lines=$(git -C "$REPO" diff --no-ext-diff "main...$BRANCH" -- $diff_paths 2>/dev/null | grep -E '^\+[^+]' | grep -vE '^\+\s*$|^\+\s*(#|//|--|\*)' | head -20)
 
 if [ -z "$added_lines" ]; then
     echo "(no added lines to sample — branch may delete only)"
@@ -108,8 +184,9 @@ found_in_main=0
 total_strings=0
 while IFS= read -r str; do
     total_strings=$((total_strings + 1))
-    # Search main checkout for this string
-    matches=$(git -C "$REPO" grep -c -F -- "$str" main -- 'R/' 'inst/' 'vignettes/' 'tests/' 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')
+    # Search main checkout for this string — only in paths the branch touches
+    # shellcheck disable=SC2086
+    matches=$(git -C "$REPO" grep -c -F -- "$str" main -- $diff_paths 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')
     if [ "$matches" -gt 0 ]; then
         found_in_main=$((found_in_main + 1))
         echo "  IN MAIN: \"$str\" ($matches matches)"


### PR DESCRIPTION
## Summary

Fixes roborev #3950. Two files changed: `.claude/scripts/branch-cherry-check.sh` and `.claude/rules/branch-salvage-workflow.md`.

- **Fix 1 (High):** Implement the Step 2 closing-PR check — was previously advisory-only (printed a manual recommendation). Now uses `gh pr list --search "is:merged closes:#N"` to find merged PRs linked to the referenced issue, then checks file overlap with the candidate branch. If ≥1 overlapping file is found, outputs `VERDICT: DISCARD (squash-merged via PR #N)`. Also handles GitHub's `MERGED` issue state (not just `CLOSED`).

- **Fix 2 (High):** Broaden Step 3 search paths — replaces hardcoded `R/ inst/ vignettes/ tests/` with dynamic `diff_paths` derived from the branch diff itself. Binary and lock files excluded. Adds `--no-ext-diff` to bypass custom diff drivers (e.g. wordcount driver for `.md` files in this repo).

- **Fix 3 (Medium):** Add `name` and `type` fields to `branch-salvage-workflow.md` YAML frontmatter to match the pattern used by `analysis-rationale-mandatory.md` and other rule files.

## Test plan

- [x] `bash -n .claude/scripts/branch-cherry-check.sh` — syntax check passes
- [x] Smoke test `origin/fix/enforcement-claims-vs-impl` (squash-merged branch, issue #196 MERGED): Step 2 finds PR #196 with file overlap → `VERDICT: DISCARD`
- [x] Smoke test `origin/feat/worktree-location-convention` (open issue #199, genuinely new): Step 3 finds unique strings → `VERDICT: SALVAGE CANDIDATE`
- [x] `head -10 .claude/rules/branch-salvage-workflow.md` shows valid YAML with name/description/type between `---` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)