### PR TITLE
fix(roborev): cap age multiplier + warn on done-but-null-finished_at jobs

### DIFF
--- a/.claude/scripts/roborev_handoff.sh
+++ b/.claude/scripts/roborev_handoff.sh
@@ -125,6 +125,21 @@ for r in repos:
         for j in jobs:
             f.write(json.dumps(dict(j)) + "\n")
 
+    # Warn when done jobs lack finished_at — they are silently excluded above.
+    # A non-zero count indicates review_jobs schema integrity issues.
+    excluded = con.execute(
+        "SELECT COUNT(*) FROM review_jobs rj "
+        "WHERE rj.repo_id = ? AND rj.status = 'done' AND rj.finished_at IS NULL",
+        (r["id"],)
+    ).fetchone()[0]
+    if excluded > 0:
+        import sys as _sys
+        print(
+            f"WARN: {excluded} done-but-finished_at-null job(s) excluded from "
+            f"handoff for repo '{r['name']}' — investigate review_jobs schema integrity",
+            file=_sys.stderr,
+        )
+
 con.close()
 PYEOF
 

--- a/.claude/scripts/roborev_project_backlog.sh
+++ b/.claude/scripts/roborev_project_backlog.sh
@@ -243,14 +243,16 @@ def days_old(created_at_str):
 def priority_score(sev, categories, age_days):
     sw = SEVERITY_WEIGHT.get(sev, 1)
     cr = max(CATEGORY_RISK.get(c, 1.0) for c in categories)
-    # log10 keeps age growth sub-linear so severity stays dominant:
-    #   fresh Critical:    sev=10 * cr * (1 + log10(1))  = 10*cr
-    #   stale Low 30d:     sev=1  * cr * (1 + log10(31)) ≈ 2.49*cr
-    #   stale Low 1yr:     sev=1  * cr * (1 + log10(366)) ≈ 3.56*cr
-    # A fresh Critical (10*cr) always beats a stale Low (≤4*cr for any age).
-    # sqrt was reverted: sqrt(age) grows too fast and any item >30d old
-    # would score 6.48*cr, inverting triage order vs. fresh Critical issues.
-    age_factor = 1 + math.log10(age_days + 1)
+    # log10 keeps age growth sub-linear so severity stays dominant.
+    # Cap at 1.5 to prevent age from bridging severity tiers: a very old Low
+    # (sw=1) with cap=1.5 scores at most 1.5×cr, while a fresh Medium (sw=2)
+    # scores 2.0×cr — so Medium always beats Low regardless of age.
+    # Without the cap, after ~9-10 days a Low would exceed a fresh Medium
+    # (1 + log10(11) ≈ 2.04 > 2.0 / 1.0 ratio). Cap derivation:
+    #   cap × Low_base < Medium_base  →  cap × 1 < 2  →  cap < 2.0
+    #   1.5 chosen to allow meaningful age signal while preserving tier order.
+    #   stale Low 1yr (uncapped): sev=1 * cr * 3.56 — cap prevents this.
+    age_factor = min(1 + math.log10(age_days + 1), 1.5)
     return sw * cr * age_factor
 
 scored = []


### PR DESCRIPTION
## Summary

- **roborev_project_backlog.sh**: cap the `priority_score()` age multiplier at 1.5 to prevent age from bridging severity tiers (roborev #3321, #3343). Without the cap, a Low finding aged ~10 days scores `1 × cr × 2.04`, which exceeds a fresh Medium (`2 × cr × 1.0`) when `cr` is the same — inverting triage order. Cap derivation: `cap × Low_base < Medium_base` → `cap < 2.0`; 1.5 chosen for meaningful age signal while preserving tier dominance.
- **roborev_handoff.sh**: after the existing `rj.finished_at IS NOT NULL` guard, add a per-repo `COUNT` query that emits a `WARN` line to stderr when `done` jobs with `NULL` `finished_at` are present (roborev #3317, #3340). Silently excluding such rows with no alert masks potential schema integrity issues.

## Test plan

- [ ] `bash -n .claude/scripts/roborev_project_backlog.sh` — passes (no syntax errors)
- [ ] `bash -n .claude/scripts/roborev_handoff.sh` — passes (no syntax errors)
- [ ] `bash .claude/scripts/roborev_handoff.sh --help` — exits 0, prints usage
- [ ] Verify age multiplier cap: `python3 -c "import math; print(min(1+math.log10(11), 1.5))"` → `1.5` (capped); `min(1+math.log10(2), 1.5)` → `1.301` (uncapped, within range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)