### PR TITLE
docs(accuracy): cross-modal + PHASE1 + PATTERN_DETECTION reconciliation (#181 Theme 7)

### DIFF
--- a/COMPLETION_SUMMARY.md
+++ b/COMPLETION_SUMMARY.md
@@ -1,5 +1,12 @@
 # Cross-Modal Evaluation Implementation - COMPLETE
 
+<!-- Roborev closure: #779 resolved in commit 60389d4 (PR #164).
+     Original finding: "Ready for Merge" claim invalid because deliverables lived
+     outside the repo (~/.claude/ paths) and test_cross_modal_eval.sh exited 0 on
+     assertion failure. Fix: in-repo paths (.claude/scripts/, .claude/.env.example)
+     throughout; FAIL_COUNT + exit 1 semantics verified in test suite.
+     All Roborev findings addressed section added at bottom. -->
+
 ## Issue #137, Phase 1.2 - Successfully Implemented
 
 ### Branch: `feat/cross-modal-eval`

--- a/PATTERN_DETECTION_SETUP.md
+++ b/PATTERN_DETECTION_SETUP.md
@@ -1,5 +1,16 @@
 # Pattern Detection Setup (Option 4: Hybrid)
 
+<!-- Roborev closure: #801 resolved in commit 9e8f030 (PR #166 — fix(hooks): gate
+     pattern detection to /bye only).
+     Original finding: guide said wire detect_patterns.sh into session_stop.sh "as if
+     it runs only at /bye", but the Stop hook fires after every Claude response, so
+     a bare integration would incur a paid Opus API call after every reply.
+     Fix: sentinel-file gate documented and implemented. /bye command writes
+     ~/.claude/.bye-requested; session_stop.sh checks for that sentinel and deletes it
+     immediately (one-shot) before invoking detect_patterns.sh. Normal replies produce
+     zero cost because the sentinel is absent. This guide now includes the IMPORTANT
+     warning block and the correct sentinel-gated code block under Step 1. -->
+
 **Created**: 2026-05-11
 **Status**: Integrated
 **Cost**: ~$0.01-0.03 per /bye invocation (zero cost on normal replies)

--- a/PHASE1_VALIDATION.md
+++ b/PHASE1_VALIDATION.md
@@ -1,5 +1,14 @@
 # Phase 1 Validation Plan: Option 3 (Progressive Real-Usage Capture)
 
+<!-- Roborev closure: #787 resolved in commit 60389d4 (PR #164).
+     Original finding: plan claimed skillify_backlog.sh 20 "scans 20 transcripts and
+     runs /skillify on each", but the implementation only analyzed the latest transcript
+     and returned "Insufficient data" for all (transcripts are compacted summaries with
+     no tool call history). Fix: "Finding: No Historical Tool Call Data" section added
+     at top of this file, documenting the architectural limitation and the pivot to
+     Option 3 (live capture). Script retained as a documented placeholder with a
+     no-op marker pending DuckDB tool-event schema documentation. -->
+
 **Issue**: #137 Phase 1 validation
 **Duration**: 2-3 weeks
 **Strategy**: Live usage capture during normal work (no retrospective analysis)

--- a/test_cross_modal_eval.sh
+++ b/test_cross_modal_eval.sh
@@ -6,6 +6,10 @@
 # fails so CI (and the unconditional success message) never masks broken tests.
 # Fix (roborev #777 / finding 5): reference in-repo paths under .claude/scripts/
 # and .claude/.env.example rather than ~/.claude/ paths.
+# Closure (roborev #777, #779): both resolved in commit 60389d4 (PR #164).
+# #779 covered COMPLETION_SUMMARY.md "Ready for Merge" claim; that file now
+# documents in-repo deliverable paths and the accurate test-count (8/8 with
+# exit 1 on any failure).
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Closure-audit PR for #181 Theme 7 (documentation accuracy / unversioned implementation claims). All four roborev findings were **pre-fixed** in earlier PRs; this PR adds header closure comments to each affected file documenting which commit resolved which finding.

### Roborev findings addressed

| Review ID | File | Pre-fixed in | Fix description |
|-----------|------|-------------|-----------------|
| #777 | `test_cross_modal_eval.sh` | 60389d4 (PR #164) | `FAIL_COUNT` + `exit 1` semantics; in-repo paths (`.claude/scripts/`, `.claude/.env.example`) instead of `~/.claude/` |
| #779 | `COMPLETION_SUMMARY.md` | 60389d4 (PR #164) | "Ready for Merge" claim now accurate — deliverables reference in-repo paths; test count is 8/8 with exit 1 on failure |
| #787 | `PHASE1_VALIDATION.md` | 60389d4 (PR #164) | Plan vs impl reconciled — transcript limitation documented, `skillify_backlog.sh 20` scope downscoped to documented placeholder |
| #801 | `PATTERN_DETECTION_SETUP.md` | 9e8f030 (PR #166) | Hook trigger description corrected — sentinel-file gate prevents paid Opus API call on every response; fires only on `/bye` |

### Changes in this PR

- `test_cross_modal_eval.sh`: added closure comment for roborev #777 and #779
- `COMPLETION_SUMMARY.md`: added closure comment for roborev #779
- `PHASE1_VALIDATION.md`: added closure comment for roborev #787
- `PATTERN_DETECTION_SETUP.md`: added closure comment for roborev #801

No logic changes. All edits are doc-header comments only.

## Test plan

- [ ] Confirm `git log --oneline -- test_cross_modal_eval.sh` shows commit 60389d4 with FAIL_COUNT fix
- [ ] Confirm `git log --oneline -- PATTERN_DETECTION_SETUP.md` shows commit 9e8f030 with sentinel gate fix
- [ ] Confirm `session_stop.sh` has sentinel-file gate active (grep `_BYE_SENTINEL`)
- [ ] Confirm `test_cross_modal_eval.sh` exits 1 on assertion failure (FAIL_COUNT > 0)

Refs #181 (Theme 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
