### PR TITLE
fix(roborev_poll_merges): anchor idempotency to review tip, not range-start

### DIFF
--- a/.claude/scripts/roborev_poll_merges.sh
+++ b/.claude/scripts/roborev_poll_merges.sh
@@ -95,15 +95,21 @@ for line in "${REPOS[@]}"; do
     continue
   fi
 
-  # Idempotency anchor: range reviews store commit_id=range-start, so last_sha
-  # can lag forever behind real HEAD. Skip if HEAD already has any review_job
-  # regardless of what last_sha resolves to. Fixes JohnGavin/llm#198 Bug 2.
+  # Idempotency anchor: range reviews set commit_id=NULL (no commits row for the
+  # range tip), so the old JOIN on commits.sha always returned 0 for range jobs,
+  # making every poll enqueue a duplicate. Fix: also match against the END of
+  # git_ref (the reviewed tip SHA) for range jobs.
+  # Fixes JohnGavin/llm#198 Bug 2 / roborev #4013.
   head_review_count=$("$SQLITE" "$DB" "
       SELECT COUNT(*) FROM review_jobs rj
-      JOIN commits c ON c.id = rj.commit_id
+      LEFT JOIN commits c ON c.id = rj.commit_id
       WHERE rj.repo_id = $repo_id
-        AND c.sha = '$head_sha'
-        AND rj.status IN ('done','running','queued','failed');
+        AND rj.status IN ('done','running','queued','failed')
+        AND (
+          c.sha = '$head_sha'
+          OR rj.git_ref = '$head_sha'
+          OR rj.git_ref LIKE '%..$head_sha'
+        );
   ")
   if [ "$head_review_count" -gt 0 ]; then
     log "skip: $name — HEAD($head_sha) already has $head_review_count review(s)"


### PR DESCRIPTION
## Summary

- Range review jobs store `commit_id = NULL` (no `commits` row for the range tip), so the previous idempotency check joined `commits.sha` and always returned 0 rows for range jobs — every poll was enqueuing duplicate reviews of the same HEAD.
- Fix: change the `JOIN` to `LEFT JOIN` and add two `OR` branches that match the reviewed tip directly from `git_ref`: bare SHA match and `LIKE '%..<head>'` for range refs.
- Closes roborev #4013 / JohnGavin/llm#198 Bug 2.

## Test plan

- [ ] `bash -n .claude/scripts/roborev_poll_merges.sh` — syntax OK (verified)
- [ ] `roborev_poll_merges.sh --dry-run` runs cleanly with 55 repos, 0 behind (verified)
- [ ] Confirm no range reviews are re-enqueued after the fix is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)