### PR TITLE
feat(pkgctx): local_ctx_sync() ingests project ctx.yaml files (#207)

### DIFF
--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -373,6 +373,10 @@ phase_ctx_audit() {
       > /tmp/ctx_sync_$$.log 2>&1 &
     echo "  Background PID $! — log at /tmp/ctx_sync_$$.log"
   fi
+
+  # Auto-launch background local_ctx_sync — ingests sibling-project ctx.yaml files (#207)
+  nohup timeout 120 Rscript -e 'source("~/docs_gh/llm/R/tar_plans/plan_pkgctx.R"); local_ctx_sync(dry_run = FALSE)' \
+    > /tmp/local_ctx_sync_$$.log 2>&1 &
 }
 
 # ── Phase 6: R-universe Build Status ──────────────────────────────────

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Imports:
     purrr,
     qrcode,
     scales,
-    tibble
+    tibble,
+    yaml
 VignetteBuilder: knitr
 Suggests:
     DT,

--- a/R/tar_plans/plan_pkgctx.R
+++ b/R/tar_plans/plan_pkgctx.R
@@ -283,6 +283,242 @@ ctx_cleanup <- function(cache_dir = CTX_CACHE, max_age_days = CTX_CLEANUP_DAYS) 
   invisible(length(old))
 }
 
+# ── Registered project directories for local_ctx_sync() ──────────────
+LOCAL_CTX_PROJECTS <- c(
+  file.path(Sys.getenv("HOME"), "docs_gh/proj/finance/data/historical"),
+  file.path(Sys.getenv("HOME"), "docs_gh/proj/data/coMMpass"),
+  file.path(Sys.getenv("HOME"), "docs_gh/proj/medicine/mycare"),
+  file.path(Sys.getenv("HOME"), "docs_gh/proj/data/irishbuoys")
+)
+
+#' Extract package name and version from a multi-doc ctx.yaml file
+#'
+#' Reads the first `kind: package` document from a multi-document YAML file
+#' and returns its `name` and `version` fields.
+#'
+#' @param ctx_path Path to a `.ctx.yaml` file (multi-doc YAML with `---` separators)
+#' @return A named list with elements `name` (character) and `version` (character),
+#'   or `NULL` if the file cannot be parsed or lacks a `kind: package` document.
+#' @keywords internal
+read_ctx_package_meta <- function(ctx_path) {
+  if (!file.exists(ctx_path)) return(NULL)
+
+  # Multi-doc YAML: split on "---" separator lines, parse each doc
+  raw <- tryCatch(
+    readLines(ctx_path, warn = FALSE),
+    error = function(e) {
+      cli::cli_warn("Cannot read {.file {ctx_path}}: {conditionMessage(e)}")
+      NULL
+    }
+  )
+  if (is.null(raw)) return(NULL)
+
+  # Split into YAML documents on "---" boundary lines (keep non-empty docs)
+  doc_breaks <- c(0L, which(grepl("^---\\s*$", raw)), length(raw) + 1L)
+  docs <- lapply(
+    seq_len(length(doc_breaks) - 1L),
+    function(i) raw[(doc_breaks[i] + 1L):(doc_breaks[i + 1L] - 1L)]
+  )
+  docs <- docs[vapply(docs, function(d) any(nzchar(trimws(d))), logical(1))]
+
+  # Find the document with `kind: package`
+  for (doc_lines in docs) {
+    parsed <- tryCatch(
+      yaml::yaml.load(paste(doc_lines, collapse = "\n")),
+      error = function(e) NULL
+    )
+    if (!is.null(parsed) && identical(parsed[["kind"]], "package")) {
+      name    <- parsed[["name"]]
+      version <- parsed[["version"]]
+      if (!is.null(name) && nzchar(name)) {
+        return(list(
+          name    = as.character(name),
+          version = if (!is.null(version)) as.character(version) else "unknown"
+        ))
+      }
+    }
+  }
+  NULL
+}
+
+#' Locate ctx.yaml files in a project directory
+#'
+#' Checks the project root for a `ctx.yaml` file and also looks for ctx yaml
+#' files under `inst/extdata/ctx/` matching the project package name.
+#'
+#' @param project_dir Path to the project root directory
+#' @return Character vector of absolute paths to discovered ctx yaml files
+#' @keywords internal
+find_project_ctx_files <- function(project_dir) {
+  if (!dir.exists(project_dir)) return(character(0))
+
+  candidates <- c(
+    file.path(project_dir, "ctx.yaml"),
+    list.files(
+      file.path(project_dir, "inst", "extdata", "ctx"),
+      pattern = "\\.ctx\\.yaml$",
+      full.names = TRUE
+    )
+  )
+  candidates[file.exists(candidates)]
+}
+
+#' Sync local project ctx.yaml files into the central cache
+#'
+#' Scans a list of registered project directories for `ctx.yaml` files
+#' (multi-document YAML, schema v1.1) and copies them into the central context
+#' cache at `~/docs_gh/proj/data/llm/content/inst/ctx/external/` using the
+#' version-stamped naming convention `{name}\@{version}.ctx.yaml`.
+#'
+#' By default (`dry_run = TRUE`) no files are written — the function only
+#' reports what it would do. Set `dry_run = FALSE` to perform the actual copy.
+#'
+#' @param dirs Character vector of project root directories to scan.
+#'   Defaults to `LOCAL_CTX_PROJECTS` (the configured registry).
+#' @param cache_dir Destination directory. Defaults to `CTX_CACHE`.
+#' @param dry_run Logical. When `TRUE` (the default) no files are written;
+#'   the function returns a tibble describing what *would* be synced.
+#' @return A [tibble::tibble()] with columns:
+#'   \describe{
+#'     \item{project_dir}{Source project directory}
+#'     \item{ctx_src}{Absolute path to the source ctx file}
+#'     \item{package}{Package name extracted from the ctx file}
+#'     \item{version}{Package version extracted from the ctx file}
+#'     \item{dest}{Destination path in the central cache}
+#'     \item{action}{One of `"copied"`, `"skipped"` (already current),
+#'       `"dry_run"`, `"error"`, or `"parse_failed"`}
+#'   }
+#' @examples
+#' # Report what would be synced (no writes)
+#' local_ctx_sync(dry_run = TRUE)
+#'
+#' # Actually copy files into the central cache
+#' \dontrun{
+#' local_ctx_sync(dry_run = FALSE)
+#' }
+#' @export
+local_ctx_sync <- function(
+    dirs      = LOCAL_CTX_PROJECTS,
+    cache_dir = CTX_CACHE,
+    dry_run   = TRUE
+) {
+  if (!is.character(dirs)) {
+    cli::cli_abort(c(
+      "x" = "{.arg dirs} must be a character vector.",
+      "i" = "Got {.cls {class(dirs)}}."
+    ))
+  }
+  if (!is.logical(dry_run) || length(dry_run) != 1L) {
+    cli::cli_abort(c(
+      "x" = "{.arg dry_run} must be a single logical value.",
+      "i" = "Got {.cls {class(dry_run)}} of length {length(dry_run)}."
+    ))
+  }
+
+  if (dry_run) {
+    cli::cli_inform("local_ctx_sync: dry_run=TRUE — no files will be written")
+  }
+
+  rows <- list()
+
+  for (project_dir in dirs) {
+    ctx_files <- find_project_ctx_files(project_dir)
+    if (length(ctx_files) == 0L) next
+
+    for (ctx_src in ctx_files) {
+      meta <- tryCatch(
+        read_ctx_package_meta(ctx_src),
+        warning = function(w) {
+          cli::cli_warn(
+            "Parsing {.file {ctx_src}}: {conditionMessage(w)}",
+            .frequency = "once",
+            .frequency_id = ctx_src
+          )
+          NULL
+        },
+        error = function(e) {
+          cli::cli_warn(
+            "Failed to parse {.file {ctx_src}}: {conditionMessage(e)}"
+          )
+          NULL
+        }
+      )
+
+      if (is.null(meta)) {
+        rows <- c(rows, list(tibble::tibble(
+          project_dir = project_dir,
+          ctx_src     = ctx_src,
+          package     = NA_character_,
+          version     = NA_character_,
+          dest        = NA_character_,
+          action      = "parse_failed"
+        )))
+        next
+      }
+
+      dest_name <- ctx_filename(meta$name, meta$version)
+      dest      <- file.path(cache_dir, dest_name)
+
+      # Determine action
+      action <- if (dry_run) {
+        "dry_run"
+      } else if (file.exists(dest) &&
+                 identical(
+                   readLines(ctx_src,  warn = FALSE),
+                   readLines(dest, warn = FALSE)
+                 )) {
+        "skipped"
+      } else {
+        dir.create(cache_dir, showWarnings = FALSE, recursive = TRUE)
+        ok <- tryCatch(
+          { file.copy(ctx_src, dest, overwrite = TRUE); TRUE },
+          error = function(e) {
+            cli::cli_warn("Copy failed for {.file {dest_name}}: {conditionMessage(e)}")
+            FALSE
+          }
+        )
+        if (ok) "copied" else "error"
+      }
+
+      if (action == "copied") {
+        cli::cli_alert_success(
+          "Synced {.pkg {meta$name}} {meta$version} → {.file {dest_name}}"
+        )
+      } else if (action == "skipped") {
+        cli::cli_alert_info(
+          "Already current: {.file {dest_name}}"
+        )
+      } else if (action == "dry_run") {
+        cli::cli_alert_info(
+          "[dry_run] Would copy {.pkg {meta$name}} {meta$version} → {.file {dest_name}}"
+        )
+      }
+
+      rows <- c(rows, list(tibble::tibble(
+        project_dir = project_dir,
+        ctx_src     = ctx_src,
+        package     = meta$name,
+        version     = meta$version,
+        dest        = dest,
+        action      = action
+      )))
+    }
+  }
+
+  if (length(rows) == 0L) {
+    return(tibble::tibble(
+      project_dir = character(0),
+      ctx_src     = character(0),
+      package     = character(0),
+      version     = character(0),
+      dest        = character(0),
+      action      = character(0)
+    ))
+  }
+
+  do.call(rbind, rows)
+}
+
 # ── Targets plan (for llm project) ───────────────────────────────────
 
 plan_pkgctx <- function() {
@@ -308,6 +544,13 @@ plan_pkgctx <- function() {
         ctx_sync("DESCRIPTION", CTX_CACHE, fix_missing = TRUE, fix_stale = TRUE)
       },
       packages = c("cli"),
+      cue = targets::tar_cue(mode = "always")
+    ),
+
+    targets::tar_target(
+      pkgctx_local_sync,
+      local_ctx_sync(dry_run = FALSE),
+      packages = c("cli", "yaml", "tibble"),
       cue = targets::tar_cue(mode = "always")
     )
   )

--- a/tests/testthat/test-pkgctx-local-sync.R
+++ b/tests/testthat/test-pkgctx-local-sync.R
@@ -1,0 +1,182 @@
+test_that("local_ctx_sync returns empty tibble for directory with no ctx files", {
+  empty_dir <- withr::local_tempdir()
+  result <- local_ctx_sync(dirs = empty_dir, cache_dir = withr::local_tempdir())
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 0L)
+  expect_named(result, c("project_dir", "ctx_src", "package", "version", "dest", "action"))
+})
+
+test_that("local_ctx_sync returns 1-row tibble for directory with 1 valid ctx.yaml", {
+  proj_dir  <- withr::local_tempdir()
+  cache_dir <- withr::local_tempdir()
+
+  # Write a minimal multi-doc ctx.yaml
+  writeLines(
+    c(
+      "---",
+      "kind: context_header",
+      "llm_instructions: test",
+      "---",
+      "kind: package",
+      "schema_version: '1.1'",
+      "name: mypkg",
+      "version: 0.2.0",
+      "language: R",
+      "description: Test package"
+    ),
+    file.path(proj_dir, "ctx.yaml")
+  )
+
+  result <- local_ctx_sync(dirs = proj_dir, cache_dir = cache_dir, dry_run = TRUE)
+
+  expect_s3_class(result, "tbl_df")
+  expect_equal(nrow(result), 1L)
+  expect_equal(result$package, "mypkg")
+  expect_equal(result$version, "0.2.0")
+  expect_equal(result$action, "dry_run")
+})
+
+test_that("local_ctx_sync warns and marks parse_failed for malformed yaml", {
+  proj_dir  <- withr::local_tempdir()
+  cache_dir <- withr::local_tempdir()
+
+  # Write an empty file — yaml::yaml.load on an empty file raises an error,
+  # which local_ctx_sync catches and re-emits as a cli_warn() call.
+  writeLines(character(0), file.path(proj_dir, "ctx.yaml"))
+
+  result <- suppressWarnings(
+    local_ctx_sync(dirs = proj_dir, cache_dir = cache_dir, dry_run = TRUE)
+  )
+  # Empty file -> parse error -> parse_failed row
+  expect_equal(nrow(result), 1L)
+  expect_equal(result$action, "parse_failed")
+  expect_true(is.na(result$package))
+})
+
+test_that("local_ctx_sync dry_run=TRUE does not write files to cache", {
+  proj_dir  <- withr::local_tempdir()
+  cache_dir <- withr::local_tempdir()
+
+  writeLines(
+    c(
+      "---",
+      "kind: package",
+      "name: testpkg",
+      "version: 1.0.0",
+      "language: R",
+      "description: Test"
+    ),
+    file.path(proj_dir, "ctx.yaml")
+  )
+
+  result <- local_ctx_sync(dirs = proj_dir, cache_dir = cache_dir, dry_run = TRUE)
+
+  # No files should be written to cache
+  cache_files <- list.files(cache_dir, pattern = "\\.ctx\\.yaml$")
+  expect_equal(length(cache_files), 0L)
+  expect_equal(result$action, "dry_run")
+})
+
+test_that("local_ctx_sync dry_run=FALSE copies file to central cache", {
+  proj_dir  <- withr::local_tempdir()
+  cache_dir <- withr::local_tempdir()
+
+  writeLines(
+    c(
+      "---",
+      "kind: package",
+      "name: writepkg",
+      "version: 0.3.1",
+      "language: R",
+      "description: Write test"
+    ),
+    file.path(proj_dir, "ctx.yaml")
+  )
+
+  result <- local_ctx_sync(dirs = proj_dir, cache_dir = cache_dir, dry_run = FALSE)
+
+  expect_equal(result$action, "copied")
+  expect_true(file.exists(file.path(cache_dir, "writepkg@0.3.1.ctx.yaml")))
+})
+
+test_that("local_ctx_sync dry_run=FALSE marks 'skipped' when dest is identical", {
+  proj_dir  <- withr::local_tempdir()
+  cache_dir <- withr::local_tempdir()
+
+  ctx_lines <- c(
+    "---",
+    "kind: package",
+    "name: skippkg",
+    "version: 1.0.0",
+    "language: R",
+    "description: Skip test"
+  )
+  src_file  <- file.path(proj_dir, "ctx.yaml")
+  dest_file <- file.path(cache_dir, "skippkg@1.0.0.ctx.yaml")
+  writeLines(ctx_lines, src_file)
+  writeLines(ctx_lines, dest_file)
+
+  result <- local_ctx_sync(dirs = proj_dir, cache_dir = cache_dir, dry_run = FALSE)
+  expect_equal(result$action, "skipped")
+})
+
+test_that("local_ctx_sync aborts if dirs is not a character vector", {
+  expect_error(
+    local_ctx_sync(dirs = 42L),
+    "dirs"
+  )
+})
+
+test_that("local_ctx_sync aborts if dry_run is not a single logical", {
+  expect_error(
+    local_ctx_sync(dry_run = c(TRUE, FALSE)),
+    "dry_run"
+  )
+})
+
+test_that("read_ctx_package_meta extracts name and version from multi-doc yaml", {
+  tmp <- withr::local_tempfile(fileext = ".ctx.yaml")
+  writeLines(
+    c(
+      "---",
+      "kind: context_header",
+      "llm_instructions: test",
+      "---",
+      "kind: package",
+      "name: mypkg",
+      "version: 2.0.0",
+      "language: R",
+      "description: A test",
+      "---",
+      "kind: function",
+      "name: foo"
+    ),
+    tmp
+  )
+  meta <- read_ctx_package_meta(tmp)
+  expect_equal(meta$name, "mypkg")
+  expect_equal(meta$version, "2.0.0")
+})
+
+test_that("read_ctx_package_meta returns NULL for non-existent file", {
+  expect_null(read_ctx_package_meta("/does/not/exist.ctx.yaml"))
+})
+
+test_that("read_ctx_package_meta returns NULL when no kind: package document exists", {
+  tmp <- withr::local_tempfile(fileext = ".ctx.yaml")
+  writeLines(c("---", "kind: function", "name: foo"), tmp)
+  expect_null(read_ctx_package_meta(tmp))
+})
+
+test_that("find_project_ctx_files returns character(0) for non-existent dir", {
+  result <- find_project_ctx_files("/does/not/exist")
+  expect_equal(result, character(0))
+})
+
+test_that("find_project_ctx_files finds ctx.yaml at project root", {
+  proj_dir <- withr::local_tempdir()
+  ctx_file <- file.path(proj_dir, "ctx.yaml")
+  writeLines("---\nkind: package\nname: x\nversion: 0.1.0\n", ctx_file)
+  result <- find_project_ctx_files(proj_dir)
+  expect_true(ctx_file %in% result)
+})


### PR DESCRIPTION
## Summary

- Adds `local_ctx_sync()` to `R/tar_plans/plan_pkgctx.R` — scans registered sibling project directories for `ctx.yaml` files and copies them version-stamped into the central cache (`~/docs_gh/proj/data/llm/content/inst/ctx/external/`)
- Adds three helper functions: `LOCAL_CTX_PROJECTS` constant, `read_ctx_package_meta()` (multi-doc YAML parser), `find_project_ctx_files()` (finds ctx files at project root and in `inst/extdata/ctx/`)
- Wires a `pkgctx_local_sync` target into `plan_pkgctx()` with `cue = tar_cue(mode = "always")` so every `tar_make()` re-syncs
- Adds background `local_ctx_sync()` call to `session_init.sh` alongside existing `ctx_sync("DESCRIPTION")`
- Adds `yaml` to DESCRIPTION Imports

## Function signature + example

```r
local_ctx_sync(
  dirs      = LOCAL_CTX_PROJECTS,  # registered project dirs
  cache_dir = CTX_CACHE,
  dry_run   = TRUE                  # safe default
)
```

```r
# Report what would be synced (no writes):
local_ctx_sync(dry_run = TRUE)
#> ℹ local_ctx_sync: dry_run=TRUE — no files will be written
#> ℹ [dry_run] Would copy historicaldata 0.1.0 → 'historicaldata@0.1.0.ctx.yaml'
#> ℹ [dry_run] Would copy coMMpass 0.1.0 → 'coMMpass@0.1.0.ctx.yaml'
#>   project_dir                                       ctx_src   package        version  dest                      action
#>   <chr>                                             <chr>     <chr>          <chr>    <chr>                     <chr>
#> 1 ~/docs_gh/proj/finance/data/historical            .../ctx.yaml  historicaldata 0.1.0   .../historicaldata@0.1.0… dry_run
#> 2 ~/docs_gh/proj/data/coMMpass                      .../ctx.yaml  coMMpass       0.1.0   .../coMMpass@0.1.0.ctx.… dry_run
```

## Test output

```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 24 ]
```

Tests cover: empty dir → empty tibble; valid ctx.yaml → 1-row tibble; malformed yaml → parse_failed + warning; dry_run=TRUE → no writes; dry_run=FALSE → file copied; identical dest → skipped; input validation; helper unit tests.

## Integration note

The existing `ctx_sync("DESCRIPTION")` call (lines 372, 1006 of session_init.sh) handles CRAN/Bioconductor/GitHub package ctx generation. `local_ctx_sync()` is a complementary concern — it ingests pre-built ctx files from sibling projects. The two calls are independent and run in separate background processes.

Registered projects in `LOCAL_CTX_PROJECTS`: `historical`, `coMMpass`, `mycare`, `irishbuoys`. Add new projects by appending to this constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
