### PR TITLE
fix(tests): load plan_pkgctx.R via helper (24/24 tests pass)

### DIFF
--- a/tests/testthat/helper-pkgctx-local-sync.R
+++ b/tests/testthat/helper-pkgctx-local-sync.R
@@ -1,0 +1,17 @@
+# Helper auto-loaded by testthat before any test in this directory.
+#
+# `local_ctx_sync()` and `read_ctx_package_meta()` are defined in
+# `R/tar_plans/plan_pkgctx.R`, a targets-plan file. devtools::load_all()
+# does NOT source plan files, so the functions are unavailable in tests
+# unless we source the plan file explicitly.
+#
+# We source into the global env (default for source() with local = FALSE)
+# so `test_that()` blocks can see the functions through normal R lookup.
+#
+# Tracked in JohnGavin/llm#257 follow-up.
+local({
+  plan_file <- testthat::test_path("..", "..", "R", "tar_plans", "plan_pkgctx.R")
+  if (file.exists(plan_file)) {
+    source(plan_file, local = FALSE)
+  }
+})

--- a/tests/testthat/test-pkgctx-local-sync.R
+++ b/tests/testthat/test-pkgctx-local-sync.R
@@ -1,3 +1,9 @@
+# NOTE: `local_ctx_sync()` and `read_ctx_package_meta()` live in
+# `R/tar_plans/plan_pkgctx.R` — a targets-plan file sourced explicitly,
+# NOT a package function loaded by `devtools::load_all()`.
+# The companion `helper-pkgctx-local-sync.R` sources the plan file into
+# the global env before tests run.
+
 test_that("local_ctx_sync returns empty tibble for directory with no ctx files", {
   empty_dir <- withr::local_tempdir()
   result <- local_ctx_sync(dirs = empty_dir, cache_dir = withr::local_tempdir())


### PR DESCRIPTION
## Problem

PR #257 (merged earlier today) added `local_ctx_sync()` and `read_ctx_package_meta()` to `R/tar_plans/plan_pkgctx.R`. The accompanying test file at `tests/testthat/test-pkgctx-local-sync.R` calls these functions directly:

```r
test_that("local_ctx_sync returns empty tibble ...", {
  result <- local_ctx_sync(dirs = empty_dir, ...)
```

But `R/tar_plans/plan_pkgctx.R` is a **targets-plan file**, not a package R file. `devtools::load_all()` does not source plan files (they're invoked explicitly via `source()` from `_targets.R` or session_init.sh). Result: all 13 tests in this file error with `could not find function "local_ctx_sync"`.

The wave-5 hover-popup PR (#263) flagged these as pre-existing failures in main. They were not introduced by wave 5 — they came in with #257.

## Fix

Two-line, testthat-idiomatic:

1. Add `tests/testthat/helper-pkgctx-local-sync.R`. testthat 3.x auto-sources `helper-*.R` files before tests in that directory.
2. The helper sources `R/tar_plans/plan_pkgctx.R` into the global env, making both functions visible to `test_that()` blocks.
3. Update the test-file header comment to point at the helper.

## Verification

Before:

```
══ Failed ══════════════════════════════════════════════════════════════════════
── 1. Error ('test-pkgctx-local-sync.R:3:3'): local_ctx_sync returns empty ...
Error: could not find function "local_ctx_sync"
... (10 errors before testthat truncates)
```

After:

```
pkgctx-local-sync: ...........................
══ DONE ══════════════════════════════════════
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 24 ]
```

Verified by running `testthat::test_file()` in a fresh worktree off origin/main with this fix applied.

## Why not move the functions to R/ instead?

That's the alternative and may still be the right longer-term move. Reasoning for keeping them in the plan file:

- The companion function `ctx_sync()` (existing, not added by #257) lives in the same plan file and is invoked via `source()` from `session_init.sh`.
- Moving just `local_ctx_sync` while leaving `ctx_sync` in the plan would be inconsistent.
- A bigger refactor to extract both is out of scope for a test-failure hotfix.

If we decide to move them later, the helper file is trivial to delete.

## Origin

Surfaced by #263's pre-existing-regressions note. Tracked separately because #263 is a hover-popup PR and shouldn't claim to fix a different concern.

Fixes the pre-existing failure in main; does NOT close any issue (the underlying #207 is already closed via PR #257).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
