### PR TITLE
fix(roborev): script bug fixes (#181 Theme 5)

### DIFF
--- a/.claude/scripts/roborev_agent_health.sh
+++ b/.claude/scripts/roborev_agent_health.sh
@@ -2,6 +2,12 @@
 # roborev_agent_health.sh — detect sustained codex failures and temporarily
 # swap to gemini in ~/.roborev/config.toml; probe for recovery and swap back.
 #
+# Closes roborev #900 (#181 Theme 5) — timestamp format mismatch fixed.
+# The WHERE clause normalises ISO-8601 (YYYY-MM-DDTHH:MM:SS...Z) to SQLite's
+# internal format (YYYY-MM-DD HH:MM:SS) via replace() before passing to
+# datetime(), ensuring the "last 60 min" failure count is not inflated.
+# Fix landed in commit a93b670.
+#
 # Portability: this script is invoked by launchd, which provides only a bare
 # PATH (/usr/bin:/bin:/usr/sbin:/sbin). Prepend coreutils paths so that
 # `timeout` (from GNU coreutils) is visible under both Homebrew and Nix.

--- a/.claude/scripts/roborev_handoff.sh
+++ b/.claude/scripts/roborev_handoff.sh
@@ -2,6 +2,11 @@
 # roborev_handoff.sh — hand off stale cross-repo roborev findings to their
 # owning projects via GitHub issues or CURRENT_WORK.md inbox entries.
 #
+# Closes roborev #899 (#181 Theme 5) — staleness filter uses finished_at (not
+# enqueued_at), so fresh reviews on long-queued jobs are not auto-closed.
+# Fix landed in commit f2b851f (primary) and a05eb7f (warn on null finished_at).
+# Jobs where finished_at IS NULL are excluded and produce a stderr WARN.
+#
 # Handles three populations (threshold = THRESHOLD_DAYS, default 7d):
 #   Phase 1a  verdict=fail       → per-commit GH issue (label roborev-handoff)
 #   Phase 1b  verdict=pass+notes → append to weekly digest issue (label roborev-digest)

--- a/.claude/scripts/roborev_project_backlog.sh
+++ b/.claude/scripts/roborev_project_backlog.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # roborev_project_backlog.sh — Phase 1 of roborev closure-loop automation (#163)
 #
+# Closes roborev #1747 and #2109 (#181 Theme 5) — priority formula uses log10
+# (not sqrt), keeping age growth sub-linear so severity stays dominant.
+# The sqrt variant caused age to dominate severity, inverting triage order.
+# Fix landed in commit 24de32e.
+#
 # Usage: roborev_project_backlog.sh <project-name>
 #
 # Reads ~/.roborev/reviews.db (read-only), categorizes open rejected findings,


### PR DESCRIPTION
## Summary

- **Roborev #899** (`roborev_handoff.sh`): staleness filter already uses `finished_at` (not `enqueued_at`) — fresh reviews on long-queued jobs are not auto-closed. Jobs where `finished_at IS NULL` emit a stderr WARN rather than being silently skipped. Fix confirmed in commits `f2b851f` and `a05eb7f`.
- **Roborev #900** (`roborev_agent_health.sh`): ISO-8601 timestamp (`YYYY-MM-DDTHH:MM:SS...Z`) is normalised to SQLite's `YYYY-MM-DD HH:MM:SS` format via `replace()` before `datetime()`, preventing inflated "last 60 min" failure counts. Fix confirmed in commit `a93b670`.
- **Roborev #1747 / #2109** (`roborev_project_backlog.sh`): priority formula uses `log10` (not `sqrt`), keeping age growth sub-linear so severity stays dominant and triage order is correct. Fix confirmed in commit `24de32e`.

All three bugs were pre-fixed in prior commits. This PR adds explicit closure comments at the top of each file referencing the roborev IDs and fix commit SHAs, completing the audit trail for #181 Theme 5.

## Test plan

- [x] `bash -n` passes on all three scripts
- [x] Grep confirms `finished_at` in handoff staleness query (lines 118-120)
- [x] Grep confirms `replace(replace(enqueued_at, 'T', ' '), 'Z', ''))` normalisation in agent_health (line 86)
- [x] Grep confirms `math.log10` in priority_score (line 255)
- [x] Closure comments added to all three scripts with commit SHA references

🤖 Generated with [Claude Code](https://claude.com/claude-code)
