### PR TITLE
fix(scripts): branch-cherry-check.sh grep pattern works under ugrep

### DIFF
--- a/.claude/scripts/branch-cherry-check.sh
+++ b/.claude/scripts/branch-cherry-check.sh
@@ -39,8 +39,8 @@ echo
 # -------- Step 1: patch-id check --------
 echo "--- Step 1: patch-id check (git cherry main $BRANCH) ---"
 cherry_out=$(git -C "$REPO" cherry main "$BRANCH" 2>&1)
-new_count=$(echo "$cherry_out" | grep -c '^+' || true)
-old_count=$(echo "$cherry_out" | grep -c '^-' || true)
+new_count=$(echo "$cherry_out" | grep -cE '^\+' || true)
+old_count=$(echo "$cherry_out" | grep -cE '^-' || true)
 
 echo "$cherry_out"
 echo "Result: $new_count genuinely-new patches, $old_count already-applied patches"


### PR DESCRIPTION
## Problem

`~/.claude/scripts/branch-cherry-check.sh` line 42-43 used `grep -c '^+'` / `grep -c '^-'`. Under ugrep, `'^+'` is **invalid syntax** because `+` is a regex repetition operator without a preceding atom. Step 1 of the 3-step salvage workflow silently degraded on ugrep systems — surfaced in #212 during the historical#238 audit.

## Fix

```diff
- new_count=$(echo "$cherry_out" | grep -c '^+' || true)
- old_count=$(echo "$cherry_out" | grep -c '^-' || true)
+ new_count=$(echo "$cherry_out" | grep -cE '^\+' || true)
+ old_count=$(echo "$cherry_out" | grep -cE '^-' || true)
```

`-E '^\+'` keeps the line-start anchor and treats `+` as a literal. The companion `'^-'` line is updated to `-E '^-'` for consistency; technically `-` is fine in BRE outside a character class, but matching ERE on both lines is cleaner and slightly more portable.

## Audit

The full grep audit of the script:

| Line | Pattern | Status |
|---|---|---|
| 42 | `grep -c '^+'` | **Fixed** → `grep -cE '^\+'` |
| 43 | `grep -c '^-'` | **Fixed** → `grep -cE '^-'` (consistency) |
| 57, 61 | `grep -oE …` | Already safe (ERE) |
| 99, 154 | `grep -vE …` | Already safe (ERE) |
| 114 | `grep -qxF …` | Already safe (fixed string) |
| 163 | `grep -E '^\+[^+]'` / `grep -vE '^\+\s*'` | Already safe (ERE, escaped) |
| 189 | `git grep -c -F` | Already safe (fixed string) |

No further changes needed.

## Verification

- `bash -n` exits 0
- Script runs end-to-end against an existing branch (verified locally — output identical to pre-fix behaviour on BSD grep)

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
