### PR TITLE
fix(docs): trim AGENTS.md + rule files to per-file size caps via companion docs

### DIFF
--- a/.claude/rules/_companions/auto-delegation-dispatch-details.md
+++ b/.claude/rules/_companions/auto-delegation-dispatch-details.md
@@ -1,0 +1,133 @@
+# Auto-Delegation — Dispatch Details
+
+Full verbatim prefixes, Tier 3 verification pattern, and right/wrong examples.
+Companion to `auto-delegation.md`.
+
+---
+
+## Mandatory Agent Dispatch Prefixes (BOTH required)
+
+Every Bash-capable agent dispatch with `isolation: "worktree"` MUST include
+BOTH of the following prefixes verbatim at the top of the prompt, BEFORE any
+task-specific instructions. The orchestrator owns the responsibility for
+injecting both. Agents that receive a prompt missing either prefix exhibit
+the failure modes documented in `JohnGavin/llm#182` (sandbox over-restrict)
+and `JohnGavin/llm#191` (silent drift to main checkout).
+
+**Prefix 1 — Bash discipline** (from `bash-safety.md`):
+
+```
+**CRITICAL — Bash discipline:** Compound bash commands (`&&`/`||`/`;`/`|`) are
+HOOK-REJECTED in block mode. Every Bash tool call must contain exactly ONE
+command. The ONLY exception is subshell `(cd dir && cmd)` for atomic cd+cmd.
+Use `git -C <path>` for git operations. For multi-step shell logic, write a
+script file and run it.
+```
+
+**Prefix 2 — Worktree isolation** (closes `JohnGavin/llm#191`):
+
+```
+**CRITICAL — Worktree isolation:** Your worktree is $WORKTREE_PATH (the
+orchestrator replaces this with the actual absolute path before dispatch).
+ALL writes (Edit, Write, Bash) MUST target paths under $WORKTREE_PATH.
+NEVER write to the orchestrator's main checkout. For read-only reference
+you may Read/Grep from main-checkout paths.
+
+Git operations MUST use `git -C $WORKTREE_PATH ...`. Your worktree's branch
+is set by the orchestrator — NEVER `git checkout main` or any other branch.
+If you need to switch branches, STOP and report back — let the orchestrator
+decide.
+
+When you finish, your report MUST include three self-check lines:
+  - pwd (must start with $WORKTREE_PATH)
+  - git -C $WORKTREE_PATH rev-parse --abbrev-ref HEAD (must NOT be `main`)
+  - Last commit SHA on YOUR worktree's branch
+
+If pwd doesn't start with $WORKTREE_PATH, STOP — something is wrong.
+```
+
+Orchestrator responsibilities when dispatching:
+
+1. Compute the worktree path the harness will create (typically `.claude/worktrees/agent-<id>/`) and inject it as the literal `$WORKTREE_PATH` value — OR instruct the agent to capture its own `pwd` at startup (more robust since the agent ID is generated at dispatch time)
+2. Stop referencing absolute paths to the main checkout for write-target file references — use `$WORKTREE_PATH`-relative paths or omit the prefix and use repo-relative paths
+3. **Tier 3 post-verify (MANDATORY):** Before dispatching, capture the main checkout's HEAD SHA. After the agent completes, verify HEAD hasn't moved. See "Tier 3 — Post-Agent Verification" below.
+
+---
+
+## Tier 3 — Post-Agent Verification
+
+Even with both prefixes in place, an agent may ignore them. The orchestrator's
+last line of defence is a HEAD-snapshot check around every `isolation: "worktree"`
+dispatch. This is Tier 3 of the multi-tier plan in `JohnGavin/llm#191`.
+
+**Pattern:**
+
+```bash
+# Before dispatch
+main_head_before=$(git -C <main-checkout> rev-parse HEAD)
+main_branch_before=$(git -C <main-checkout> rev-parse --abbrev-ref HEAD)
+
+# ... dispatch agent, wait for completion ...
+
+# After completion
+main_head_after=$(git -C <main-checkout> rev-parse HEAD)
+main_branch_after=$(git -C <main-checkout> rev-parse --abbrev-ref HEAD)
+
+if [ "$main_head_before" != "$main_head_after" ] || [ "$main_branch_before" != "$main_branch_after" ]; then
+    echo "ISOLATION VIOLATION: agent mutated main checkout"
+    # Auto-recovery (with user confirmation):
+    #   git -C <main-checkout> branch <agent-recovery-branch> $main_head_after
+    #   git -C <main-checkout> reset --hard $main_head_before
+    # Then re-merge from the recovery branch.
+fi
+```
+
+Helper script: `~/.claude/scripts/agent-post-verify.sh` wraps this pattern.
+Usage: capture state with `agent-post-verify.sh capture <repo-path>` before
+dispatch; check with `agent-post-verify.sh check <repo-path>` after.
+
+**When the check fires:**
+
+| Drift detected | Action |
+|---|---|
+| Main HEAD moved but branch is still `main` | Agent committed directly to main. Move the new commit to a feature branch, reset main, alert user. |
+| Main HEAD moved AND branch changed (e.g. from `main` to `fix/something`) | Agent switched + committed. Switch main back, leave the feature branch in place. |
+| Main HEAD unchanged but branch changed | Agent switched without committing. Switch main back. No data loss. |
+| No drift | Agent honoured isolation. Proceed normally. |
+
+**Logging:** every check writes to `~/.claude/logs/worktree_post_verify.log`
+with timestamp, agent ID, before/after SHA, and verdict. Review this log
+periodically to gauge whether Tier 1+3 alone is sufficient or whether Tier 2
+(hook enforcement) is needed.
+
+---
+
+## Right vs Wrong
+
+```
+# WRONG: fixer runs in main checkout — live tokens exposed, may overwrite .Renviron
+Agent(subagent_type="fixer",
+      prompt="Fix R/foo.R line 42 — add NA check before division.")
+
+# WRONG: isolation set but neither prefix injected — agent may drift to main checkout (llm#191)
+Agent(subagent_type="fixer",
+      isolation="worktree",
+      prompt="Fix R/foo.R line 42 — add NA check before division.")
+
+# RIGHT: isolation set + BOTH prefixes injected
+Agent(subagent_type="fixer",
+      isolation="worktree",
+      prompt="""**CRITICAL — Bash discipline:** Compound bash commands
+(`&&`/`||`/`;`/`|`) are HOOK-REJECTED in block mode. Every Bash tool call
+must contain exactly ONE command. The ONLY exception is subshell `(cd dir && cmd)`
+for atomic cd+cmd. Use `git -C <path>` for git operations. For multi-step
+shell logic, write a script file and run it.
+
+**CRITICAL — Worktree isolation:** Your worktree is /Users/johngavin/docs_gh/<repo>/.claude/worktrees/agent-<id>.
+ALL writes MUST target paths under that worktree. NEVER write to the main checkout
+at /Users/johngavin/docs_gh/<repo>. Git operations MUST use git -C <worktree-path>.
+NEVER git checkout to a different branch. End-of-run report MUST include pwd,
+git rev-parse --abbrev-ref HEAD, and last commit SHA — all from the worktree.
+
+Fix R/foo.R line 42 — add NA check before division.""")
+```

--- a/.claude/rules/_companions/bash-safety-dispatch-template.md
+++ b/.claude/rules/_companions/bash-safety-dispatch-template.md
@@ -1,0 +1,22 @@
+# Bash Safety — Agent Dispatch Template
+
+## Verbatim prefix for every Agent dispatch that involves Bash
+
+Copy this text **exactly** to the top of every agent prompt, before any task-specific instructions. Orchestrators are responsible for injecting this prefix. An agent that receives a prompt without it will default to compound commands and have its calls rejected.
+
+```
+**CRITICAL — Bash discipline:** Compound bash commands (`&&`/`||`/`;`/`|`) are
+HOOK-REJECTED in block mode. Every Bash tool call must contain exactly ONE
+command. The ONLY exception is subshell `(cd dir && cmd)` for atomic cd+cmd.
+Use `git -C <path>` for git operations. For multi-step shell logic, write a
+script file and run it.
+```
+
+## Why this is mandatory
+
+`COMPOUND_GUARD_MODE=block` is active in `settings.json`. The pre-tool hook exits non-zero before the command reaches the shell. There is no fallback — the prompt prefix is the only way to inform the agent of this constraint before its first Bash call.
+
+## Related
+
+- `bash-safety.md` — the parent rule
+- `auto-delegation.md` — orchestrator responsibilities; Prefix 1 is this template

--- a/.claude/rules/auto-delegation.md
+++ b/.claude/rules/auto-delegation.md
@@ -62,16 +62,7 @@ Agent(
 )
 ```
 
-This implements recursive summarisation: a cheap model compresses the expensive model's accumulated context before it grows quadratically. Opus retains ownership of CURRENT_WORK.md; haiku is a delegate writer, not an autonomous updater.
-
-**Trigger conditions (ANY ONE):**
-- `CLAUDE_CONTEXT_USAGE_PERCENT` ≥ 65
-- About to start a `/loop` or multi-turn automation
-- About to spawn 3+ sequential subagents
-
-**Do NOT use haiku for summarisation when:**
-- Context < 40% (premature compression adds latency)
-- The session involves active debugging with many intermediate states needed
+Triggers: context ≥ 65%, starting a `/loop`, or spawning 3+ sequential subagents. Do NOT trigger when context < 40% or during active debugging. Opus retains ownership of CURRENT_WORK.md; haiku is a delegate writer, not an autonomous updater.
 
 ## CRITICAL: Do Not Use Opus for Sonnet-Level Work
 
@@ -137,126 +128,9 @@ called with `isolation: "worktree"`. This includes:
 
 ### Mandatory Agent Dispatch Prefixes (BOTH required)
 
-Every Bash-capable agent dispatch with `isolation: "worktree"` MUST include
-BOTH of the following prefixes verbatim at the top of the prompt, BEFORE any
-task-specific instructions. The orchestrator owns the responsibility for
-injecting both. Agents that receive a prompt missing either prefix exhibit
-the failure modes documented in `JohnGavin/llm#182` (sandbox over-restrict)
-and `JohnGavin/llm#191` (silent drift to main checkout).
+Every Bash-capable agent dispatch with `isolation: "worktree"` MUST include BOTH prefixes verbatim at the top of the prompt, before any task-specific instructions. Missing either prefix causes the failure modes in `JohnGavin/llm#182` and `JohnGavin/llm#191`.
 
-**Prefix 1 — Bash discipline** (from `bash-safety.md`):
-
-```
-**CRITICAL — Bash discipline:** Compound bash commands (`&&`/`||`/`;`/`|`) are
-HOOK-REJECTED in block mode. Every Bash tool call must contain exactly ONE
-command. The ONLY exception is subshell `(cd dir && cmd)` for atomic cd+cmd.
-Use `git -C <path>` for git operations. For multi-step shell logic, write a
-script file and run it.
-```
-
-**Prefix 2 — Worktree isolation** (closes `JohnGavin/llm#191`):
-
-```
-**CRITICAL — Worktree isolation:** Your worktree is $WORKTREE_PATH (the
-orchestrator replaces this with the actual absolute path before dispatch).
-ALL writes (Edit, Write, Bash) MUST target paths under $WORKTREE_PATH.
-NEVER write to the orchestrator's main checkout. For read-only reference
-you may Read/Grep from main-checkout paths.
-
-Git operations MUST use `git -C $WORKTREE_PATH ...`. Your worktree's branch
-is set by the orchestrator — NEVER `git checkout main` or any other branch.
-If you need to switch branches, STOP and report back — let the orchestrator
-decide.
-
-When you finish, your report MUST include three self-check lines:
-  - pwd (must start with $WORKTREE_PATH)
-  - git -C $WORKTREE_PATH rev-parse --abbrev-ref HEAD (must NOT be `main`)
-  - Last commit SHA on YOUR worktree's branch
-
-If pwd doesn't start with $WORKTREE_PATH, STOP — something is wrong.
-```
-
-Orchestrator responsibilities when dispatching:
-
-1. Compute the worktree path the harness will create (typically `.claude/worktrees/agent-<id>/`) and inject it as the literal `$WORKTREE_PATH` value — OR instruct the agent to capture its own `pwd` at startup (more robust since the agent ID is generated at dispatch time)
-2. Stop referencing absolute paths to the main checkout for write-target file references — use `$WORKTREE_PATH`-relative paths or omit the prefix and use repo-relative paths
-3. **Tier 3 post-verify (MANDATORY):** Before dispatching, capture the main checkout's HEAD SHA. After the agent completes, verify HEAD hasn't moved. See "Tier 3 — Post-Agent Verification" below.
-
-### Tier 3 — Post-Agent Verification
-
-Even with both prefixes in place, an agent may ignore them. The orchestrator's
-last line of defence is a HEAD-snapshot check around every `isolation: "worktree"`
-dispatch. This is Tier 3 of the multi-tier plan in `JohnGavin/llm#191`.
-
-**Pattern:**
-
-```bash
-# Before dispatch
-main_head_before=$(git -C <main-checkout> rev-parse HEAD)
-main_branch_before=$(git -C <main-checkout> rev-parse --abbrev-ref HEAD)
-
-# ... dispatch agent, wait for completion ...
-
-# After completion
-main_head_after=$(git -C <main-checkout> rev-parse HEAD)
-main_branch_after=$(git -C <main-checkout> rev-parse --abbrev-ref HEAD)
-
-if [ "$main_head_before" != "$main_head_after" ] || [ "$main_branch_before" != "$main_branch_after" ]; then
-    echo "ISOLATION VIOLATION: agent mutated main checkout"
-    # Auto-recovery (with user confirmation):
-    #   git -C <main-checkout> branch <agent-recovery-branch> $main_head_after
-    #   git -C <main-checkout> reset --hard $main_head_before
-    # Then re-merge from the recovery branch.
-fi
-```
-
-Helper script: `~/.claude/scripts/agent-post-verify.sh` wraps this pattern.
-Usage: capture state with `agent-post-verify.sh capture <repo-path>` before
-dispatch; check with `agent-post-verify.sh check <repo-path>` after.
-
-**When the check fires:**
-
-| Drift detected | Action |
-|---|---|
-| Main HEAD moved but branch is still `main` | Agent committed directly to main. Move the new commit to a feature branch, reset main, alert user. |
-| Main HEAD moved AND branch changed (e.g. from `main` to `fix/something`) | Agent switched + committed. Switch main back, leave the feature branch in place. |
-| Main HEAD unchanged but branch changed | Agent switched without committing. Switch main back. No data loss. |
-| No drift | Agent honoured isolation. Proceed normally. |
-
-**Logging:** every check writes to `~/.claude/logs/worktree_post_verify.log`
-with timestamp, agent ID, before/after SHA, and verdict. Review this log
-periodically to gauge whether Tier 1+3 alone is sufficient or whether Tier 2
-(hook enforcement) is needed.
-
-### Right vs Wrong
-
-```
-# WRONG: fixer runs in main checkout — live tokens exposed, may overwrite .Renviron
-Agent(subagent_type="fixer",
-      prompt="Fix R/foo.R line 42 — add NA check before division.")
-
-# WRONG: isolation set but neither prefix injected — agent may drift to main checkout (llm#191)
-Agent(subagent_type="fixer",
-      isolation="worktree",
-      prompt="Fix R/foo.R line 42 — add NA check before division.")
-
-# RIGHT: isolation set + BOTH prefixes injected
-Agent(subagent_type="fixer",
-      isolation="worktree",
-      prompt="""**CRITICAL — Bash discipline:** Compound bash commands
-(`&&`/`||`/`;`/`|`) are HOOK-REJECTED in block mode. Every Bash tool call
-must contain exactly ONE command. The ONLY exception is subshell `(cd dir && cmd)`
-for atomic cd+cmd. Use `git -C <path>` for git operations. For multi-step
-shell logic, write a script file and run it.
-
-**CRITICAL — Worktree isolation:** Your worktree is /Users/johngavin/docs_gh/<repo>/.claude/worktrees/agent-<id>.
-ALL writes MUST target paths under that worktree. NEVER write to the main checkout
-at /Users/johngavin/docs_gh/<repo>. Git operations MUST use git -C <worktree-path>.
-NEVER git checkout to a different branch. End-of-run report MUST include pwd,
-git rev-parse --abbrev-ref HEAD, and last commit SHA — all from the worktree.
-
-Fix R/foo.R line 42 — add NA check before division.""")
-```
+See [_companions/auto-delegation-dispatch-details.md](_companions/auto-delegation-dispatch-details.md) for the full verbatim text of both prefixes, orchestrator responsibilities, Tier 3 post-verification pattern, and right/wrong examples.
 
 ## Parallel Worktree Sessions
 

--- a/.claude/rules/bash-safety.md
+++ b/.claude/rules/bash-safety.md
@@ -23,21 +23,7 @@ Every Bash tool call, without exception.
 
 ### Agent Dispatch Template
 
-Every Agent dispatch that involves Bash MUST include the following prefix
-**verbatim** at the top of the agent prompt. Orchestrators are responsible for
-pasting this prefix before any other instructions:
-
-```
-**CRITICAL — Bash discipline:** Compound bash commands (`&&`/`||`/`;`/`|`) are
-HOOK-REJECTED in block mode. Every Bash tool call must contain exactly ONE
-command. The ONLY exception is subshell `(cd dir && cmd)` for atomic cd+cmd.
-Use `git -C <path>` for git operations. For multi-step shell logic, write a
-script file and run it.
-```
-
-This is not optional. An agent that receives a prompt without this prefix will
-default to compound commands and have its calls rejected. The orchestrator owns
-the responsibility for injecting this prefix.
+Every Agent dispatch involving Bash MUST include the verbatim Bash discipline prefix at the top of the prompt. See [_companions/bash-safety-dispatch-template.md](_companions/bash-safety-dispatch-template.md) for the full text and rationale.
 
 ### CRITICAL: Never Use `&&` in Bash Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,13 +170,7 @@ For detailed guidance, invoke the relevant skill. For tool preferences, see `mem
 
 **Loop intervals:** `30s`, `5m`, `1h`, `2d` (or trailing: `every 30 minutes`). Minimum `/schedule` interval: 1 hour.
 
-**Common loop patterns:**
-- `/loop 30m /check` — Continuous R CMD check (catch issues early)
-- `/loop 1h /ctx-check` — Verify ctx.yaml coverage
-- `/loop 5m /roborev` — Auto code review on push
-- `/schedule '0 9 * * 1-5' /pr-status` — Weekday 9 AM PR checks
-
-**Loop management:** List running loops via `/schedule list`. Stop: `/schedule stop <job-id>`.
+**Common loop patterns:** `/loop 30m /check` (continuous R CMD check), `/loop 5m /roborev` (auto code review), `/schedule '0 9 * * 1-5' /pr-status` (weekday AM PR checks). List: `/schedule list`. Stop: `/schedule stop <job-id>`.
 
 **Hooks integration:** R auto-format and dark-contrast checks run via pre-commit scripts; see `~/.claude/scripts/r_code_check.sh` and `~/.claude/scripts/check_dark_contrast.sh`.
 


### PR DESCRIPTION
## Summary

- `AGENTS.md` (203→197 lines): compress multi-line loop-patterns bullets into a single inline summary, saving 6 lines
- `.claude/rules/bash-safety.md` (164→150 lines): extract verbatim Agent Dispatch Template block to `_companions/bash-safety-dispatch-template.md`; replace with a one-line reference
- `.claude/rules/auto-delegation.md` (272→146 lines): extract verbatim dispatch prefixes, Tier 3 verification pattern, and right/wrong examples to `_companions/auto-delegation-dispatch-details.md`; also compress haiku-summarisation trigger conditions to one line

All load-bearing content is preserved in companion docs under `.claude/rules/_companions/`. Main rule files contain the decision logic and reference companions for copy-paste templates.

Closes roborev #4041, #4038, #3851, #3841, #3832, #3810

## Test plan

- [x] `wc -l AGENTS.md` → 197 (≤200)
- [x] `wc -l .claude/rules/bash-safety.md` → 150 (≤150)
- [x] `wc -l .claude/rules/auto-delegation.md` → 146 (≤150)
- [x] Companion files exist at referenced paths
- [x] Reference links in main rules use correct relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)