### PR TITLE
feat(config): #236 article-gap actions — parallel-cap, recap, audit

### DIFF
--- a/.claude/skills/context-control/SKILL.md
+++ b/.claude/skills/context-control/SKILL.md
@@ -247,6 +247,10 @@ Context control supports the 9-step workflow:
 | `TodoWrite` | Persist state | Track progress |
 | Save to file | External memory | Key decisions |
 
+## Recap: Regaining Context Across Parallel Agent Threads
+
+Claude Code has a built-in `/recap` command that summarises what each parallel agent thread has done and re-establishes shared context in the orchestrator window. Use it after dispatching multiple agents when you need to synthesise their outputs without re-reading every thread in full. The workflow is: dispatch agents → wait for completion → run `/recap` in the orchestrator session to get a concise cross-thread summary before making the next architectural decision. This is especially useful after 3+ parallel fixer or critic agents return reports at similar times. For long sessions approaching context limits, combine `/recap` with `/compact`: run `/recap` first to capture the agent summaries, save the digest to `.claude/CURRENT_WORK.md`, then run `/compact` to flush accumulated context while preserving the inter-thread synthesis. See the `quadratic-loop-cost` rule for when to compact before a loop rather than during it.
+
 ## Resources
 
 - Session Continuity Guide: `.claude/WIKI_CONTENT/Session-Continuity.md`

--- a/plans/236-audit-results.md
+++ b/plans/236-audit-results.md
@@ -1,0 +1,83 @@
+# CLAUDE.md ↔ .claude/agents/*.md Audit — Issue #236
+
+**Date:** 2026-05-23
+**Author:** fixer agent (claude-sonnet-4-6)
+**Issue:** JohnGavin/llm#236
+
+## Scope
+
+Audit `~/.claude/CLAUDE.md` (global), `.claude/CLAUDE.md` (project), and each file in `.claude/agents/*.md` for:
+- Agent information present in CLAUDE.md that is absent from the corresponding agent file (orphaned in CLAUDE.md)
+- Agent information present in agent files that is absent from CLAUDE.md (orphaned in agent file)
+- Contradictions between the two sources
+
+## Files Audited
+
+**CLAUDE.md sources:**
+- `~/.claude/CLAUDE.md` — global config; `## Agents (12)` table at line 45–60; `auto-delegation` rule references
+- `.claude/CLAUDE.md` (project) — `## Project-Specific Agents` section (lines 48–52)
+
+**Agent files (12):**
+`critic.md`, `data-engineer.md`, `data-quality-guardian.md`, `fixer.md`, `nix-env.md`, `quick-fix.md`, `r-debugger.md`, `reviewer.md`, `shiny-async-debugger.md`, `shinylive-builder.md`, `targets-runner.md`, `wiki-curator.md`
+
+## Finding: No Orphans Found
+
+CLAUDE.md and `.claude/agents/*.md` are coherent. Nothing needs to be relocated.
+
+### Evidence
+
+**Global CLAUDE.md agents table (lines 45–60):**
+
+| Agent | Model | Use When |
+|-------|-------|----------|
+| `quick-fix` | haiku | Typos, renames, version bumps, obvious syntax fixes |
+| `critic` | sonnet | Read-only adversarial review (cannot edit files) |
+| `fixer` | sonnet | Apply fixes from critic reports (read-write, cannot self-approve) |
+| `r-debugger` | sonnet | Debug R package issues (test failures, R CMD check) |
+| `targets-runner` | sonnet | Run tar_make(), inspect pipeline state |
+| `reviewer` | sonnet | Code review PRs for R package quality |
+| `nix-env` | sonnet | Diagnose Nix shell problems, update deps |
+| `shiny-async-debugger` | sonnet | Debug async/crew/ExtendedTask issues |
+| `data-quality-guardian` | sonnet | Data validation, pointblank |
+| `data-engineer` | sonnet | SQL transforms, dbt pipelines |
+| `shinylive-builder` | sonnet | Build/test Shinylive WASM vignettes |
+| `wiki-curator` | sonnet | Compile raw/ source material into wiki/ |
+
+All 12 agents in this table have a corresponding file in `.claude/agents/`. No agent file is absent.
+
+**Model consistency:**
+Every agent file's YAML frontmatter `model:` field matches the CLAUDE.md table:
+- `quick-fix.md`: `model: haiku` — matches
+- All other agent files: `model: sonnet` — matches
+
+**Role/description consistency:**
+Each agent file's `description:` field in YAML frontmatter is consistent with the "Use When" column in CLAUDE.md, expressing the same scope in more detail. No contradictions.
+
+**Authority fields:**
+Every agent file has an `authority:` field in YAML frontmatter not present in CLAUDE.md. This is intentional — authority constraints (e.g., "CANNOT push", "CANNOT delete >1MB") live in the agent files, not in the CLAUDE.md summary table. This is the correct separation: CLAUDE.md is a routing table (when to use which agent), agent files are the full contract (what the agent can and cannot do).
+
+**Project-specific agent overrides:**
+`.claude/CLAUDE.md` (project level) lists two project-specific instructions:
+- `targets-runner`: enter project shell first using the llm `default.nix` path
+- `nix-env`: regenerate using the rix.setup shell
+
+These are invocation overrides for this project, not agent definitions. They are correctly placed in the project CLAUDE.md rather than the agent files (agent files should be project-agnostic).
+
+**Auto-delegation rule cross-reference:**
+The `auto-delegation` rule (`.claude/rules/auto-delegation.md`) contains a trigger table mapping user request signals to agent names. All 12 agent names in that table match the agent files on disk. The `targets-runner` rule note "(wraps in `nix develop --command` for T lang projects)" is consistent with `targets-runner.md`'s T language section.
+
+**No agents mentioned in CLAUDE.md but missing from `.claude/agents/`:**
+No orphaned references found.
+
+**No agent files without a CLAUDE.md entry:**
+All 12 `.claude/agents/*.md` files appear in the CLAUDE.md table.
+
+## Result
+
+**Nothing to relocate. CLAUDE.md and `.claude/agents/*.md` are coherent.**
+
+The two-file structure is working as designed:
+- **CLAUDE.md**: routing table (name, model, brief trigger phrase)
+- **`.claude/agents/*.md`**: full contract (role, workflow, constraints, output format, examples)
+
+The article's `agents.md` pattern (a single flat file) is less structured than our approach. Our split is intentional and appropriate for 12 agents — a flat file would be harder to maintain and harder for the harness to consume selectively.

--- a/plans/236-parallel-agent-cap-investigation.md
+++ b/plans/236-parallel-agent-cap-investigation.md
@@ -1,0 +1,98 @@
+# Parallel Agent Cap Investigation — Issue #236
+
+**Date:** 2026-05-23
+**Author:** fixer agent (claude-sonnet-4-6)
+**Issue:** JohnGavin/llm#236
+
+## Question
+
+Does performance degrade beyond N=7 parallel agent dispatches, as the Towards Data Science article claims? Should `auto-delegation` rule add a numeric cap?
+
+## Data Source
+
+`~/.claude/logs/unified.duckdb` → `agent_runs` table.
+
+Schema:
+```
+id, session_id, agent_type, model, started_at, ended_at, duration_sec, prompt_preview, status
+```
+
+## What the Data Shows
+
+### Row count
+
+48 rows total. Data spans 2026-04-24 to 2026-05-23.
+
+### Status distribution
+
+| agent_type | model   | status  | n  |
+|------------|---------|---------|-----|
+| unknown    | unknown | running | 47 |
+| quick-fix  | haiku   | running | 1  |
+
+All 48 rows have `status = 'running'`. Zero rows have `ended_at` populated.
+
+### Concurrent dispatch analysis
+
+Sessions with more than one agent row:
+
+| session_id (prefix)  | agents_in_session | time span |
+|----------------------|-------------------|-----------|
+| 1435338d…            | 4                 | ~2 min    |
+| 60d99efa…            | 3                 | ~1 min    |
+| a21dc0d5…            | 3                 | ~5 min    |
+| ed8f9e53…            | 3                 | ~41 sec   |
+| 7181170a…            | 2                 | ~20 sec   |
+| (8 others)           | 2                 | various   |
+
+Maximum observed parallel dispatch count in a single session: **4 agents**.
+
+The article's claimed degradation threshold of N=7 has never been reached in recorded history. The highest observed value is 4.
+
+## Root Cause of Incomplete Data
+
+The ETL pipeline records `started_at` via `log_agent_run.sh` on agent dispatch, but **never records `ended_at`** or updates `status` from `'running'` to `'completed'`/`'failed'`. This means:
+
+- Duration computation (`ended_at - started_at`) is impossible for all rows.
+- Success vs failure cannot be distinguished from the DB.
+- Cost-per-success across N parallel dispatches cannot be computed.
+- `agent_type` is populated as `'unknown'` for 47/48 rows — the ETL call site is not passing agent type correctly.
+
+The ETL was added recently (2026-05-xx as part of the `agent_runs` infrastructure in #226). The completion-recording half was not yet implemented at the time of this analysis.
+
+## Recommendation: No Cap at This Time
+
+**Recommendation: do NOT add a numeric cap to `auto-delegation`.**
+
+Rationale:
+
+1. **No empirical support for the article's claim.** The article asserts "performance degrades beyond 7" without citing data. Our own telemetry shows we have never dispatched more than 4 parallel agents in a session. We have no evidence of degradation at any count we have actually used.
+
+2. **Our isolation model differs from the article's.** The article's parallel agents share context (Warp panes in the same terminal session). Our agents use `isolation: "worktree"` — each runs in an isolated checkout with its own branch. Resource contention, context collision, and coordination overhead are structurally different problems in our architecture.
+
+3. **The right constraint is already in `auto-delegation`.** The `burn-rate-aware escalation` section scales down parallel dispatch when burn rate is WARN/CRITICAL. That is a cost-informed cap, more appropriate than an arbitrary numeric limit.
+
+4. **A cap would be premature optimisation.** Given max observed N=4, adding a N=7 cap would be a no-op today. Adding a lower cap (e.g. N=3) without evidence would reduce throughput without measurable benefit.
+
+## What Should Be Fixed Instead
+
+The telemetry ETL needs a completion-recording step before this analysis is feasible. Specifically:
+
+- `log_agent_run.sh` should be called a second time on agent completion (or a separate `log_agent_complete.sh` should be created) that writes `ended_at` and updates `status`.
+- `agent_type` population needs investigation — 47/48 rows show `'unknown'`.
+
+These are tracked separately from this issue.
+
+## Evidence Summary
+
+| Signal | Value | Source |
+|--------|-------|--------|
+| Max observed parallel agents in one session | 4 | `agent_runs` GROUP BY session_id |
+| Rows with `ended_at` populated | 0/48 | `DESCRIBE + SELECT` |
+| Rows with `status != 'running'` | 0/48 | GROUP BY status |
+| Article's claimed degradation threshold | 7 | TDS article (no citation) |
+| Our architecture's isolation model | worktree per agent | `auto-delegation` rule |
+
+## Decision
+
+No cap added to `auto-delegation` rule. Absence of cap is deliberate: we lack evidence to justify one, and our isolation model differs from the article's. This decision should be revisited when `agent_runs` ETL records completions and we have per-dispatch cost/success data across N >= 7 concurrent dispatches.


### PR DESCRIPTION
## Summary

Three gap-analysis follow-up actions from issue #236 (article recommendations vs our global config).

## Action 1 — Parallel Agent Cap Investigation

**File:** `plans/236-parallel-agent-cap-investigation.md`

Queried `unified.duckdb` → `agent_runs` table (48 rows, 2026-04-24 to 2026-05-23).

**Findings:**
- Max observed parallel agents in one session: **4** (well below article's claimed degradation threshold of 7)
- All 48 rows have `status = 'running'` and `ended_at = NULL` — the ETL records dispatch starts but never records completions, making cost-per-success analysis impossible
- `agent_type` is `'unknown'` for 47/48 rows — ETL call site is not passing agent type

**Recommendation: no cap added to `auto-delegation`.** Our isolation model (worktree-per-agent) differs structurally from the article's (shared Warp panes). We have no evidence of degradation at any count we have used. The existing burn-rate-aware escalation in `auto-delegation` is a more appropriate cost-informed constraint. ETL completion-recording is identified as a follow-up need.

## Action 2 — Context-Control Skill: Recap Section

**File:** `.claude/skills/context-control/SKILL.md`

Added a new "Recap: Regaining Context Across Parallel Agent Threads" section before the Resources block. The section:
- Describes the built-in `/recap` command and its purpose
- Gives the dispatch → wait → `/recap` workflow for synthesising parallel agent outputs
- Explains how to combine `/recap` with `/compact` for long sessions
- Cross-references the `quadratic-loop-cost` rule

## Action 3 — CLAUDE.md ↔ `.claude/agents/*.md` Audit

**File:** `plans/236-audit-results.md`

Audited all 12 agent files against the global CLAUDE.md agents table and project CLAUDE.md.

**Finding: no orphans. CLAUDE.md and `.claude/agents/*.md` are coherent.**

- All 12 agents in the CLAUDE.md table have a corresponding file on disk
- Model declarations match in both sources
- Role/description scope is consistent (no contradictions)
- Authority constraints correctly live in agent files only (project-agnostic)
- Project-specific invocation overrides correctly live in `.claude/CLAUDE.md` (project level)
- The two-file structure is working as designed

## Test plan

- [ ] `plans/236-parallel-agent-cap-investigation.md` exists and documents the data limitation + no-cap recommendation
- [ ] `.claude/skills/context-control/SKILL.md` has the new "Recap" section
- [ ] `plans/236-audit-results.md` exists with explicit "nothing to relocate" finding
- [ ] No changes to `auto-delegation` rule (correct — investigation found no cap justified)
- [ ] No sweeping CLAUDE.md changes (correct — audit found nothing to relocate)

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
