### PR TITLE
fix(scripts): Bash 3.2 / BSD-grep portability sweep (#181 Theme 2)

### DIFF
--- a/.claude/scripts/entity_propagate.sh
+++ b/.claude/scripts/entity_propagate.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # entity_propagate.sh — minimal entity propagation (#137 Phase 3)
 #
+# Portability fixes (#181 Theme 2 — roborev id 848):
+#   - BSD grep /usr/bin/grep on macOS does NOT support \b word-boundary
+#     assertions in ERE mode (-E). All word-boundary matches now use
+#     POSIX character-class anchors: (^|[^[:alnum:]_])PATTERN([^[:alnum:]_]|$)
+#
 # Scans the current session's JSONL transcript for mentions of curated
 # project names and appends one-line entries to
 # knowledge/mentions/<project>.md per occurrence.

--- a/.claude/scripts/qa_vignette_tabs.sh
+++ b/.claude/scripts/qa_vignette_tabs.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # qa_vignette_tabs.sh — QA check for vignette tab content
 #
+# Portability fixes (#181 Theme 2 — roborev ids 1724, 1731, 1745):
+#   - mapfile replaced with portable while-read loop (Bash 3.2 compat;
+#     macOS ships Bash 3.2 which lacks the mapfile builtin).
+#
 # Usage:
 #   qa_vignette_tabs.sh [docs_dir]
 #

--- a/.claude/scripts/roborev_agent_health.sh
+++ b/.claude/scripts/roborev_agent_health.sh
@@ -5,6 +5,10 @@
 # Portability: this script is invoked by launchd, which provides only a bare
 # PATH (/usr/bin:/bin:/usr/sbin:/sbin). Prepend coreutils paths so that
 # `timeout` (from GNU coreutils) is visible under both Homebrew and Nix.
+# Portability fixes (#181 Theme 2 — roborev id 900):
+#   - macOS /usr/bin/timeout does not exist. The _timeout() helper detects
+#     timeout/gtimeout via `command -v` and falls back to a portable
+#     background-kill pattern (SIGTERM then SIGKILL, exits 124 on timeout).
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 #
 # Logic:

--- a/.claude/scripts/roborev_autoclose.sh
+++ b/.claude/scripts/roborev_autoclose.sh
@@ -4,6 +4,9 @@
 # Portability: this script is invoked by launchd, which provides only a bare
 # PATH (/usr/bin:/bin:/usr/sbin:/sbin). Prepend coreutils paths so that
 # python3, sqlite3, and other tools are visible on both Homebrew and Nix Macs.
+# Portability fixes (#181 Theme 2 — roborev ids 844):
+#   - mapfile replaced with portable while-read loop (Bash 3.2 compat;
+#     macOS ships Bash 3.2 which lacks the mapfile builtin).
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 #
 # Two phases:

--- a/.claude/scripts/roborev_poll_merges.sh
+++ b/.claude/scripts/roborev_poll_merges.sh
@@ -4,6 +4,10 @@
 # Portability: this script is invoked by launchd, which provides only a bare
 # PATH (/usr/bin:/bin:/usr/sbin:/sbin). Prepend coreutils paths so that git,
 # sqlite3, and roborev are visible on both Homebrew and Nix Macs.
+# Portability fixes (#181 Theme 2 — roborev id 1509):
+#   - Shebang changed from /opt/homebrew/bin/bash (Apple Silicon only) to
+#     #!/usr/bin/env bash so the script runs on Intel Macs and non-Homebrew
+#     setups. PATH export ensures launchd's bare env finds coreutils binaries.
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 # hook missed (remote-merged PRs don't fire local post-commit).
 #


### PR DESCRIPTION
## Summary

Closes roborev findings **844, 848, 900, 1509, 1724, 1731, 1745** from #181 Theme 2 (Bash 3.2 / BSD-grep portability bugs).

All five fixes were already applied to `main` via earlier commits during the #167 and #171 portability sweeps. This PR adds explicit roborev-closure comments to each file's header, creating a permanent audit trail that ties review IDs to the specific fix patterns that resolved them.

## Per-bug before / after

| Roborev id | File | Bug | Fix (commit) |
|---:|---|---|---|
| 844 | `roborev_autoclose.sh:55` | `mapfile` not in Bash 3.2 — weekly job fails at startup | `while IFS= read -r` loop (`4f4c35e`) |
| 1724, 1731, 1745 | `qa_vignette_tabs.sh:44` | `mapfile` — QA check exits immediately, validates nothing | `while IFS= read -r` loop (`4f4c35e`) |
| 848 | `entity_propagate.sh:66` | BSD grep `-E` silently drops `\b` word-boundary — all project mentions missed | POSIX char-class anchors `(^|[^[:alnum:]_])PAT([^[:alnum:]_]|$)` (`2bf7296`) |
| 1509 | `roborev_poll_merges.sh:1` | Shebang pinned to `/opt/homebrew/bin/bash` — absent on Intel Macs / non-Homebrew | `#!/usr/bin/env bash` + explicit `PATH=` (`d8c9698`) |
| 900 | `roborev_agent_health.sh:84-88` | `timeout` called directly; macOS has no `/usr/bin/timeout`; launchd PATH misses coreutils | `_timeout()` helper: `command -v timeout \|\| gtimeout` + portable SIGTERM→SIGKILL fallback (`d02a737`, `e08ea2e`) |

## Verification

All five files pass `bash -n` (exit 0):

```
bash -n .claude/scripts/roborev_autoclose.sh    # exit 0
bash -n .claude/scripts/qa_vignette_tabs.sh     # exit 0
bash -n .claude/scripts/entity_propagate.sh     # exit 0
bash -n .claude/scripts/roborev_poll_merges.sh  # exit 0
bash -n .claude/scripts/roborev_agent_health.sh # exit 0
```

## Scope note

This PR touches only the 5 files identified in #181 Theme 2. Other portability issues in other files (Themes 3–7) are deferred — the umbrella issue #181 remains open.

## Test plan

- [ ] `bash -n` on each edited file — all exit 0 (done in CI / pre-merge)
- [ ] Confirm roborev IDs 844, 848, 900, 1509, 1724, 1731, 1745 appear in file headers as closure evidence
- [ ] Verify #181 remains open (only Theme 2 row is resolved by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
