### PR TITLE
fix(default.sh): bound peer-build wait, don't hang forever

### DIFF
--- a/default.sh
+++ b/default.sh
@@ -165,17 +165,58 @@ cachix use rstats-on-nix
 
 # Lock only the nix-build step to prevent concurrent builds
 # (multiple tabs can run default.sh to enter the shell, but only one builds)
+#
+# Configurable bounds (so a hung peer build cannot hang us forever):
+#   NIX_BUILD_WAIT_MAX  seconds to wait for peer build (default 1800 = 30 min;
+#                       set 0 to skip waiting and fail immediately)
+#   NIX_BUILD_NO_WAIT=1 shorthand for NIX_BUILD_WAIT_MAX=0
+#   NIX_BUILD_FORCE=1   ignore existing lock entirely (assume stale)
+NIX_BUILD_WAIT_MAX="${NIX_BUILD_WAIT_MAX:-1800}"
+if [ "${NIX_BUILD_NO_WAIT:-0}" = "1" ]; then NIX_BUILD_WAIT_MAX=0; fi
+
 if [ -f "$LOCK_FILE" ]; then
     LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null)
-    if kill -0 "$LOCK_PID" 2>/dev/null; then
-        echo "Another nix-build is running (PID $LOCK_PID). Waiting for it to finish..."
-        while kill -0 "$LOCK_PID" 2>/dev/null; do sleep 2; done
-        echo "Build finished. Continuing..."
+    if [ "${NIX_BUILD_FORCE:-0}" = "1" ]; then
+        echo "NIX_BUILD_FORCE=1 set; ignoring lock file (was PID '$LOCK_PID')."
+        rm -f "$LOCK_FILE"
+    elif [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
+        if [ "$NIX_BUILD_WAIT_MAX" -le 0 ] 2>/dev/null; then
+            echo "ERROR: Another nix-build is running (PID $LOCK_PID) and NIX_BUILD_WAIT_MAX=0."
+            echo "  Lock: $LOCK_FILE"
+            echo "  To wait:        NIX_BUILD_WAIT_MAX=1800 $0"
+            echo "  To force-take:  NIX_BUILD_FORCE=1 $0   (only if PID $LOCK_PID is stuck)"
+            exit 1
+        fi
+        SLEEP_INTERVAL=10
+        elapsed=0
+        echo "Another nix-build is running (PID $LOCK_PID). Waiting up to ${NIX_BUILD_WAIT_MAX}s..."
+        echo "  To override: NIX_BUILD_FORCE=1 $0  (or remove $LOCK_FILE)"
+        while kill -0 "$LOCK_PID" 2>/dev/null; do
+            if [ "$elapsed" -ge "$NIX_BUILD_WAIT_MAX" ]; then
+                echo ""
+                echo "ERROR: Timed out after ${NIX_BUILD_WAIT_MAX}s waiting for PID $LOCK_PID."
+                echo "  Peer build may be hung. Options:"
+                echo "    1. Inspect:  ps -p $LOCK_PID -o pid,etime,command"
+                echo "    2. Kill:     kill $LOCK_PID; rm $LOCK_FILE"
+                echo "    3. Force:    NIX_BUILD_FORCE=1 $0"
+                echo "    4. Wait 2x:  NIX_BUILD_WAIT_MAX=$((NIX_BUILD_WAIT_MAX*2)) $0"
+                exit 1
+            fi
+            sleep "$SLEEP_INTERVAL"
+            elapsed=$((elapsed + SLEEP_INTERVAL))
+            if [ $((elapsed % 60)) -eq 0 ]; then
+                echo "  ...still waiting (${elapsed}s/${NIX_BUILD_WAIT_MAX}s, PID $LOCK_PID alive)"
+            fi
+        done
+        echo "Peer build finished after ${elapsed}s. Continuing..."
     else
+        echo "Stale lock file (PID '$LOCK_PID' not running). Removing $LOCK_FILE."
         rm -f "$LOCK_FILE"
     fi
 fi
 echo $$ > "$LOCK_FILE"
+# Clear our lock on any exit path (not just successful completion below)
+trap '[ -f "$LOCK_FILE" ] && [ "$(cat "$LOCK_FILE" 2>/dev/null)" = "$$" ] && rm -f "$LOCK_FILE"' EXIT
 
 echo "Starting nix-build '$NIX_FILE' ..."
 if ! time nix-build "$NIX_FILE" \


### PR DESCRIPTION
## Problem

When another `nix-build` is already running, `default.sh` waits for it via:

```bash
while kill -0 "$LOCK_PID" 2>/dev/null; do sleep 2; done
```

There's no timeout. If the peer build is hung, every subsequent invocation hangs forever with it — exactly what the user hit:

> if another nix-build is running, this waiting script hangs forever. fix it.

## Fix (`default.sh:166-224`)

| Behaviour | Before | After |
|---|---|---|
| Wait for peer build | Infinite | Bounded by `NIX_BUILD_WAIT_MAX` (default 1800s) |
| Progress visibility | None | Status line every 60s with elapsed/total |
| Override | None | `NIX_BUILD_FORCE=1` to ignore lock; `NIX_BUILD_NO_WAIT=1` / `NIX_BUILD_WAIT_MAX=0` to fail fast |
| On timeout | Hangs forever | Exit 1 with 4 actionable options (inspect / kill / force / wait 2×) |
| Stale-lock cleanup | Removed only on success path | `trap … EXIT` clears our own lock on any exit |
| Empty `$LOCK_PID` guard | `kill -0 ""` (spuriously succeeds on some shells) | Explicit `[ -n "$LOCK_PID" ]` |

## Escape hatches

```bash
NIX_BUILD_FORCE=1     ~/docs_gh/llm/default.sh   # ignore lock, take over
NIX_BUILD_NO_WAIT=1   ~/docs_gh/llm/default.sh   # don't wait at all
NIX_BUILD_WAIT_MAX=60 ~/docs_gh/llm/default.sh   # custom timeout (seconds)
```

## Verification

- `bash -n default.sh` → SYNTAX OK
- All existing behaviour preserved when the lock holder is running and finishes within the timeout
- Skill-size hook check passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)