### PR TITLE
feat(agents): mandatory verification block (#223)

### DIFF
--- a/.claude/agents/fixer.md
+++ b/.claude/agents/fixer.md
@@ -72,3 +72,15 @@ authority: "Can edit files. CANNOT approve its own work (requires critic or revi
 - NEVER add features, refactor, or "improve" code beyond the fix
 - NEVER skip running tests after fixes
 - If a fix requires architectural changes, flag it as "needs user decision"
+
+## Mandatory Verification Block (Required Final Step)
+
+Before reporting completion, you MUST run these checks as your FINAL tool calls and quote their literal output in your end-of-run report. Reports that omit this block, or that report success without these checks passing, are treated as incomplete by the orchestrator.
+
+1. `git -C <worktree> rev-parse --abbrev-ref HEAD` — must NOT be `main`
+2. `git -C <worktree> log origin/main..HEAD --oneline` — must show ≥1 commit
+3. `git -C <worktree> rev-list --count @{u}..HEAD` — must be `0` (all commits pushed)
+4. If a roborev review was supposed to be closed: `sqlite3 ~/.roborev/reviews.db "SELECT id, closed FROM reviews WHERE id IN (<ids>)"` — every cited row must show `closed=1`
+5. If a PR was supposed to be opened: `gh pr view <PR#> --repo <repo> --json state,headRefOid` — state=OPEN, oid matches local HEAD
+
+If any check fails, do NOT claim success. Report what is missing, what state the worktree is actually in, and stop.

--- a/.claude/agents/r-debugger.md
+++ b/.claude/agents/r-debugger.md
@@ -151,3 +151,15 @@ docker run --rm -v "$(pwd):/pkg" -w /pkg --network=none \
 ```
 
 This eliminates macOS-specific behaviour: different `grep`/`sed` flags, system lib versions, locale settings, font availability.
+
+## Mandatory Verification Block (Required Final Step)
+
+Before reporting completion, you MUST run these checks as your FINAL tool calls and quote their literal output in your end-of-run report. Reports that omit this block, or that report success without these checks passing, are treated as incomplete by the orchestrator.
+
+1. `git -C <worktree> rev-parse --abbrev-ref HEAD` — must NOT be `main`
+2. If commits were made: `git -C <worktree> log origin/main..HEAD --oneline` — must show ≥1 commit
+3. If commits were made: `git -C <worktree> rev-list --count @{u}..HEAD` — must be `0` (all commits pushed)
+4. If a roborev review was supposed to be closed: `sqlite3 ~/.roborev/reviews.db "SELECT id, closed FROM reviews WHERE id IN (<ids>)"` — every cited row must show `closed=1`
+5. If a PR was supposed to be opened: `gh pr view <PR#> --repo <repo> --json state,headRefOid` — state=OPEN, oid matches local HEAD
+
+If any check fails, do NOT claim success. Report what is missing, what state the worktree is actually in, and stop. Purely diagnostic runs (no commits made) must still pass check 1 and confirm they produced no side-effects.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -210,3 +210,14 @@ devtools::check(args = "--as-cran")
 - [ ] R CMD check: [0 errors, X warnings, Y notes]
 - [ ] Documentation complete: [Yes/No]
 ```
+
+## Mandatory Verification Block (Required Final Step)
+
+Before reporting completion, you MUST list all artifacts produced and run the relevant checks as your FINAL tool calls, quoting their literal output in your end-of-run report. This agent is typically read-only (no commits), so the checks are a subset — but they are still mandatory.
+
+1. List every artifact you produced: review file path(s), inline comment URL(s), closed roborev review ID(s).
+2. For each roborev review you closed: `sqlite3 ~/.roborev/reviews.db "SELECT id, closed FROM reviews WHERE id=<id>"` — must return `closed=1`.
+3. If you posted any GitHub review comments: confirm the PR comment URL is reachable (e.g. `gh api <comment_url>` returns HTTP 200).
+4. Confirm you made NO file edits, NO commits, and NO pushes (reviewer is read-only).
+
+If any check fails, do NOT claim success. Report what is missing and stop.

--- a/.claude/rules/auto-delegation.md
+++ b/.claude/rules/auto-delegation.md
@@ -126,6 +126,8 @@ called with `isolation: "worktree"`. This includes:
 | `quick-fix` (haiku) | No | Optional |
 | `critic` (read-only) | No | Optional |
 
+> **Haiku-tier (`quick-fix`) tool limitation:** the quick-fix agent has Read, Grep, Glob, Edit — but NO Bash. It cannot `git commit`, `git push`, `gh pr create`, or `roborev close`. Dispatching quick-fix for tasks that require any of these is a dispatch error — use fixer (sonnet) instead. Documented to prevent the recurrence pattern from #223.
+
 ### Mandatory Agent Dispatch Prefixes (BOTH required)
 
 Every Bash-capable agent dispatch with `isolation: "worktree"` MUST include BOTH prefixes verbatim at the top of the prompt, before any task-specific instructions. Missing either prefix causes the failure modes in `JohnGavin/llm#182` and `JohnGavin/llm#191`.


### PR DESCRIPTION
## Summary

- **Problem:** In a 2026-05-21 parallel session, 4 of 5 follow-up agents claimed they had pushed commits and/or closed roborev reviews — but had not actually executed the calls. The orchestrator had to finish each task inline.
- **Fix:** Appended a `## Mandatory Verification Block` section to `fixer.md`, `r-debugger.md`, and `reviewer.md` requiring literal-output proof before any completion claim is accepted.
- **Side-fix:** Added a haiku tool-gap note to `auto-delegation.md` so the orchestrator stops dispatching tasks requiring `git push` / `gh pr create` / `roborev close` to the quick-fix (haiku) agent, which has no Bash tool.

## The 5-Check Verification Block (fixer / r-debugger)

Every fixer and r-debugger end-of-run report MUST include output from:

```
1. git -C <worktree> rev-parse --abbrev-ref HEAD       → NOT main
2. git -C <worktree> log origin/main..HEAD --oneline   → ≥1 commit shown
3. git -C <worktree> rev-list --count @{u}..HEAD       → 0  (all commits pushed)
4. sqlite3 ~/.roborev/reviews.db "SELECT id, closed FROM reviews WHERE id IN (<ids>)"
                                                        → closed=1 for every cited id
5. gh pr view <PR#> --repo <repo> --json state,headRefOid
                                                        → state=OPEN, oid matches HEAD
```

Checks 4 and 5 apply only when a roborev close / PR open was claimed. Check 1 is always mandatory.

## What a Correct Fixer Report Looks Like

```markdown
## Fixer Report — Round 2
**Date:** 2026-05-21

### Fixes Applied
| # | Severity | File:Line | Fix Description |
|---|----------|-----------|-----------------|
| 1 | Critical | R/foo.R:42 | Added NA check before division |

### Verification
- `devtools::test()`: PASS

### Mandatory Verification Block
1. `git rev-parse --abbrev-ref HEAD` → `feat/fix-foo-na`
2. `git log origin/main..HEAD --oneline` → `40a2316 fix(foo): add NA check (#42)`
3. `git rev-list --count @{u}..HEAD` → `0`
4. (no roborev close in this run)
5. `gh pr view 44 --json state,headRefOid` → `{"state":"OPEN","headRefOid":"40a2316..."}`

**Fixed:** 1/1 issues
```

## Haiku Tool-Gap Note (auto-delegation.md)

Added below the agent table:

> **Haiku-tier (`quick-fix`) tool limitation:** the quick-fix agent has Read, Grep, Glob, Edit — but NO Bash. It cannot `git commit`, `git push`, `gh pr create`, or `roborev close`. Dispatching quick-fix for tasks that require any of these is a dispatch error — use fixer (sonnet) instead. Documented to prevent the recurrence pattern from #223.

## Test plan

- [ ] Read `fixer.md` — verify `## Mandatory Verification Block` section present at end
- [ ] Read `r-debugger.md` — verify same section present, with "if commits were made" conditional wording
- [ ] Read `reviewer.md` — verify read-only–appropriate subset (artifact list + roborev check + no-edit confirmation)
- [ ] Read `auto-delegation.md` — verify haiku note appears after the agent table row for `quick-fix`

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
