### PR TITLE
fix(cc.sh): non-resetting worktree add + TTY guard + collision-safe path

### DIFF
--- a/.claude/scripts/cc.sh
+++ b/.claude/scripts/cc.sh
@@ -177,7 +177,14 @@ offer_worktree() {
   printf "Open a new worktree? [y / N / branch-name]: "
 
   local answer
-  read -r answer </dev/tty
+  if [ -t 0 ] && [ -r /dev/tty ]; then
+    if ! read -r answer </dev/tty 2>/dev/null; then
+      answer="n"
+    fi
+  else
+    # non-interactive — decline worktree, fall through to plain claude
+    answer="n"
+  fi
 
   case "$answer" in
     ""|n|N) return 0 ;;
@@ -191,6 +198,16 @@ offer_worktree() {
   wt_path="$(cd "${repo_root}/.." && pwd)/${repo_name}-${suffix}"
 
   if [ -d "$wt_path" ]; then
+    # Safety check: confirm the existing directory really is the intended branch,
+    # not a collision where a different branch mapped to the same path
+    # (e.g. feat/foo and feat-foo both → feat-foo under tr '/' '-').
+    local actual_branch
+    actual_branch=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [ "$actual_branch" != "$branch" ]; then
+      echo "ERROR: Directory $wt_path exists but is on branch '$actual_branch', not '$branch'."
+      echo "Refusing to reuse — possible branch-name collision. Use a different branch name."
+      return 0
+    fi
     echo "Worktree already exists: $wt_path"
     echo "Switched to worktree: $wt_path"
     cd "$wt_path"
@@ -201,11 +218,32 @@ offer_worktree() {
   echo "Creating worktree $wt_path on branch $branch ..."
   if git -C "$repo_root" worktree add -b "$branch" "$wt_path" 2>/dev/null; then
     echo "Switched to worktree: $wt_path"
-  elif git -C "$repo_root" worktree add -B "$branch" "$wt_path" 2>/dev/null; then
-    echo "Switched to worktree (reset existing branch): $wt_path"
+  elif git -C "$repo_root" worktree add "$wt_path" "$branch" 2>/dev/null; then
+    # Branch already exists — attach worktree without resetting its tip.
+    echo "Switched to worktree (existing branch): $wt_path"
   else
-    echo "Could not create worktree — continuing in main checkout."
-    return 0
+    # Branch exists AND may be checked out elsewhere, or user wants a forced reset.
+    local reset_answer="n"
+    printf "Branch '%s' already exists. Reset its tip to current HEAD? [y/N]: " "$branch"
+    if [ -t 0 ] && [ -r /dev/tty ]; then
+      if ! read -r reset_answer </dev/tty 2>/dev/null; then
+        reset_answer="n"
+      fi
+    fi
+    case "$reset_answer" in
+      y|Y)
+        if git -C "$repo_root" worktree add -B "$branch" "$wt_path"; then
+          echo "Switched to worktree (branch tip reset): $wt_path"
+        else
+          echo "Could not create worktree — continuing in main checkout."
+          return 0
+        fi
+        ;;
+      *)
+        echo "Could not create worktree — continuing in main checkout."
+        return 0
+        ;;
+    esac
   fi
 
   cd "$wt_path"


### PR DESCRIPTION
## Summary

Fixes three issues in `.claude/scripts/cc.sh` identified in roborev #3815:

- **Fix 1 (High)**: The fallback `git worktree add -B "$branch"` silently reset an existing branch tip to current HEAD, potentially orphaning previous work. Now: first attempts `worktree add "$wt_path" "$branch"` (no reset); only uses `-B` if the user explicitly confirms `[y/N]` prompt.

- **Fix 2 (Medium)**: `read -r answer </dev/tty` under `set -e` would abort the wrapper when launched without a controlling TTY (scripted, CI, or piped invocations). Now guarded with `[ -t 0 ] && [ -r /dev/tty ]`; non-interactive launches default `answer="n"` and fall through to plain `claude`.

- **Fix 3 (Medium)**: Worktree directory name built by `${branch//\//-}` causes path collisions (`feat/foo` and `feat-foo` both map to `feat-foo`). Added a hard branch-verification check before reusing any existing directory: if `git rev-parse --abbrev-ref HEAD` in the target dir doesn't match `$branch`, the script errors and returns rather than silently entering the wrong worktree.

## Test plan

- [ ] `bash -n .claude/scripts/cc.sh` — syntax check passes (verified)
- [ ] Manual: `cc.sh feat/test` from a main checkout creates worktree without resetting any existing branch
- [ ] Non-interactive: pipe stdin when calling cc.sh — confirm it starts plain claude without error
- [ ] Collision: pre-create a worktree for `feat-foo`, then call `cc.sh feat/foo` — confirm error message rather than silent entry into wrong worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)