### PR TITLE
fix(backup): switch default BACKUP_ROOT from iCloud (inactive) to Dropbox (active)

### DIFF
--- a/.claude/scripts/unified_duckdb_backup.sh
+++ b/.claude/scripts/unified_duckdb_backup.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# unified_duckdb_backup.sh — WAL-safe daily backup of unified.duckdb to iCloud Drive.
+# unified_duckdb_backup.sh — WAL-safe daily backup of unified.duckdb to Dropbox.
+#
+# Default backup target is Dropbox (`~/Dropbox/Backups/unified_duckdb/`) because
+# Dropbox sync is active on this Mac while iCloud Drive is not (verified via
+# absence of synced content in `~/Library/Mobile Documents/com~apple~CloudDocs/`).
+# Override via `BACKUP_ROOT=...` env var or `--dest DIR` flag.
 #
 # Strategy: DuckDB EXPORT DATABASE (Parquet) — reads a consistent MVCC snapshot
 # while the DB may be live; produces a portable directory of Parquet files +
@@ -7,7 +12,7 @@
 #
 # Flags:
 #   --dry-run   (default) show what would be backed up; no writes
-#   --apply     write backup to iCloud Drive
+#   --apply     write backup to Dropbox (or whatever BACKUP_ROOT resolves to)
 #   --db PATH   override source DB path (default: ~/.claude/logs/unified.duckdb)
 #   --dest DIR  override backup root directory
 #   --prune     delete daily exports older than 30 days and monthly exports older than 365 days
@@ -46,8 +51,10 @@ export _UNIFIED_DUCKDB_BACKUP_DEPTH=$((_DEPTH + 1))
 
 # ── Paths / defaults ──────────────────────────────────────────────────────────
 UNIFIED_DB="${UNIFIED_DB:-${HOME}/.claude/logs/unified.duckdb}"
-ICLOUD_ROOT="${HOME}/Library/Mobile Documents/com~apple~CloudDocs"
-BACKUP_ROOT="${BACKUP_ROOT:-${ICLOUD_ROOT}/Backups/unified_duckdb}"
+# Dropbox sync root — `~/Dropbox` symlinks to `~/Library/CloudStorage/Dropbox`
+# on macOS when the Dropbox client is installed. Override with BACKUP_ROOT.
+DROPBOX_ROOT="${HOME}/Dropbox"
+BACKUP_ROOT="${BACKUP_ROOT:-${DROPBOX_ROOT}/Backups/unified_duckdb}"
 LOGFILE="${HOME}/.claude/logs/unified_duckdb_backup.log"
 DAILY_RETAIN_DAYS=30
 MONTHLY_RETAIN_DAYS=365
@@ -138,7 +145,7 @@ perform_backup() {
   # --apply path: create destination and export
   log "APPLY: exporting $db_path → $dest_dir"
 
-  # iCloud parent may need to exist
+  # Sync-root parent (Dropbox / iCloud / NAS) may need to exist
   mkdir -p "$backup_root"
 
   if [ -d "$dest_dir" ]; then
@@ -351,7 +358,7 @@ Usage: unified_duckdb_backup.sh [--dry-run] [--apply] [--prune]
 
 Flags:
   --dry-run   (default) show what would be backed up; no writes
-  --apply     write backup to iCloud Drive
+  --apply     write backup to Dropbox (or whatever BACKUP_ROOT resolves to)
   --prune     remove daily exports > 30 days, monthly > 365 days
   --db PATH   override source DB (default: ~/.claude/logs/unified.duckdb)
   --dest DIR  override backup root directory

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -22,8 +22,8 @@ All other state in this project is reproducible from git + `tar_make()` / `quart
 
 | Field | Value |
 |---|---|
-| Backup location | `~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/` |
-| Failure domain | iCloud Drive (Apple servers — different from laptop disk) |
+| Backup location | `~/Dropbox/Backups/unified_duckdb/` (override via `BACKUP_ROOT` env var) |
+| Failure domain | Dropbox (Dropbox servers + paired devices — different from laptop disk) |
 | Mechanism | DuckDB `EXPORT DATABASE` (Parquet, ZSTD) — WAL-safe consistent snapshot |
 | Cadence | Daily at 03:00 local time (one hour after roborev ETL at 02:00) |
 | Retention — daily | 30 days |
@@ -31,15 +31,15 @@ All other state in this project is reproducible from git + `tar_make()` / `quart
 | Script | `~/.claude/scripts/unified_duckdb_backup.sh` |
 | launchd plist | `~/.claude/launchd/com.claude.unified-duckdb-backup.plist` |
 
-**RPO (Recovery Point Objective):** 24 hours  
-**RTO (Recovery Time Objective):** 15 minutes (download from iCloud + run restore commands)
+**RPO (Recovery Point Objective):** 24 hours
+**RTO (Recovery Time Objective):** 15 minutes (sync from Dropbox + run restore commands)
 
 ---
 
 ## Backup Layout
 
 ```
-~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/
+~/Dropbox/Backups/unified_duckdb/
   2026-05-23/
     schema.sql         ← DDL for all tables
     agent_runs.parquet
@@ -89,7 +89,7 @@ launchctl list | grep unified-duckdb-backup
 ### Step 1 — Identify the backup to restore from
 
 ```bash
-ls -la ~/Library/Mobile\ Documents/com~apple~CloudDocs/Backups/unified_duckdb/
+ls -la ~/Dropbox/Backups/unified_duckdb/
 ```
 
 Choose the most recent date directory, e.g. `2026-05-23`.
@@ -98,7 +98,7 @@ Choose the most recent date directory, e.g. `2026-05-23`.
 
 ```bash
 # Count the parquet files — should match the number of tables in unified.duckdb
-ls ~/Library/Mobile\ Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23/*.parquet | wc -l
+ls ~/Dropbox/Backups/unified_duckdb/2026-05-23/*.parquet | wc -l
 # Expected: 12
 ```
 
@@ -117,7 +117,7 @@ mv ~/.claude/logs/unified.duckdb \
 duckdb ~/.claude/logs/unified.duckdb
 
 -- Inside the duckdb prompt:
-IMPORT DATABASE '/Users/johngavin/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23';
+IMPORT DATABASE '/Users/johngavin/Dropbox/Backups/unified_duckdb/2026-05-23';
 .quit
 ```
 
@@ -179,7 +179,7 @@ Run quarterly to verify backups are valid:
 ```bash
 # Restore to a temp location
 duckdb /tmp/unified_restore_test.duckdb -c \
-  "IMPORT DATABASE '/Users/johngavin/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/$(ls ~/Library/Mobile\ Documents/com~apple~CloudDocs/Backups/unified_duckdb/ | tail -1)'"
+  "IMPORT DATABASE '/Users/johngavin/Dropbox/Backups/unified_duckdb/$(ls ~/Dropbox/Backups/unified_duckdb/ | tail -1)'"
 
 # Verify counts
 duckdb /tmp/unified_restore_test.duckdb -c \
@@ -226,7 +226,7 @@ If the duckdb binary version differs from the version that wrote the backup, the
 
 ```bash
 # Check the duckdb version used by the backup (recorded in schema.sql)
-head -5 ~/Library/Mobile\ Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23/schema.sql
+head -5 ~/Dropbox/Backups/unified_duckdb/2026-05-23/schema.sql
 
 # Install a matching duckdb version and retry
 ```

--- a/plans/228-unified-duckdb-backup.md
+++ b/plans/228-unified-duckdb-backup.md
@@ -76,14 +76,19 @@ catches the fresh data within one hour. The 24h RPO is acceptable given:
 | GitHub LFS private repo | DIFFERENT — GitHub servers | After push | 1 GB LFS free; DuckDB EXPORT produces ~5 MB parquet per backup |
 | Time Machine (local snapshots) | SAME volume snapshots | N/A | `/Volumes/com.apple.TimeMachine.localsnapshots` is local; not a different failure domain |
 
-**Recommendation:** iCloud Drive. It is already enabled on this machine
-(`~/Library/Mobile Documents/com~apple~CloudDocs/Documents/` exists), provides a
-genuinely different failure domain (Apple servers in a different geographic location),
-syncs automatically without credentials or API keys, and retains deleted files for 30
-days in iCloud trash. A 30-day retention of daily backups requires ~150 MB of iCloud
-storage (12 tables × 30 days × ~400 KB per EXPORT).
+**Recommendation:** Dropbox. The Dropbox client is already installed on this Mac
+(`~/Dropbox -> ~/Library/CloudStorage/Dropbox`), provides a genuinely different
+failure domain (Dropbox servers + any paired devices), syncs automatically without
+extra credentials, and retains deleted files for 30 days (longer with paid plans).
+A 30-day retention of daily backups requires ~150 MB of Dropbox storage (12 tables ×
+30 days × ~400 KB per EXPORT).
 
-Backup path: `~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/YYYY-MM-DD/`
+iCloud Drive was the original recommendation but is NOT active on this Mac — the
+directory `~/Library/Mobile Documents/com~apple~CloudDocs/` exists with only a
+`.DS_Store` and a Desktop symlink (no synced content). Writing there would NOT
+sync anywhere, failing the `backup-architecture` rule.
+
+Backup path: `~/Dropbox/Backups/unified_duckdb/YYYY-MM-DD/`
 
 ---
 
@@ -102,7 +107,7 @@ directory of Parquet files (one per table) plus a `schema.sql` file — human-re
 inspectable with any Parquet reader, and restorable with `IMPORT DATABASE`.
 
 ```sql
-EXPORT DATABASE '~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23'
+EXPORT DATABASE '~/Dropbox/Backups/unified_duckdb/2026-05-23'
   (FORMAT PARQUET, COMPRESSION ZSTD);
 ```
 
@@ -111,7 +116,7 @@ Restore:
 -- Create new db
 duckdb ~/.claude/logs/unified.duckdb.restored
 -- Inside duckdb:
-IMPORT DATABASE '~/Library/Mobile Documents/com~apple~CloudDocs/Backups/unified_duckdb/2026-05-23';
+IMPORT DATABASE '~/Dropbox/Backups/unified_duckdb/2026-05-23';
 ```
 
 ---
@@ -146,11 +151,12 @@ Manual restore test should be performed quarterly:
 | Option | Failure domain | WAL-safe | Automated | Storage | Complexity |
 |---|---|---|---|---|---|
 | `cp` same disk | SAME | No | Yes | Minimal | Minimal |
-| iCloud `EXPORT DATABASE` daily | DIFFERENT | **Yes** | **Yes** (launchd) | ~150 MB/month | Low |
+| **Dropbox `EXPORT DATABASE` daily** | **DIFFERENT** | **Yes** | **Yes** (launchd) | **~150 MB/month** | **Low** |
+| iCloud `EXPORT DATABASE` daily | DIFFERENT (but iCloud sync not active on this Mac) | Yes | Yes | ~150 MB/month | Low (but inactive — would silently fail) |
 | B2 `EXPORT DATABASE` daily | DIFFERENT | Yes | Yes | ~150 MB/month | Medium (API keys) |
-| External drive | DIFFERENT (when connected) | Yes | Partial | Unlimited | Low |
+| External drive (Passport) | DIFFERENT (when connected) | Yes | Partial | Unlimited | Low (already TM-registered) |
 
-**Selected option:** iCloud Drive + `EXPORT DATABASE` (Parquet) + daily at 03:00 +
+**Selected option:** Dropbox + `EXPORT DATABASE` (Parquet) + daily at 03:00 +
 30-day daily retention + 12-month monthly retention. Implemented in
 `.claude/scripts/unified_duckdb_backup.sh` and scheduled via
 `.claude/launchd/com.claude.unified-duckdb-backup.plist`.


### PR DESCRIPTION
## Problem

PR #256 set the default backup target to iCloud Drive based on `~/Library/Mobile Documents/com~apple~CloudDocs/` existing. That directory exists on all macOS installs by default — but on this Mac **iCloud Drive sync is not active**. The dir contents:

```
$ ls -la ~/Library/Mobile\ Documents/com~apple~CloudDocs/
.DS_Store
Desktop -> /Users/johngavin/Desktop
```

No synced files, no Documents folder pointing INTO iCloud. Backups written there would NOT replicate anywhere → silently fails the `backup-architecture` rule's "different failure domain" requirement.

## Fix

Switch the default `BACKUP_ROOT` to **Dropbox**, which IS active on this Mac:

```
$ ls -la ~/Dropbox
~/Dropbox -> ~/Library/CloudStorage/Dropbox
```

Dropbox provides a genuine different-failure-domain target (Dropbox servers + paired devices).

### Changes

| File | Change |
|---|---|
| `.claude/scripts/unified_duckdb_backup.sh` | `ICLOUD_ROOT` → `DROPBOX_ROOT`, default points at `~/Dropbox/Backups/unified_duckdb/`; header comment + `--help` + flag docs updated; rationale comment notes "iCloud not active" so future agents don't re-make the same assumption |
| `plans/228-unified-duckdb-backup.md` | Recommendation flipped; iCloud row in comparison table marked "would silently fail" with explanation |
| `RECOVERY.md` | Backup location, failure-domain description, restore commands all point at `~/Dropbox/Backups/unified_duckdb/` |

### Override still supported

```bash
BACKUP_ROOT=/some/other/path ~/.claude/scripts/unified_duckdb_backup.sh --apply
# or
~/.claude/scripts/unified_duckdb_backup.sh --apply --dest /some/other/path
```

## Verification

- `bash -n unified_duckdb_backup.sh` → exit 0
- `SELFTEST=1 bash unified_duckdb_backup.sh` → **10/10 PASS**
- Dry-run smoke test: `dest=/Users/johngavin/Dropbox/Backups/unified_duckdb` ✓
- `~/Dropbox` resolves (symlink to `~/Library/CloudStorage/Dropbox`) ✓

## Why iCloud wasn't caught earlier

The #228 agent saw the directory exist and assumed sync. Future safeguard: the rationale comment in `unified_duckdb_backup.sh` now explicitly notes the verification check (synced-content absence) so any subsequent agent that wants to flip back to iCloud has to grapple with that evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
