### PR TITLE
docs(plans): #149 Phase 1a pilot report (randomwalk)

### DIFF
--- a/.claude/scripts/roborev_handoff.sh
+++ b/.claude/scripts/roborev_handoff.sh
@@ -46,7 +46,7 @@ set -euo pipefail
 # ── Config ───────────────────────────────────────────────────────────────────
 ROBOREV="${ROBOREV:-/usr/local/bin/roborev}"
 SQLITE="${SQLITE:-/usr/bin/sqlite3}"
-GH="${GH:-/usr/bin/gh}"
+GH="${GH:-$(command -v gh 2>/dev/null || echo /usr/bin/gh)}"
 PYTHON="${PYTHON:-/usr/bin/python3}"
 ROBOREV_DB="${ROBOREV_DB:-$HOME/.roborev/reviews.db}"
 THRESHOLD_DAYS="${THRESHOLD_DAYS:-7}"

--- a/plans/149-handoff-mvp.md
+++ b/plans/149-handoff-mvp.md
@@ -1,5 +1,8 @@
 # MVP Plan: Cross-Repo Roborev Handoff — Phase 1a Only
 
+> **Pilot target updated 2026-05-23: crypto inactive → randomwalk**
+> All §7 pilot references changed from `crypto` to `randomwalk`. See `plans/149-handoff-pilot-report.md` for dry-run output and the manual `--apply` command.
+
 **Issue:** [JohnGavin/llm#149](https://github.com/JohnGavin/llm/issues/149)
 **Plan source:** `.claude/plans/cross-repo-roborev-handoff.md` (full plan, all phases)
 **MVP scope:** Phase 1a only — per-commit fail issues; Phases 1b and 1c deferred
@@ -55,7 +58,7 @@ The script already exists. The MVP is about verifying the slice that matters:
 
 1. **`--dry-run` (default):** for 3 manually-picked stale `verdict=fail` jobs, the script prints `[dry] <repo>: would create GH issue (commit <sha>, job <id>, label roborev-handoff)` and exits 0 without touching GH.
 
-2. **`--apply` single-repo pilot:** `ROBOREV_REPO=crypto ~/.claude/scripts/roborev_handoff.sh --apply` creates one GH issue per stale fail job in `crypto` with:
+2. **`--apply` single-repo pilot:** `ROBOREV_REPO=randomwalk ~/.claude/scripts/roborev_handoff.sh --apply` creates one GH issue per stale fail job in `randomwalk` with:
    - Title: `roborev review for <7-char sha>`
    - Label: `roborev-handoff`
    - Body: review markdown + `roborev job: <id>` footer
@@ -85,7 +88,7 @@ The script already exists. The MVP is about verifying the slice that matters:
 All distinct from the full issue's acceptance checklist:
 
 - [ ] `roborev_handoff.sh --dry-run` (no args) runs without error on the current DB; output lists at least one `[dry] ... would create GH issue` line (or "nothing to do" if DB is empty)
-- [ ] `ROBOREV_REPO=crypto roborev_handoff.sh --apply` creates ≥1 GH issue in `JohnGavin/crypto` with label `roborev-handoff` OR exits cleanly with "nothing to do"
+- [ ] `ROBOREV_REPO=randomwalk roborev_handoff.sh --apply` creates ≥1 GH issue in `JohnGavin/randomwalk` with label `roborev-handoff` OR exits cleanly with "nothing to do"
 - [ ] Re-running `--apply` on the same repo within 60 seconds produces zero new issues (idempotency gate)
 - [ ] `~/.claude/logs/roborev_handoff.log` contains a `1a: created issue` line AND a `1a: closed job=` line for the same job_id
 - [ ] If `gh issue create` is forced to fail (e.g., `GH=/usr/bin/false`), the roborev job remains open (close-after-success ordering)
@@ -100,24 +103,25 @@ Phase 1b, 1c, and plist wiring are NOT acceptance criteria for this PR.
 |---|---|---|
 | GH rate-limit on repos with many stale fail jobs | Medium | Script already logs and leaves job open on API failure; re-run next day |
 | Duplicate issues from concurrent `--apply` runs (two launchd invocations overlap) | Low | Idempotency search reduces window; the sha search is not atomic but concurrent runs are rare given weekly launchd trigger |
-| Target repo has `roborev-handoff` label missing, causing `gh issue create` to fail | Medium | Pre-flight the pilot: `gh label create roborev-handoff --repo JohnGavin/crypto --color 8B5CF6` before first `--apply`; add to the rollout checklist |
+| Target repo has `roborev-handoff` label missing, causing `gh issue create` to fail | Medium | Pre-flight the pilot: `gh label create roborev-handoff --repo JohnGavin/randomwalk --color 8B5CF6` before first `--apply`; add to the rollout checklist |
 
 ---
 
 ## 7. Pilot Target
 
-Use **`crypto`** as the first `--apply` target (as suggested in the issue's Phase 2 row). Rationale:
+Use **`randomwalk`** as the first `--apply` target. Rationale:
 
-- Quietest dev repo; any spurious issues are easy to identify and close.
-- Has GitHub issues enabled (confirmed).
-- Has stale roborev jobs (the DB query in the plan file will show candidates).
+- `crypto` is inactive (user decision 2026-05-23); `randomwalk` is the replacement pilot.
+- Active dev repo with 7 confirmed stale verdict=fail candidates (verified 2026-05-23).
+- Has GitHub issues enabled (confirmed: `hasIssuesEnabled=true`).
+- Any spurious issues are easy to identify and close.
 
 Pilot sequence:
-1. `sqlite3 ~/.roborev/reviews.db "SELECT COUNT(*) FROM review_jobs rj JOIN repos r ON r.id=rj.repo_id JOIN reviews rv ON rv.job_id=rj.id WHERE r.name='crypto' AND rj.status='done' AND (julianday('now')-julianday(rj.finished_at))>7 AND rv.verdict_bool=0"` — confirm ≥1 candidate
-2. Ensure `roborev-handoff` label exists in `JohnGavin/crypto`
-3. `ROBOREV_REPO=crypto ~/.claude/scripts/roborev_handoff.sh` (dry-run first)
+1. `sqlite3 ~/.roborev/reviews.db "SELECT COUNT(*) FROM review_jobs rj JOIN repos r ON r.id=rj.repo_id JOIN reviews rv ON rv.job_id=rj.id WHERE r.name='randomwalk' AND rj.status='done' AND (julianday('now')-julianday(rj.finished_at))>7 AND rv.verdict_bool=0"` — confirms 7 candidates (verified 2026-05-23)
+2. Ensure `roborev-handoff` label exists in `JohnGavin/randomwalk`
+3. `ROBOREV_REPO=randomwalk ~/.claude/scripts/roborev_handoff.sh` (dry-run first)
 4. Inspect dry-run output
-5. `ROBOREV_REPO=crypto ~/.claude/scripts/roborev_handoff.sh --apply`
+5. `ROBOREV_REPO=randomwalk ~/.claude/scripts/roborev_handoff.sh --apply`
 6. Verify issue on GitHub; verify log; verify idempotency
 
 ---

--- a/plans/149-handoff-pilot-report.md
+++ b/plans/149-handoff-pilot-report.md
@@ -1,0 +1,160 @@
+# Phase 1a Pilot Report — randomwalk
+
+**Date:** 2026-05-23
+**Author:** Claude Sonnet 4.6 (fixer agent, worktree `agent-a5ad23a4d7c46563f`)
+**Issue:** [JohnGavin/llm#149](https://github.com/JohnGavin/llm/issues/149)
+**Status:** DRY-RUN ONLY — `--apply` NOT executed (creates irreversible GH issues; user runs manually)
+
+---
+
+## Pilot Target
+
+**Repo:** `randomwalk` (substituted for inactive `crypto` per user decision 2026-05-23)
+
+---
+
+## Candidate Count Query
+
+Query run:
+```sql
+SELECT COUNT(*)
+FROM review_jobs rj
+JOIN repos r ON r.id = rj.repo_id
+JOIN reviews rv ON rv.job_id = rj.id
+WHERE r.name = 'randomwalk'
+  AND rj.status = 'done'
+  AND (julianday('now') - julianday(rj.finished_at)) > 7
+  AND rv.verdict_bool = 0
+```
+
+Result: **7 stale verdict=fail candidates** (confirmed 2026-05-23)
+
+---
+
+## Script Portability Fix Applied
+
+During dry-run inspection, a portability bug was found and fixed:
+
+**Before:** `GH="${GH:-/usr/bin/gh}"` — hardcoded path, fails in Nix environments where `gh` lives in the Nix store.
+
+**After:** `GH="${GH:-$(command -v gh 2>/dev/null || echo /usr/bin/gh)}"` — resolves `gh` from `$PATH` at script start, falls back to `/usr/bin/gh` on macOS without Nix.
+
+Without this fix, the script exits early with `"roborev_handoff: skipped (/usr/bin/gh missing)"` in any Nix shell session. The fix makes the script work without requiring the caller to set `GH=` manually.
+
+---
+
+## Dry-Run Output
+
+Command: `ROBOREV_REPO=randomwalk bash ~/.claude/scripts/roborev_handoff.sh 2>&1`
+
+```
+[dry] randomwalk: would close pass-clean (job 291)
+[dry] randomwalk: would close pass-clean (job 369)
+[dry] randomwalk: would create GH issue (commit 93da959, job 687, label roborev-handoff)
+[dry] randomwalk: would create GH issue (commit 699993d, job 689, label roborev-handoff)
+[dry] randomwalk: would create GH issue (commit 2840d8d, job 690, label roborev-handoff)
+[dry] randomwalk: would create GH issue (commit 4367dc6, job 692, label roborev-handoff)
+[dry] randomwalk: would create GH issue (commit d7c9be9, job 693, label roborev-handoff)
+[dry] randomwalk: would close pass-clean (job 694)
+[dry] randomwalk: would create GH issue (commit 384beff, job 701, label roborev-handoff)
+[dry] randomwalk: would close pass-clean (job 702)
+[dry] randomwalk: would create GH issue (commit 507cc3f, job 709, label roborev-handoff)
+[dry] randomwalk: would close pass-clean (job 906)
+roborev_handoff [dry-run]: repos=1 processed=1 actions={1a:7,1b:0,1c:5,B:0} skipped=0
+```
+
+**Interpretation:**
+- 7 Phase 1a actions: 7 GH issues would be created (one per fail commit)
+- 5 Phase 1c actions: 5 pass-clean jobs would be silently closed
+- 0 Phase 1b actions: no pass-with-comments jobs (all passes are clean)
+- 0 Mechanism B: issues enabled on randomwalk, no inbox fallback needed
+
+---
+
+## Pre-Flight Checklist for `--apply`
+
+Run these from a terminal (NOT from a Claude Code dispatch — `--apply` is irreversible):
+
+### 1. Create the `roborev-handoff` label in randomwalk
+
+```bash
+gh label create roborev-handoff \
+  --repo JohnGavin/randomwalk \
+  --color 8B5CF6 \
+  --description "Findings surfaced by roborev_handoff.sh (Phase 1a)"
+```
+
+If the label already exists, this will error — ignore the error and proceed.
+
+### 2. Confirm issues are enabled
+
+```bash
+gh repo view JohnGavin/randomwalk --json hasIssuesEnabled
+```
+
+Expected output (confirmed 2026-05-23):
+```json
+{"hasIssuesEnabled":true}
+```
+
+### 3. Run `--apply` (user runs this manually from terminal)
+
+```bash
+ROBOREV_REPO=randomwalk bash ~/.claude/scripts/roborev_handoff.sh --apply
+```
+
+Expected outcome: 7 issues created in `JohnGavin/randomwalk`, 5 pass-clean jobs closed in the roborev DB.
+
+---
+
+## Idempotency Check Plan
+
+After the first `--apply` run, wait 60 seconds then run again:
+
+```bash
+ROBOREV_REPO=randomwalk bash ~/.claude/scripts/roborev_handoff.sh --apply
+```
+
+Expected: `actions={1a:0,1b:0,1c:0,B:0}` — no new issues created (idempotency gate). The `gh issue list --search "$commit_sha in:body"` guard in the script prevents duplicates.
+
+---
+
+## Verification After `--apply`
+
+1. Check GitHub: `gh issue list --repo JohnGavin/randomwalk --label roborev-handoff` — should show 7 new issues.
+2. Check log: `tail -20 ~/.claude/logs/roborev_handoff.log` — should show 7 `1a: created issue` lines and 7 `1a: closed job=` lines.
+3. Check DB: the 7 fail jobs should now be closed in the roborev DB. Run the candidate count query again — result should be 0.
+
+---
+
+## Rollback If It Goes Wrong
+
+If spurious issues are created:
+
+```bash
+# List issues created by the handoff
+gh issue list --repo JohnGavin/randomwalk --label roborev-handoff --state open
+
+# Close each spurious one (replace N with the issue number)
+gh issue close N --repo JohnGavin/randomwalk --comment "Closed by rollback — roborev_handoff.sh pilot cleanup"
+```
+
+Leave roborev jobs OPEN in the DB (do not close them) — the next `--apply` will re-process them.
+
+---
+
+## Acceptance Criteria Status (Plan §5)
+
+| Criterion | Status |
+|---|---|
+| `--dry-run` runs without error; prints `[dry] ... would create GH issue` lines | PASS — 7 lines printed, exit 0 |
+| `ROBOREV_REPO=randomwalk --apply` creates ≥1 GH issue OR exits with "nothing to do" | PENDING — user runs `--apply` manually |
+| Re-running `--apply` within 60s produces zero new issues | PENDING — verify after first `--apply` |
+| Log contains `1a: created issue` AND `1a: closed job=` for same job_id | PENDING — verify after first `--apply` |
+| If `gh issue create` forced to fail, roborev job stays open | NOT TESTED in this PR — requires manual test with `GH=/usr/bin/false` |
+
+Phase 1b, 1c, and plist wiring are NOT acceptance criteria for this PR.
+
+---
+
+*Report generated 2026-05-23 by fixer agent. Script fix applied to `~/.claude/scripts/roborev_handoff.sh` (GH path portability). All other script logic unchanged.*


### PR DESCRIPTION
## Summary

- **Pilot retargeted**: `crypto` inactive → `randomwalk` (user decision 2026-05-23)
- **Dry-run validated**: 7 stale verdict=fail candidates found; script exits 0, prints 7 `[dry] ... would create GH issue` lines
- **Script portability fix**: `GH="${GH:-/usr/bin/gh}"` → `command -v gh` fallback so the script works in Nix shell sessions without manual `GH=` override
- **`--apply` NOT run**: creates irreversible GH issues; user runs the precise command from their terminal (see pilot report)

## Dry-Run Result (captured 2026-05-23)

```
[dry] randomwalk: would close pass-clean (job 291)
[dry] randomwalk: would close pass-clean (job 369)
[dry] randomwalk: would create GH issue (commit 93da959, job 687, label roborev-handoff)
[dry] randomwalk: would create GH issue (commit 699993d, job 689, label roborev-handoff)
[dry] randomwalk: would create GH issue (commit 2840d8d, job 690, label roborev-handoff)
[dry] randomwalk: would create GH issue (commit 4367dc6, job 692, label roborev-handoff)
[dry] randomwalk: would create GH issue (commit d7c9be9, job 693, label roborev-handoff)
[dry] randomwalk: would close pass-clean (job 694)
[dry] randomwalk: would create GH issue (commit 384beff, job 701, label roborev-handoff)
[dry] randomwalk: would close pass-clean (job 702)
[dry] randomwalk: would create GH issue (commit 507cc3f, job 709, label roborev-handoff)
[dry] randomwalk: would close pass-clean (job 906)
roborev_handoff [dry-run]: repos=1 processed=1 actions={1a:7,1b:0,1c:5,B:0} skipped=0
```

## Manual `--apply` Command (run from terminal, not Claude)

```bash
# Step 1: create the label (idempotent — error if exists is safe to ignore)
gh label create roborev-handoff \
  --repo JohnGavin/randomwalk \
  --color 8B5CF6 \
  --description "Findings surfaced by roborev_handoff.sh (Phase 1a)"

# Step 2: run --apply
ROBOREV_REPO=randomwalk bash ~/.claude/scripts/roborev_handoff.sh --apply

# Step 3: idempotency check (run again, expect 0 new issues)
ROBOREV_REPO=randomwalk bash ~/.claude/scripts/roborev_handoff.sh --apply
```

## Acceptance Criteria Status

| Criterion | Status |
|---|---|
| `--dry-run` runs without error; prints `[dry]` lines | PASS |
| Script works without `GH=` override in Nix sessions | PASS (portability fix applied) |
| `ROBOREV_REPO=randomwalk --apply` creates ≥1 GH issue | PENDING — user runs manually |
| Re-run `--apply` within 60s → 0 new issues (idempotency) | PENDING — verify after first `--apply` |
| Log has `1a: created issue` + `1a: closed job=` for same job_id | PENDING — verify after first `--apply` |

## Files Changed

- `plans/149-handoff-mvp.md` — §7 pilot sequence updated (crypto → randomwalk), top-banner added, §3/§5/§6 refs updated
- `plans/149-handoff-pilot-report.md` — NEW: full dry-run findings, pre-flight checklist, `--apply` command, idempotency and rollback plans
- `.claude/scripts/roborev_handoff.sh` — GH path portability fix (`command -v gh` fallback)

Refs #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
