### PR TITLE
feat(backup): unified.duckdb backup strategy + script + RECOVERY.md (#228)

### DIFF
--- a/.claude/launchd/com.claude.unified-duckdb-backup.plist
+++ b/.claude/launchd/com.claude.unified-duckdb-backup.plist
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.claude.unified-duckdb-backup.plist
+     Daily WAL-safe backup of unified.duckdb to iCloud Drive.
+     Runs at 03:00 local time — one hour after roborev ETL at 02:00,
+     ensuring the nightly ETL data is captured in the backup.
+
+     Backup destination:
+       ~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/YYYY-MM-DD/
+
+     Retention:
+       Daily exports  — 30 days
+       Monthly anchor — 365 days (1st-of-month export)
+
+     Install:
+       cp ~/.claude/launchd/com.claude.unified-duckdb-backup.plist \
+          ~/Library/LaunchAgents/com.claude.unified-duckdb-backup.plist
+       launchctl load ~/Library/LaunchAgents/com.claude.unified-duckdb-backup.plist
+
+     Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.claude.unified-duckdb-backup.plist
+       rm ~/Library/LaunchAgents/com.claude.unified-duckdb-backup.plist
+
+     Manual dry-run (no writes):
+       ~/.claude/scripts/unified_duckdb_backup.sh --dry-run
+
+     Manual apply (writes backup):
+       ~/.claude/scripts/unified_duckdb_backup.sh --apply --prune
+
+     Self-test:
+       SELFTEST=1 bash ~/.claude/scripts/unified_duckdb_backup.sh
+
+     Tracked in llm#228.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.unified-duckdb-backup</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/.claude/scripts/unified_duckdb_backup.sh</string>
+        <string>--apply</string>
+        <string>--prune</string>
+    </array>
+
+    <!-- Daily at 03:00 local time (one hour after roborev ETL at 02:00) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <!-- Do NOT run immediately on launchctl load -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/unified_duckdb_backup.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/unified_duckdb_backup.log</string>
+
+    <!-- Retry once after 60s if the job exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <!-- PATH must include nix store and homebrew for duckdb -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/opt/homebrew/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+    </dict>
+</dict>
+</plist>

--- a/.claude/scripts/unified_duckdb_backup.sh
+++ b/.claude/scripts/unified_duckdb_backup.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# unified_duckdb_backup.sh — WAL-safe daily backup of unified.duckdb to iCloud Drive.
+#
+# Strategy: DuckDB EXPORT DATABASE (Parquet) — reads a consistent MVCC snapshot
+# while the DB may be live; produces a portable directory of Parquet files +
+# schema.sql that can be restored with IMPORT DATABASE.
+#
+# Flags:
+#   --dry-run   (default) show what would be backed up; no writes
+#   --apply     write backup to iCloud Drive
+#   --db PATH   override source DB path (default: ~/.claude/logs/unified.duckdb)
+#   --dest DIR  override backup root directory
+#   --prune     delete daily exports older than 30 days and monthly exports older than 365 days
+#   --help      usage
+#
+# Self-test (no subprocess recursion — per PR #253 pattern):
+#   SELFTEST=1 bash unified_duckdb_backup.sh
+#   → calls internal functions directly; exits 0 on pass, 1 on any failure.
+#   Must complete in <10s.
+#
+# Backup layout:
+#   <BACKUP_ROOT>/
+#     YYYY-MM-DD/           ← daily export directory
+#       schema.sql
+#       *.parquet           ← one file per table
+#
+# Retention:
+#   Daily exports  → kept 30 days
+#   Monthly anchor → last daily of each month, kept 365 days
+#
+# Tracked in llm#228.
+#
+# Portability: may be invoked by launchd with a bare PATH.
+export PATH="/usr/local/bin:/opt/homebrew/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+set -euo pipefail
+
+# ── Anti-fork-bomb depth guard ────────────────────────────────────────────────
+# Must appear before any code that could invoke this script recursively.
+_DEPTH="${_UNIFIED_DUCKDB_BACKUP_DEPTH:-0}"
+if [ "$_DEPTH" -gt 2 ]; then
+  echo "ERROR: recursion depth $_DEPTH — aborting" >&2
+  exit 2
+fi
+export _UNIFIED_DUCKDB_BACKUP_DEPTH=$((_DEPTH + 1))
+
+# ── Paths / defaults ──────────────────────────────────────────────────────────
+UNIFIED_DB="${UNIFIED_DB:-${HOME}/.claude/logs/unified.duckdb}"
+ICLOUD_ROOT="${HOME}/Library/Mobile Documents/com~apple~CloudDocs"
+BACKUP_ROOT="${BACKUP_ROOT:-${ICLOUD_ROOT}/Backups/unified_duckdb}"
+LOGFILE="${HOME}/.claude/logs/unified_duckdb_backup.log"
+DAILY_RETAIN_DAYS=30
+MONTHLY_RETAIN_DAYS=365
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+log() {
+  local ts
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')
+  echo "${ts} $*" | tee -a "$LOGFILE" 2>/dev/null || true
+}
+
+die() { log "ERROR: $*"; echo "ERROR: $*" >&2; exit 1; }
+
+# ── Helper: find duckdb binary ────────────────────────────────────────────────
+find_duckdb() {
+  # Prefer nix-store duckdb (pinned version), fall back to PATH
+  if command -v duckdb >/dev/null 2>&1; then
+    command -v duckdb
+    return 0
+  fi
+  # Try common Homebrew/Nix paths
+  for candidate in \
+    /nix/store/*/bin/duckdb \
+    /opt/homebrew/bin/duckdb \
+    /usr/local/bin/duckdb; do
+    if [ -x "$candidate" ] 2>/dev/null; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# ── Helper: today's date ──────────────────────────────────────────────────────
+today_date() {
+  date -u '+%Y-%m-%d'
+}
+
+# ── Helper: month anchor (last day of previous calendar month) ────────────────
+# We anchor monthly backups to the 1st of the current month so we keep
+# exactly one backup per calendar month. A daily backup taken on the 1st
+# that still exists after pruning becomes the monthly anchor automatically.
+is_monthly_anchor() {
+  local dir_date="$1"
+  # Extract day portion
+  local day
+  day=$(echo "$dir_date" | cut -d'-' -f3)
+  # Keep the 1st of every month as the monthly anchor
+  [ "$day" = "01" ]
+}
+
+# ── Core function: perform_backup ────────────────────────────────────────────
+# Args: <db_path> <backup_root> <date_str> <apply: 0|1>
+# Returns: 0 on success, 1 on failure
+perform_backup() {
+  local db_path="$1"
+  local backup_root="$2"
+  local date_str="$3"
+  local apply="$4"
+
+  local dest_dir="${backup_root}/${date_str}"
+
+  if [ ! -f "$db_path" ]; then
+    log "WARN: source DB not found: $db_path (skipping)"
+    return 0
+  fi
+
+  local duckdb_bin
+  if ! duckdb_bin=$(find_duckdb); then
+    die "duckdb binary not found — install duckdb or ensure it is in PATH"
+  fi
+
+  # Verify DB is readable
+  if ! "$duckdb_bin" "$db_path" -c ".tables" >/dev/null 2>&1; then
+    die "cannot open DB for reading: $db_path"
+  fi
+
+  if [ "$apply" = "0" ]; then
+    log "DRY-RUN: would export $db_path → $dest_dir"
+    # Show table counts as a sanity check
+    log "DRY-RUN: table inventory:"
+    "$duckdb_bin" "$db_path" -c \
+      "SELECT table_name, estimated_size FROM duckdb_tables() ORDER BY table_name" \
+      2>/dev/null | while IFS= read -r line; do log "  $line"; done || true
+    return 0
+  fi
+
+  # --apply path: create destination and export
+  log "APPLY: exporting $db_path → $dest_dir"
+
+  # iCloud parent may need to exist
+  mkdir -p "$backup_root"
+
+  if [ -d "$dest_dir" ]; then
+    log "WARN: destination already exists ($dest_dir) — skipping (use --prune to clean old exports)"
+    return 0
+  fi
+
+  mkdir -p "$dest_dir"
+
+  # EXPORT DATABASE: WAL-safe consistent Parquet snapshot
+  # The single-quoted path must be escaped for the SQL string literal.
+  local export_sql
+  export_sql="EXPORT DATABASE '${dest_dir}' (FORMAT PARQUET, COMPRESSION ZSTD);"
+
+  if "$duckdb_bin" "$db_path" -c "$export_sql"; then
+    log "OK: export complete → $dest_dir"
+    # Log sizes
+    local export_size
+    export_size=$(du -sh "$dest_dir" 2>/dev/null | cut -f1 || echo "unknown")
+    log "OK: export size = $export_size"
+  else
+    log "ERROR: export failed"
+    rm -rf "$dest_dir"
+    return 1
+  fi
+
+  return 0
+}
+
+# ── Core function: prune_old_backups ──────────────────────────────────────────
+# Args: <backup_root> <apply: 0|1>
+prune_old_backups() {
+  local backup_root="$1"
+  local apply="$2"
+
+  if [ ! -d "$backup_root" ]; then
+    log "PRUNE: backup root does not exist ($backup_root) — nothing to prune"
+    return 0
+  fi
+
+  local today_epoch
+  today_epoch=$(date -u '+%s' 2>/dev/null || date '+%s')
+
+  # Iterate over YYYY-MM-DD subdirectories
+  for dir in "${backup_root}"/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]; do
+    [ -d "$dir" ] || continue
+    local dir_date
+    dir_date=$(basename "$dir")
+
+    # Compute age in days
+    local dir_epoch
+    # macOS date -j -f: convert date string to epoch
+    if dir_epoch=$(date -j -f '%Y-%m-%d' "$dir_date" '+%s' 2>/dev/null); then
+      local age_days=$(( (today_epoch - dir_epoch) / 86400 ))
+    else
+      # GNU date fallback
+      dir_epoch=$(date -d "$dir_date" '+%s' 2>/dev/null || echo "0")
+      local age_days=$(( (today_epoch - dir_epoch) / 86400 ))
+    fi
+
+    # Monthly anchors (1st of each month) are retained for MONTHLY_RETAIN_DAYS
+    if is_monthly_anchor "$dir_date"; then
+      if [ "$age_days" -gt "$MONTHLY_RETAIN_DAYS" ]; then
+        if [ "$apply" = "0" ]; then
+          log "PRUNE DRY-RUN: would delete monthly anchor $dir (${age_days}d old)"
+        else
+          log "PRUNE: deleting monthly anchor $dir (${age_days}d old)"
+          rm -rf "$dir"
+        fi
+      else
+        log "PRUNE: keeping monthly anchor $dir (${age_days}d old, retain=${MONTHLY_RETAIN_DAYS}d)"
+      fi
+    else
+      # Daily exports retained for DAILY_RETAIN_DAYS
+      if [ "$age_days" -gt "$DAILY_RETAIN_DAYS" ]; then
+        if [ "$apply" = "0" ]; then
+          log "PRUNE DRY-RUN: would delete daily $dir (${age_days}d old)"
+        else
+          log "PRUNE: deleting daily $dir (${age_days}d old)"
+          rm -rf "$dir"
+        fi
+      else
+        log "PRUNE: keeping daily $dir (${age_days}d old, retain=${DAILY_RETAIN_DAYS}d)"
+      fi
+    fi
+  done
+}
+
+# ── Self-test (no subprocess recursion — per PR #253 pattern) ─────────────────
+if [ "${SELFTEST:-0}" = "1" ]; then
+  PASS=0
+  FAIL=0
+
+  _assert() {
+    local label="$1" result="$2" expected="$3"
+    if [ "$result" = "$expected" ]; then
+      PASS=$((PASS + 1))
+      echo "  PASS [$label]"
+    else
+      FAIL=$((FAIL + 1))
+      echo "  FAIL [$label]: expected='$expected' got='$result'"
+    fi
+  }
+
+  echo "unified_duckdb_backup selftest: running..."
+
+  # Case 1: find_duckdb locates a binary
+  _db_bin=$(find_duckdb 2>/dev/null || true)
+  if [ -n "$_db_bin" ] && [ -x "$_db_bin" ]; then
+    _assert "find_duckdb_works" "yes" "yes"
+  else
+    _assert "find_duckdb_works" "no" "yes"
+  fi
+
+  # Case 2: today_date returns YYYY-MM-DD format
+  _today=$(today_date)
+  if echo "$_today" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+    _assert "today_date_format" "yes" "yes"
+  else
+    _assert "today_date_format" "no (got: $_today)" "yes"
+  fi
+
+  # Case 3: is_monthly_anchor correctly identifies 1st-of-month
+  if is_monthly_anchor "2026-05-01"; then
+    _assert "monthly_anchor_1st" "yes" "yes"
+  else
+    _assert "monthly_anchor_1st" "no" "yes"
+  fi
+
+  # Case 4: is_monthly_anchor returns false for non-1st
+  if is_monthly_anchor "2026-05-15"; then
+    _assert "monthly_anchor_not_15th" "no" "yes"
+  else
+    _assert "monthly_anchor_not_15th" "yes" "yes"
+  fi
+
+  # Case 5: perform_backup --dry-run on absent DB exits 0 and logs WARN
+  _tmplog=$(mktemp /tmp/selftest_duckdb_backup_XXXXX)
+  LOGFILE="$_tmplog" perform_backup \
+    "/tmp/no_such_unified_db_$$.duckdb" \
+    "/tmp/no_such_backup_root_$$" \
+    "2026-01-01" \
+    "0"
+  _ec=$?
+  _assert "dryrun_absent_db_exits_0" "$_ec" "0"
+  if grep -q "WARN" "$_tmplog" 2>/dev/null; then
+    _assert "dryrun_absent_db_logs_warn" "yes" "yes"
+  else
+    _assert "dryrun_absent_db_logs_warn" "no" "yes"
+  fi
+  rm -f "$_tmplog"
+
+  # Case 6: perform_backup --dry-run on real DB exits 0
+  if [ -f "$UNIFIED_DB" ]; then
+    _tmplog2=$(mktemp /tmp/selftest_duckdb_backup_XXXXX)
+    LOGFILE="$_tmplog2" perform_backup \
+      "$UNIFIED_DB" \
+      "/tmp/no_such_backup_root_$$" \
+      "$(today_date)" \
+      "0"
+    _ec=$?
+    _assert "dryrun_real_db_exits_0" "$_ec" "0"
+    if grep -q "DRY-RUN" "$_tmplog2" 2>/dev/null; then
+      _assert "dryrun_real_db_logs_dryrun" "yes" "yes"
+    else
+      _assert "dryrun_real_db_logs_dryrun" "no" "yes"
+    fi
+    rm -f "$_tmplog2"
+  else
+    echo "  SKIP [dryrun_real_db_exits_0] — unified.duckdb not present"
+    echo "  SKIP [dryrun_real_db_logs_dryrun] — unified.duckdb not present"
+  fi
+
+  # Case 7: prune_old_backups on absent root exits 0
+  _tmplog3=$(mktemp /tmp/selftest_duckdb_backup_XXXXX)
+  LOGFILE="$_tmplog3" prune_old_backups \
+    "/tmp/no_such_backup_root_$$" \
+    "0"
+  _ec=$?
+  _assert "prune_absent_root_exits_0" "$_ec" "0"
+  rm -f "$_tmplog3"
+
+  # Case 8: depth guard exported
+  _depth_val="${_UNIFIED_DUCKDB_BACKUP_DEPTH:-0}"
+  if [ "$_depth_val" -ge 1 ]; then
+    _assert "depth_guard_increments" "yes" "yes"
+  else
+    _assert "depth_guard_increments" "no" "yes"
+  fi
+
+  echo ""
+  TOTAL=$((PASS + FAIL))
+  if [ "$FAIL" -eq 0 ]; then
+    echo "${PASS}/${TOTAL} PASS"
+    exit 0
+  else
+    echo "${PASS}/${TOTAL} PASS — ${FAIL} FAILED"
+    exit 1
+  fi
+fi
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+MODE="dry-run"
+DO_PRUNE=0
+
+usage() {
+  cat <<'EOF'
+Usage: unified_duckdb_backup.sh [--dry-run] [--apply] [--prune]
+                                 [--db PATH] [--dest DIR] [--help]
+
+Flags:
+  --dry-run   (default) show what would be backed up; no writes
+  --apply     write backup to iCloud Drive
+  --prune     remove daily exports > 30 days, monthly > 365 days
+  --db PATH   override source DB (default: ~/.claude/logs/unified.duckdb)
+  --dest DIR  override backup root directory
+  --help      show this message
+
+Self-test:
+  SELFTEST=1 bash unified_duckdb_backup.sh
+
+Tracked in llm#228.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)  MODE="dry-run"; shift ;;
+    --apply)    MODE="apply";   shift ;;
+    --prune)    DO_PRUNE=1;     shift ;;
+    --db)       UNIFIED_DB="$2"; shift 2 ;;
+    --dest)     BACKUP_ROOT="$2"; shift 2 ;;
+    --help|-h)  usage; exit 0 ;;
+    *)          die "Unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+APPLY=0
+[ "$MODE" = "apply" ] && APPLY=1
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+TODAY=$(today_date)
+log "unified_duckdb_backup: mode=$MODE date=$TODAY db=$UNIFIED_DB dest=$BACKUP_ROOT"
+
+perform_backup "$UNIFIED_DB" "$BACKUP_ROOT" "$TODAY" "$APPLY"
+
+if [ "$DO_PRUNE" = "1" ]; then
+  prune_old_backups "$BACKUP_ROOT" "$APPLY"
+fi
+
+log "unified_duckdb_backup: done"

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -1,0 +1,242 @@
+# RECOVERY.md — llm project
+
+Per the `backup-architecture` rule: this file documents the non-reproducible state
+in this project, where backups live, and how to restore them.
+
+**Owner:** John Gavin
+**Last drill date:** Not yet performed — run quarterly restore test after first backup completes.
+
+---
+
+## Non-Reproducible State
+
+| Asset | Path | Size | Why irreplaceable |
+|---|---|---|---|
+| `unified.duckdb` | `~/.claude/logs/unified.duckdb` | ~123 MB | Operational telemetry since 2026-01-10; financial cost records ($49K+); session history; roborev metrics. Cannot be regenerated — data is created at runtime. |
+
+All other state in this project is reproducible from git + `tar_make()` / `quarto render`.
+
+---
+
+## Backup Details
+
+| Field | Value |
+|---|---|
+| Backup location | `~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/` |
+| Failure domain | iCloud Drive (Apple servers — different from laptop disk) |
+| Mechanism | DuckDB `EXPORT DATABASE` (Parquet, ZSTD) — WAL-safe consistent snapshot |
+| Cadence | Daily at 03:00 local time (one hour after roborev ETL at 02:00) |
+| Retention — daily | 30 days |
+| Retention — monthly | 12 months (1st-of-month export kept automatically) |
+| Script | `~/.claude/scripts/unified_duckdb_backup.sh` |
+| launchd plist | `~/.claude/launchd/com.claude.unified-duckdb-backup.plist` |
+
+**RPO (Recovery Point Objective):** 24 hours  
+**RTO (Recovery Time Objective):** 15 minutes (download from iCloud + run restore commands)
+
+---
+
+## Backup Layout
+
+```
+~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/
+  2026-05-23/
+    schema.sql         ← DDL for all tables
+    agent_runs.parquet
+    braindump_actions.parquet
+    braindumps.parquet
+    costs.parquet
+    errors.parquet
+    hook_events.parquet
+    roborev_agent_performance.parquet
+    roborev_cadence_efficacy.parquet
+    roborev_daily_metrics.parquet
+    roborev_review_lifecycle.parquet
+    roborev_threshold_changes.parquet
+    sessions.parquet
+  2026-05-22/
+    ...
+```
+
+---
+
+## Install / Activate Backups
+
+After deploying the script (first-time setup):
+
+```bash
+# 1. Copy plist to LaunchAgents
+cp ~/.claude/launchd/com.claude.unified-duckdb-backup.plist \
+   ~/Library/LaunchAgents/com.claude.unified-duckdb-backup.plist
+
+# 2. Load it (starts scheduling — does not run immediately)
+launchctl load ~/Library/LaunchAgents/com.claude.unified-duckdb-backup.plist
+
+# 3. Verify it is scheduled
+launchctl list | grep unified-duckdb-backup
+
+# 4. Run a dry-run to confirm the script works
+~/.claude/scripts/unified_duckdb_backup.sh --dry-run
+
+# 5. Run a manual apply to create the first backup immediately
+~/.claude/scripts/unified_duckdb_backup.sh --apply
+```
+
+---
+
+## Restore Procedure
+
+### Step 1 — Identify the backup to restore from
+
+```bash
+ls -la ~/Library/Mobile\ Documents/com~apple~CloudDocs/Backups/unified_duckdb/
+```
+
+Choose the most recent date directory, e.g. `2026-05-23`.
+
+### Step 2 — Verify backup integrity
+
+```bash
+# Count the parquet files — should match the number of tables in unified.duckdb
+ls ~/Library/Mobile\ Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23/*.parquet | wc -l
+# Expected: 12
+```
+
+### Step 3 — Move or rename the corrupted/lost DB (if it still exists)
+
+```bash
+# Move aside the corrupted file
+mv ~/.claude/logs/unified.duckdb \
+   ~/.claude/logs/unified.duckdb.$(date +%Y%m%d_%H%M%S).corrupted
+```
+
+### Step 4 — Restore into a new DB
+
+```bash
+# Open a new empty DuckDB and import from the backup
+duckdb ~/.claude/logs/unified.duckdb
+
+-- Inside the duckdb prompt:
+IMPORT DATABASE '/Users/johngavin/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23';
+.quit
+```
+
+### Step 5 — Verify restore consistency
+
+Run the following row-count verification queries against the restored DB:
+
+```bash
+duckdb ~/.claude/logs/unified.duckdb -c "
+SELECT
+  table_name,
+  estimated_size AS row_count
+FROM duckdb_tables()
+ORDER BY table_name;
+"
+```
+
+Expected row counts (as of 2026-05-23, update this table quarterly):
+
+| Table | Rows at last drill |
+|---|---|
+| `agent_runs` | 48 |
+| `braindump_actions` | 33 |
+| `braindumps` | 31 |
+| `costs` | 85 |
+| `errors` | 1 |
+| `hook_events` | 1 |
+| `roborev_agent_performance` | 4 |
+| `roborev_cadence_efficacy` | 2 |
+| `roborev_daily_metrics` | 54 |
+| `roborev_review_lifecycle` | 834 |
+| `roborev_threshold_changes` | 28 |
+| `sessions` | 423 |
+
+Counts in the restored DB should be within a few rows of these values (the backup
+may be up to 24h old; ETL runs once daily at 02:00).
+
+### Step 6 — Spot-check financial data
+
+```bash
+duckdb ~/.claude/logs/unified.duckdb -c "
+SELECT MIN(date), MAX(date), ROUND(SUM(total_cost), 2) AS total_usd
+FROM costs;
+"
+# Expected: date range 2026-01-10 to recent, total ~$49K+
+```
+
+### Step 7 — Resume normal operations
+
+No further steps needed. The launchd backup agent will continue writing new daily
+backups to iCloud Drive automatically.
+
+---
+
+## Quarterly Restore Drill
+
+Run quarterly to verify backups are valid:
+
+```bash
+# Restore to a temp location
+duckdb /tmp/unified_restore_test.duckdb -c \
+  "IMPORT DATABASE '/Users/johngavin/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/$(ls ~/Library/Mobile\ Documents/com~apple~CloudDocs/Backups/unified_duckdb/ | tail -1)'"
+
+# Verify counts
+duckdb /tmp/unified_restore_test.duckdb -c \
+  "SELECT table_name, estimated_size FROM duckdb_tables() ORDER BY table_name"
+
+# Clean up
+rm /tmp/unified_restore_test.duckdb
+
+# Update the "Last drill date" at the top of this file
+```
+
+---
+
+## Troubleshooting
+
+### Backup job not running
+
+```bash
+# Check if loaded
+launchctl list | grep unified-duckdb-backup
+
+# Check the log
+tail -50 ~/.claude/logs/unified_duckdb_backup.log
+
+# Run manually
+~/.claude/scripts/unified_duckdb_backup.sh --apply
+```
+
+### iCloud not syncing
+
+Ensure iCloud Drive is enabled in System Settings > Apple ID > iCloud > iCloud Drive.
+Backups will accumulate locally and sync when iCloud is available (on next connection).
+
+### Restore from partial backup (iCloud not synced)
+
+If the laptop was lost before iCloud sync completed, the most recent backup may be
+older than expected. In this case, restore from the most recent available backup and
+accept the data loss for the period since that backup.
+
+### DuckDB version mismatch
+
+If the duckdb binary version differs from the version that wrote the backup, the
+`IMPORT DATABASE` command may fail. In that case:
+
+```bash
+# Check the duckdb version used by the backup (recorded in schema.sql)
+head -5 ~/Library/Mobile\ Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23/schema.sql
+
+# Install a matching duckdb version and retry
+```
+
+---
+
+## Related
+
+- `backup-architecture` rule — `~/.claude/rules/backup-architecture.md`
+- Backup script — `~/.claude/scripts/unified_duckdb_backup.sh`
+- launchd plist — `~/.claude/launchd/com.claude.unified-duckdb-backup.plist`
+- Plan document — `plans/228-unified-duckdb-backup.md`
+- Issue — https://github.com/JohnGavin/llm/issues/228

--- a/plans/228-unified-duckdb-backup.md
+++ b/plans/228-unified-duckdb-backup.md
@@ -1,0 +1,167 @@
+# Plan: unified.duckdb Backup Strategy (#228)
+
+**Issue:** https://github.com/JohnGavin/llm/issues/228
+**Date:** 2026-05-23
+**Status:** Implemented
+
+---
+
+## 1. What unified.duckdb Contains
+
+`~/.claude/logs/unified.duckdb` is a 123 MB DuckDB file with 12 tables accumulating
+irreplaceable operational telemetry since 2026-01-10. It is explicitly non-reproducible:
+the data is generated in real time and no upstream source can regenerate it.
+
+| Table | Rows | Date range | Value at risk |
+|---|---|---|---|
+| `sessions` | 423 | 2026-02-13 → present | Full session history with burn_status, duration, project |
+| `roborev_review_lifecycle` | 834 | 2026-05-20 → present | PR review outcomes, escalation decisions |
+| `costs` | 85 | 2026-01-10 → 2026-04-21 | $49,579.73 tracked LLM spend (financial record) |
+| `roborev_daily_metrics` | 54 | 2026-05-20 → present | Daily roborev KPIs |
+| `agent_runs` | 48 | — | Agent dispatch outcomes |
+| `braindump_actions` | 33 | — | Braindump lifecycle (act/complete records) |
+| `braindumps` | 31 | — | Raw braindump captures |
+| `roborev_threshold_changes` | 28 | — | Severity threshold change history |
+| `roborev_agent_performance` | 4 | — | Agent effectiveness metrics |
+| `roborev_cadence_efficacy` | 2 | — | Cadence effectiveness snapshots |
+| `hook_events` | 1 | — | Hook execution events |
+| `errors` | 1 | — | Error log |
+
+**Total:** 1,544 rows of irreplaceable operational data. The costs table alone records
+nearly $50K of spend — loss would eliminate the financial audit trail.
+
+---
+
+## 2. Failure Domains
+
+| Failure mode | Probability | Impact |
+|---|---|---|
+| Laptop disk failure / SSD corruption | Low-medium | Total loss |
+| Accidental wipe (`rm -rf ~/.claude/logs/`) | Medium (agent risk) | Total loss |
+| Malicious or erroneous agent deletion | Low | Total loss |
+| DuckDB file corruption (incomplete write, crash during CHECKPOINT) | Low | Partial to total loss |
+| Ransomware / OS-level encryption | Very low | Total loss |
+
+The `destructive-fs-guard` hook blocks `rm -rf .claude/` with a confirmation code —
+but an agent using `DESTRUCTIVE_CONFIRM=XXXX rm -rf ...` would bypass the advisory
+layer. The primary protection must be an off-disk backup.
+
+---
+
+## 3. Backup Frequency Options
+
+| Cadence | Pro | Con |
+|---|---|---|
+| **Hourly** | Max 1h data loss | 24× I/O per day; EXPORT takes ~2s each run |
+| **Daily at 03:00** | After ETL at 02:00; low contention | Up to 24h data loss |
+| **On-change via fswatch** | Near-zero data loss | Requires fswatch daemon; complex |
+| **Weekly** | Minimal overhead | Up to 7 days data loss — unacceptable |
+
+**Recommendation:** Daily at 03:00. The roborev ETL runs at 02:00; a 03:00 backup
+catches the fresh data within one hour. The 24h RPO is acceptable given:
+- sessions table updates are granular but the session itself is the atomic unit
+- costs table is a daily aggregate — no intraday granularity is lost
+- roborev tables are populated by ETL, so one ETL cycle = one day of data
+
+---
+
+## 4. Backup Location Options
+
+| Location | Failure domain | Availability | Notes |
+|---|---|---|---|
+| `~/Backups/` same disk | SAME — not a backup | Instant | Violates backup-architecture rule |
+| iCloud Drive (`~/Library/Mobile Documents/com~apple~CloudDocs/`) | DIFFERENT — Apple servers | Syncs in minutes | Available on this laptop; encrypted in transit; 5 GB free tier |
+| External USB drive | DIFFERENT if unplugged | When connected | Not reliably present |
+| Backblaze B2 | DIFFERENT — cloud object store | After upload | Requires API key setup; overkill for current scale |
+| GitHub LFS private repo | DIFFERENT — GitHub servers | After push | 1 GB LFS free; DuckDB EXPORT produces ~5 MB parquet per backup |
+| Time Machine (local snapshots) | SAME volume snapshots | N/A | `/Volumes/com.apple.TimeMachine.localsnapshots` is local; not a different failure domain |
+
+**Recommendation:** iCloud Drive. It is already enabled on this machine
+(`~/Library/Mobile Documents/com~apple~CloudDocs/Documents/` exists), provides a
+genuinely different failure domain (Apple servers in a different geographic location),
+syncs automatically without credentials or API keys, and retains deleted files for 30
+days in iCloud trash. A 30-day retention of daily backups requires ~150 MB of iCloud
+storage (12 tables × 30 days × ~400 KB per EXPORT).
+
+Backup path: `~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/YYYY-MM-DD/`
+
+---
+
+## 5. Backup Mechanism Options
+
+| Mechanism | WAL-safe? | Portable? | Notes |
+|---|---|---|---|
+| **`cp ~/.claude/logs/unified.duckdb <dest>`** | NO | Single file | Copies open WAL state; file may be corrupt on restore |
+| **`duckdb <db> "CHECKPOINT; COPY ..."` + cp** | Partial | Single file | CHECKPOINT flushes WAL but race window remains |
+| **`duckdb <db> "EXPORT DATABASE '<dir>'"` (Parquet)** | YES | Directory of `.parquet` | Reads consistent snapshot via MVCC; produces directory |
+| **`duckdb <src> "ATTACH '<dest>' AS bk; COPY FROM DATABASE..."` | YES | `.duckdb` file | DuckDB 0.10+ only; simpler restore; single file |
+
+**Recommendation:** `EXPORT DATABASE` to a dated directory. This uses DuckDB's MVCC
+to take a consistent snapshot while the database may be in use. The output is a
+directory of Parquet files (one per table) plus a `schema.sql` file — human-readable,
+inspectable with any Parquet reader, and restorable with `IMPORT DATABASE`.
+
+```sql
+EXPORT DATABASE '~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23'
+  (FORMAT PARQUET, COMPRESSION ZSTD);
+```
+
+Restore:
+```sql
+-- Create new db
+duckdb ~/.claude/logs/unified.duckdb.restored
+-- Inside duckdb:
+IMPORT DATABASE '~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23';
+```
+
+---
+
+## 6. Retention Policy
+
+| Tier | Retention | Storage estimate |
+|---|---|---|
+| Daily | 30 days | ~150 MB (5 MB/day × 30) |
+| Weekly (kept from daily) | 3 months | Additional ~60 MB |
+| Monthly | 1 year | Additional ~60 MB |
+
+Implementation: script deletes daily exports older than 30 days; the last daily of
+each month is promoted to monthly tier (kept for 12 months). Weekly tier is not
+implemented initially — the script prunes daily > 30 days only, and monthly > 365 days.
+
+---
+
+## 7. Restore Test Cadence
+
+Manual restore test should be performed quarterly:
+1. Find the most recent backup directory
+2. Run `duckdb /tmp/test_restore.duckdb`
+3. `IMPORT DATABASE '<backup_dir>'`
+4. Verify row counts match `RECOVERY.md` reference
+5. Delete `/tmp/test_restore.duckdb`
+
+---
+
+## 8. Comparison Table and Recommendation
+
+| Option | Failure domain | WAL-safe | Automated | Storage | Complexity |
+|---|---|---|---|---|---|
+| `cp` same disk | SAME | No | Yes | Minimal | Minimal |
+| iCloud `EXPORT DATABASE` daily | DIFFERENT | **Yes** | **Yes** (launchd) | ~150 MB/month | Low |
+| B2 `EXPORT DATABASE` daily | DIFFERENT | Yes | Yes | ~150 MB/month | Medium (API keys) |
+| External drive | DIFFERENT (when connected) | Yes | Partial | Unlimited | Low |
+
+**Selected option:** iCloud Drive + `EXPORT DATABASE` (Parquet) + daily at 03:00 +
+30-day daily retention + 12-month monthly retention. Implemented in
+`.claude/scripts/unified_duckdb_backup.sh` and scheduled via
+`.claude/launchd/com.claude.unified-duckdb-backup.plist`.
+
+---
+
+## 9. Files Produced
+
+| File | Purpose |
+|---|---|
+| `plans/228-unified-duckdb-backup.md` | This analysis document |
+| `.claude/scripts/unified_duckdb_backup.sh` | Backup script (--dry-run default, --apply writes) |
+| `.claude/launchd/com.claude.unified-duckdb-backup.plist` | launchd daily 03:00 trigger |
+| `RECOVERY.md` | Restore procedure per backup-architecture rule |


### PR DESCRIPTION
## Summary

- `unified.duckdb` (~123 MB, 12 tables, 1,544 rows) has accumulated irreplaceable telemetry since 2026-01-10 with zero backup protection. The `costs` table alone records $49,579.73 of tracked LLM spend — loss eliminates the financial audit trail.
- This PR implements the `backup-architecture` rule's requirement for a different-failure-domain backup of non-reproducible state.
- Four files: plan analysis, backup script, launchd plist, RECOVERY.md.

## What changed

**`plans/228-unified-duckdb-backup.md`**
- Per-table value-at-risk inventory (12 tables, date ranges, row counts)
- Failure domain comparison (same-disk `cp` vs iCloud vs B2 vs GitHub LFS)
- Mechanism comparison (`cp` vs `CHECKPOINT + cp` vs `EXPORT DATABASE`)
- Retention policy (30-day daily, 12-month monthly anchor)
- Recommendation: daily `EXPORT DATABASE` to iCloud Drive at 03:00

**`.claude/scripts/unified_duckdb_backup.sh`**
- `--dry-run` default, `--apply` writes to `~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/YYYY-MM-DD/`
- Uses `EXPORT DATABASE` (Parquet/ZSTD) — WAL-safe consistent MVCC snapshot; never a raw `cp` of the open file
- `--prune` removes daily exports > 30 days; 1st-of-month anchors kept 365 days
- Depth guard (anti-fork-bomb, per PR #253 pattern)
- 10/10 SELFTEST in 0.5s; `bash -n` passes

**`.claude/launchd/com.claude.unified-duckdb-backup.plist`**
- Daily at 03:00 local (one hour after roborev ETL at 02:00 — captures nightly ETL data)
- `RunAtLoad: false`; `ThrottleInterval: 60`; explicit `PATH` and `HOME`
- `plutil -lint OK`

**`RECOVERY.md`** (new, at repo root)
- Per `backup-architecture` rule: names the non-reproducible state, backup location + failure domain, RPO (24h) / RTO (15 min)
- Numbered restore steps using `IMPORT DATABASE`
- Verification queries with reference row counts
- Quarterly drill procedure

## Restore demo

```bash
# From the most recent backup:
duckdb ~/.claude/logs/unified.duckdb -c \
  "IMPORT DATABASE '/Users/johngavin/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23'"

# Verify:
duckdb ~/.claude/logs/unified.duckdb -c \
  "SELECT table_name, estimated_size FROM duckdb_tables() ORDER BY table_name"
```

## Retention policy

| Tier | Retention |
|---|---|
| Daily exports | 30 days (~150 MB at ~5 MB/export) |
| Monthly anchor (1st of month) | 365 days |

## Test plan

- [x] `bash -n .claude/scripts/unified_duckdb_backup.sh` — syntax OK
- [x] `SELFTEST=1 bash .claude/scripts/unified_duckdb_backup.sh` — 10/10 PASS in 0.5s
- [x] `ps aux | grep unified_duckdb_backup | grep -v grep` — 0 lingering processes after selftest
- [x] `/usr/bin/plutil -lint .claude/launchd/com.claude.unified-duckdb-backup.plist` — OK
- [ ] First `--apply` run: `~/.claude/scripts/unified_duckdb_backup.sh --apply` (after install to LaunchAgents)
- [ ] Quarterly restore drill (see RECOVERY.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
