### PR TITLE
fix(rules): resolve rule self-contradictions (#181 Theme 3)

### DIFF
--- a/.claude/rules/auto-delegation.md
+++ b/.claude/rules/auto-delegation.md
@@ -10,6 +10,8 @@ Every orchestrator decision about whether to do work directly or delegate.
 
 **Default rule:** opus delegates all code, script, and configuration edits to subagents. This includes everything under `R/`, `inst/`, `tests/`, `vignettes/`, `.github/`, `default.R`, `default.nix`, shell scripts in `.claude/scripts/` and `.claude/hooks/`, and any new file in the package source tree.
 
+> **Clarification:** "delegate code/script edits" does NOT mean opus never uses Edit/Write. Opus DOES use Edit/Write directly for the bounded exceptions listed below (prose files, memory, rules, CHANGELOG, CURRENT_WORK.md). The constraint is on code-level edits to the package source tree, not on all file writes.
+
 | Work type | Delegate to |
 |-----------|-------------|
 | Single-file edits, doc updates, version bumps | `quick-fix` (haiku) |
@@ -26,7 +28,7 @@ Opus retains write access for these — they are too small/dialog-driven to be w
 | `~/.claude/CLAUDE.md`, `.claude/CLAUDE.md` | Prose updates only (rule wording, table edits) |
 | `.claude/rules/*.md`, `.claude/memory/*.md` | Prose edits to existing rules and memory files; new rule creation OK |
 | `CHANGELOG.md` (session-end append) | Session-end changelog entries only |
-| `.claude/CURRENT_WORK.md` | Opus writes session state directly; OR delegates to haiku for context-compression summarisation (see "Haiku for Context Summarisation" below) — haiku writes the file, opus decides when |
+| `.claude/CURRENT_WORK.md` | Opus **owns** this file and writes session state directly. Exception: when context ≥ 65%, opus **decides** to delegate the physical write to haiku (see "Haiku for Context Summarisation" below) — haiku writes under opus's direction; haiku NEVER autonomously updates this file |
 | Roborev DB closure comments via `/usr/local/bin/roborev comment`/`close` | Triage actions, not code |
 | Read-only investigation: `Read`, `Grep`, `Glob`, `Bash` for queries (`git log`, `gh pr view`, `du`, SQL reads) | Pre-decomposition reconnaissance |
 
@@ -87,8 +89,8 @@ If the task matches a named agent's trigger, MUST delegate:
 - Multi-file architecture decisions
 - Plan creation requiring user dialogue
 - Synthesising results from multiple agents
-- Prose edits to memory, rules, CLAUDE.md, CHANGELOG (scope above)
-- CURRENT_WORK.md updates (opus writes directly, or delegates the write to haiku when context compression is needed — opus always decides when and what to compress)
+- Prose edits to `.claude/rules/*.md`, `.claude/memory/*.md`, `CLAUDE.md`, `CHANGELOG.md` (bounded exceptions in the table above)
+- `CURRENT_WORK.md` **ownership** — opus always decides what to write and when to compress; opus writes directly OR delegates the physical write to haiku (haiku executes, opus directs — see "Haiku for Context Summarisation" above)
 - Ambiguous requirements needing clarification
 - Roborev triage closures (`comment` + `close` on individual reviews)
 

--- a/.claude/rules/nix-agent-shell-protocol.md
+++ b/.claude/rules/nix-agent-shell-protocol.md
@@ -81,8 +81,9 @@ default.R  →  default.nix  →  nix-shell (via default.sh)
    package must be added to `DESCRIPTION` (Imports/Suggests) AND `default.R`
 3. **Regenerate `default.nix` using a cwd-safe form** — this runs
    `rix::rix()` inside a shell that has `rix` installed (the llm dev
-   shell at `~/docs_gh/llm/`). The bare form `Rscript /path/to/default.R`
-   is **WRONG** because it inherits the caller's cwd; `rix::rix()` writes
+   shell at `~/docs_gh/llm/`). The bare form
+   `nix-shell ... --run "Rscript /path/to/project/default.R"` is **WRONG**
+   because the script inherits the caller's cwd; `rix::rix()` writes
    `default.nix` relative to cwd and silently overwrites the wrong
    checkout. Always use Form A or Form B (see "Worktree-Isolated rix
    Regenerations" below for the full explanation):
@@ -162,16 +163,19 @@ In the mycare project, regenerating default.nix to add testthat/here/withr strip
 
 **Defensive workflow when regenerating default.nix:**
 
-Every step below that runs `Rscript default.R` MUST use one of the
-cwd-safe forms documented in the section above (subshell Form A or
-explicit `setwd()` Form B). There is no safe exception: even when the
-caller appears to be in the right directory, worktree-orchestrator cwd
-drift can silently overwrite the wrong checkout. Always use Form A or B.
+Every regeneration call MUST use cwd-safe Form A (subshell) or Form B
+(`setwd()`), as documented above. There is no safe exception: even when
+the caller appears to be in the right directory, worktree-orchestrator cwd
+drift can silently overwrite the wrong checkout.
+
+- **Form A** (subshell): `(cd /absolute/path/to/project && nix-shell ~/docs_gh/llm/default.nix --run "Rscript default.R")`
+- **Form B** (setwd): `nix-shell ~/docs_gh/llm/default.nix --run "Rscript -e 'setwd(\"/absolute/path/to/project\"); source(\"default.R\")'")`
+- **NEVER** use a bare absolute path: `nix-shell ... --run "Rscript /absolute/path/to/project/default.R"` — this is the pattern that caused the 2026-05-02 and 2026-05-08 incidents.
 
 Preferred — use a `default.post.sh` per project (idempotent shell script
 that re-applies the project's overlays):
 
-1. Regenerate (Form A, from agent or orchestrator):
+1. Regenerate using Form A:
    `(cd /absolute/path/to/project && nix-shell ~/docs_gh/llm/default.nix --run "Rscript default.R")`
 2. `(cd /absolute/path/to/project && ./default.post.sh)` —
    re-apply overlays. Script must be idempotent and detect
@@ -181,7 +185,8 @@ that re-applies the project's overlays):
 Fallback — when no `default.post.sh` exists yet:
 
 1. `cp /absolute/path/to/project/default.nix /absolute/path/to/project/default.nix.pre-regen.bak`
-2. `(cd /absolute/path/to/project && nix-shell ~/docs_gh/llm/default.nix --run "Rscript default.R")`
+2. Regenerate using Form A:
+   `(cd /absolute/path/to/project && nix-shell ~/docs_gh/llm/default.nix --run "Rscript default.R")`
 3. `diff /absolute/path/to/project/default.nix.pre-regen.bak /absolute/path/to/project/default.nix` — eyeball stripped sections
 4. Re-apply overlays manually
 5. Verify


### PR DESCRIPTION
## Summary

Resolves three rule self-contradictions identified in roborev reviews 677, 683, and 819 (Theme 3 of issue #181).

### Review 677 — `nix-agent-shell-protocol.md` step 3 (lines 82–90)

**Before:** Step 3 described the WRONG pattern as `Rscript /path/to/default.R` (an abstract reference), while the commented WRONG line in the code block shows `Rscript /path/to/project/default.R`. Subtly different descriptions for the same forbidden pattern created ambiguity about what exactly was wrong.

**After:** Step 3 now names the forbidden pattern as `nix-shell ... --run "Rscript /path/to/project/default.R"` — identical wording to the WRONG code comment, so the prose and the code block are consistent.

---

### Review 683 — `nix-agent-shell-protocol.md` "Defensive workflow" (lines 155–166)

**Before:** The section opened with "Every step below that runs `Rscript default.R` MUST use one of the cwd-safe forms" — naming `Rscript default.R` in isolation could be read as endorsing the bare call. The Preferred and Fallback step lists then showed Form A wrapping the call, but did not label them as "Form A."

**After:**
- Opening paragraph replaced with explicit bullet list naming Form A, Form B, and NEVER patterns, referencing the two incident dates.
- Preferred workflow step 1 now reads "Regenerate using Form A:" followed by the subshell command.
- Fallback workflow step 2 likewise reads "Regenerate using Form A:" — no bare `Rscript default.R` reference appears without the wrapping subshell.

---

### Review 819 — `auto-delegation.md` opus/haiku CURRENT_WORK.md contradiction (lines 11–24, 46–52, 85–90)

**Before:** The rule said opus delegates "all code/script/config edits" (implying never uses Edit/Write), but the Bounded Exceptions table listed `CURRENT_WORK.md` with haiku writing it. The "Keep in Opus" section said "CURRENT_WORK.md updates (opus writes directly, or delegates to haiku)" — which was accurate but not clearly reconciled with the delegation language at the top. A reader could conclude opus both "never writes" and "writes CURRENT_WORK.md."

**After (three changes):**
1. Added a clarifying blockquote immediately after the "Default rule" sentence: "delegates code/script edits does NOT mean opus never uses Edit/Write — Opus DOES use Edit/Write for the bounded exceptions."
2. Tightened the `CURRENT_WORK.md` row in the Bounded Exceptions table: "Opus OWNS this file … haiku writes under opus's direction; haiku NEVER autonomously updates this file."
3. Rewrote the "Keep in Opus" bullet: distinguishes file ownership (always opus) from the physical write act (opus directly, or haiku as delegate when opus decides to compress context).

---

## Test plan

- [ ] Read `nix-agent-shell-protocol.md` from top to bottom — every `Rscript` invocation is either inside a subshell (Form A) or uses `setwd()` (Form B); no bare absolute-path calls appear without the WRONG comment
- [ ] Check that the Preferred and Fallback workflow steps all say "using Form A" or show the subshell wrapper
- [ ] Read `auto-delegation.md` — confirm the clarifying blockquote appears before the Bounded Exceptions table
- [ ] Confirm the `CURRENT_WORK.md` row in the table says "owns" and "never autonomously"
- [ ] Confirm "Keep in Opus" bullet says "ownership" and "physical write" as separate concepts
- [ ] No other rules modified — scope limited to the two named files

Refs #181 (Theme 3 umbrella stays open)
Closes roborev 677, 683, 819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
