### PR TITLE
fix(launchd): command -v ROBOREV resolution + real timeout semantics

### DIFF
--- a/.claude/scripts/roborev_agent_health.sh
+++ b/.claude/scripts/roborev_agent_health.sh
@@ -35,8 +35,12 @@ export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PAT
 set -euo pipefail
 
 # ── Config ───────────────────────────────────────────────────────────────────
-ROBOREV="${ROBOREV:-/usr/local/bin/roborev}"
-CODEX="${CODEX:-/usr/local/bin/codex}"
+if [ -z "${ROBOREV:-}" ]; then
+    ROBOREV="$(command -v roborev 2>/dev/null || echo /usr/local/bin/roborev)"
+fi
+if [ -z "${CODEX:-}" ]; then
+    CODEX="$(command -v codex 2>/dev/null || echo /usr/local/bin/codex)"
+fi
 SQLITE="${SQLITE:-/usr/bin/sqlite3}"
 ROBOREV_DB="${ROBOREV_DB:-$HOME/.roborev/reviews.db}"
 CONFIG_TOML="${CONFIG_TOML:-$HOME/.roborev/config.toml}"
@@ -95,16 +99,35 @@ _timeout() {
   elif command -v gtimeout >/dev/null 2>&1; then
     gtimeout "$secs" "$@"
   else
-    # Shell-only fallback: run in background, sleep, kill if still running.
+    # Shell-only fallback: run in background; watchdog sends SIGTERM then
+    # SIGKILL after a 2-second grace period and exits 124 (GNU coreutils
+    # convention) so the caller can detect that the timeout actually fired.
     "$@" &
     local pid=$!
-    (sleep "$secs" && kill -TERM "$pid" 2>/dev/null) &
+    (
+      sleep "$secs"
+      kill -TERM "$pid" 2>/dev/null
+      sleep 2
+      kill -KILL "$pid" 2>/dev/null
+      exit 124
+    ) &
     local watchdog=$!
-    wait "$pid" 2>/dev/null
-    local rc=$?
-    kill -TERM "$watchdog" 2>/dev/null
-    wait "$watchdog" 2>/dev/null
-    return "$rc"
+    if wait "$pid" 2>/dev/null; then
+      local rc=$?
+      # Child completed before timeout — reap the watchdog.
+      kill "$watchdog" 2>/dev/null
+      wait "$watchdog" 2>/dev/null
+      return "$rc"
+    else
+      # Child was killed — check whether the watchdog already exited (fired).
+      if ! kill -0 "$watchdog" 2>/dev/null; then
+        wait "$watchdog" 2>/dev/null
+        return 124
+      fi
+      kill "$watchdog" 2>/dev/null
+      wait "$watchdog" 2>/dev/null
+      return 1
+    fi
   fi
 }
 

--- a/.claude/scripts/roborev_autoclose.sh
+++ b/.claude/scripts/roborev_autoclose.sh
@@ -41,7 +41,9 @@ export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PAT
 
 set -euo pipefail
 
-ROBOREV="${ROBOREV:-/usr/local/bin/roborev}"
+if [ -z "${ROBOREV:-}" ]; then
+    ROBOREV="$(command -v roborev 2>/dev/null || echo /usr/local/bin/roborev)"
+fi
 THRESHOLD_DAYS="${THRESHOLD_DAYS:-30}"
 APPLY=0
 LOGFILE="$HOME/.claude/logs/roborev_autoclose.log"


### PR DESCRIPTION
## Summary

- `roborev_autoclose.sh`: replace hardcoded `/usr/local/bin/roborev` default with `command -v` resolution; Apple Silicon Homebrew installs roborev at `/opt/homebrew/bin/roborev`, causing the old default to silently fail. Keeps `/usr/local/bin/roborev` as ultimate fallback so the existing binary-existence check still handles missing installations gracefully. Fixes roborev #3305, #3307, #3276.
- `roborev_agent_health.sh`: same `command -v` fix applied to both `ROBOREV` and `CODEX` defaults. Also replaces the weak pure-shell `_timeout()` fallback (single SIGTERM, then blocks on `wait` returning child rc regardless of whether the watchdog fired) with an escalating SIGTERM→SIGKILL pattern that returns exit code 124 (GNU coreutils convention) when the timeout actually fires. Fixes roborev #3304, #3274.

## Test plan

- [ ] `bash -n .claude/scripts/roborev_autoclose.sh` — passes (verified)
- [ ] `bash -n .claude/scripts/roborev_agent_health.sh` — passes (verified)
- [ ] On Apple Silicon Mac: confirm `ROBOREV` resolves to `/opt/homebrew/bin/roborev` when no env override set
- [ ] On Nix-only setup: confirm script exits 0 with "skip" message when roborev not installed
- [ ] `_timeout 1 sleep 5; echo "rc=$?"` in a bash session without GNU coreutils should print `rc=124`

🤖 Generated with [Claude Code](https://claude.com/claude-code)