### PR TITLE
fix(roborev): enable Critical severity, drop Info (#160)

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -14,6 +14,11 @@ review_context_count = 3
 # security, Quarto, test, and dependency failure modes per commit.
 review_guidelines = """R package (llm) — global config management project.
 
+SEVERITY OVERRIDE: The base prompt format says High/Medium/Low but this project
+uses Critical/High/Medium/Low. Use Critical when genuinely warranted — do not
+collapse critical issues into High. Valid severity values: Critical, High, Medium,
+Low. Info severity is not used in this project — upgrade to Low or omit entirely.
+
 CONTEXT:
 - Diffs are structural (difftastic/tree-sitter) — pure formatting changes
   are invisible. Focus on semantic changes only.
@@ -90,11 +95,18 @@ DEPENDENCIES & ENVIRONMENT:
 - `install.packages()` / `pak::pkg_install()` / `devtools::install()`
   anywhere — BANNED in nix.
 
-CRITICAL SEVERITY EXAMPLES (flag at critical, not medium):
-- Any committed credential.
-- Look-ahead bias in a feature used by a model.
-- Reverting an `na-propagation-rolling-stats` fix without explanation.
-- Adding `value_box()` after that rule was established.
+CRITICAL SEVERITY EXAMPLES (flag at Critical, not High — use Critical for these):
+- Any committed credential: api key, password, token, private key, `sk-...`, `ghp_...`.
+- Broken authentication or auth bypass (missing auth check, anyone can call admin endpoint).
+- SQL injection via raw string interpolation (f-string or paste0 in SQL query).
+- Production data loss: destructive ops (`rm -rf`, DROP TABLE, DELETE) on non-tmp
+  paths without confirmation code / recovery trail.
+- Look-ahead bias in any feature used by a production or backtest model.
+- Reverting an `na-propagation-rolling-stats` fix without explicit explanation.
+- Adding `value_box()`, pie chart, or stacked bar AFTER the visualization-standards
+  rule was established (regression of a named anti-pattern).
+- `install.packages()` / `pak::pkg_install()` / `devtools::install()` in any file
+  that runs inside the Nix shell (will brick the reproducible environment).
 """
 # Override the review job timeout in minutes for this repo.
 job_timeout_minutes = 0


### PR DESCRIPTION
## Summary

- **Root cause found:** The roborev binary's built-in review prompt says `**Severity**: High/Medium/Low` — the model follows this format spec literally and will not emit "Critical" unless explicitly overridden.
- **Fix:** Added `SEVERITY OVERRIDE` instruction at the top of `review_guidelines` in `.roborev.toml`, plus strengthened `CRITICAL SEVERITY EXAMPLES` with four new concrete cases.
- **Info decision:** Formally dropped — guidelines now instruct the model to upgrade Info to Low or omit.

## Investigation outcome

**Where the global prompt lives:** Embedded in the `/usr/local/bin/roborev` compiled binary. The `~/.roborev/config.toml` contains only settings fields (no prompt text). The prompt is stored verbatim in `reviews.prompt` in the SQLite DB for every review job.

**Is it editable?** No — it's a static Mach-O binary. The format spec `High/Medium/Low` cannot be changed without a roborev release.

**What actually happens in the DB:** `SELECT COUNT(*) FROM reviews WHERE output LIKE '%Severity%Critical%'` returns 74 — Critical does appear rarely when the review_guidelines are persuasive enough. The "0%" in the issue description was based on TUI queue display, not raw DB counts.

**Strategy that works:** The `review_guidelines` block is appended to the base prompt. An explicit `SEVERITY OVERRIDE:` instruction near the top overrides the format spec's three-value list.

## What changed in `.roborev.toml`

1. **Added SEVERITY OVERRIDE block** (top of `review_guidelines`, before CONTEXT):
   - States Critical/High/Medium/Low are valid; model must not collapse Critical → High
   - Formally drops Info tier: upgrade to Low or omit
2. **Strengthened CRITICAL SEVERITY EXAMPLES** (was 4 items, now 8):
   - Added: credential exposure (api key, password, token)
   - Added: broken auth / auth bypass
   - Added: SQL injection via raw string interpolation
   - Added: production data loss without confirmation/recovery trail
   - Added: `install.packages()` in Nix project (bricks reproducible environment)
   - Kept: look-ahead bias, na-propagation-rolling-stats regression, value_box regression

## No upstream action needed

This is a per-repo preference expressed via `review_guidelines`. If a future roborev release exposes a `severity_tiers` config option, we can simplify. No upstream issue filed.

## Test plan

- [ ] Next ~20 reviews: verify Critical appears for genuine credential/auth/data-loss findings
- [ ] Verify Info no longer appears in any new review output
- [ ] High/Medium/Low continue to work normally

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
