### PR TITLE
chore(roborev): populate llm's own exclude_patterns (#211)

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -119,7 +119,10 @@ refine_min_severity = 'medium'
 # Minimum severity for reviews in this repo: critical, high, medium, low.
 review_min_severity = 'medium'
 # Filenames or glob patterns to exclude from review diffs for this repo.
-exclude_patterns = []
+exclude_patterns = [
+  "CHANGELOG.md",
+  ".claude/CURRENT_WORK.md",
+]
 # Automatic post-commit review mode for this repo: commit or branch.
 post_commit_review = ''
 reuse_review_session_lookback = 0


### PR DESCRIPTION
This PR closes #211 by populating the `exclude_patterns` field in the llm repo's own `.roborev.toml`. The field was left as an empty array when the file was initially committed, creating an inconsistency with [the rule the repo enforces for other projects](https://github.com/JohnGavin/llm/issues/198) and the reference implementation in historical commit `4906b6d`. The two entries added — `CHANGELOG.md` and `.claude/CURRENT_WORK.md` — are high-churn housekeeping files that should never trigger a review cycle.

**Before:**
```toml
exclude_patterns = []
```

**After:**
```toml
exclude_patterns = [
  "CHANGELOG.md",
  ".claude/CURRENT_WORK.md",
]
```

Closes #211
