### PR TITLE
fix(rule): add YAML frontmatter to cross-project-scope.md

### DIFF
--- a/.claude/rules/cross-project-scope.md
+++ b/.claude/rules/cross-project-scope.md
@@ -1,3 +1,9 @@
+---
+name: cross-project-scope
+description: Only llm sessions may work cross-project; all other sessions are own-tree-only and must file issues rather than directly editing other projects.
+type: rule
+---
+
 # Rule: Cross-Project Scope — Only llm Sessions May Work Cross-Project
 
 ## Source


### PR DESCRIPTION
## Summary

Single-file frontmatter fix for the cross-project-scope rule.

| Roborev | Severity | File | Fix |
|---|---|---|---|
| #3855 | Medium | \`.claude/rules/cross-project-scope.md:1\` | Add YAML frontmatter block with \`name\`, \`description\`, \`type\` fields per repo policy. |

## Roborev resolution

- closes review #3855

🤖 Generated with [Claude Code](https://claude.com/claude-code)