### PR TITLE
fix(etl): record agent_runs completion + agent_type (#270)

### DIFF
--- a/.claude/hooks/log_agent_run.sh
+++ b/.claude/hooks/log_agent_run.sh
@@ -1,29 +1,59 @@
 #!/usr/bin/env bash
-# log_agent_run.sh — Log agent spawns to unified DuckDB
-# Hook: PostToolUse (Agent)
-# Captures agent type, model from tool input JSON
-
-set -euo pipefail
+# log_agent_run.sh — Log agent dispatch + completion to unified DuckDB.
+# Hook: wired to BOTH PreToolUse(Agent) and PostToolUse(Agent) in settings.json.
+#   PreToolUse  -> agent_start (status='running', captures started_at)
+#   PostToolUse -> agent_stop  (sets ended_at, duration, status done/failed)
+# Reads the hook payload as JSON on stdin (modern interface); falls back to
+# CLAUDE_TOOL_INPUT env (legacy). ALWAYS exits 0 — must never block dispatch.
+set -uo pipefail   # deliberately NOT -e
 
 _log_script="$HOME/.claude/scripts/log_session.sh"
 [ -x "$_log_script" ] || exit 0
 [ -f "$HOME/.claude/logs/.current_session" ] || exit 0
-
 _sid=$(cat "$HOME/.claude/logs/.current_session" 2>/dev/null || echo "")
 [ -n "$_sid" ] || exit 0
 
-# Claude sets CLAUDE_TOOL_INPUT as JSON for PostToolUse hooks
-_input="${CLAUDE_TOOL_INPUT:-}"
-if [ -n "$_input" ]; then
-  _agent_type=$(echo "$_input" | grep -o '"subagent_type":"[^"]*"' | cut -d'"' -f4 || echo "general-purpose")
-  _model=$(echo "$_input" | grep -o '"model":"[^"]*"' | cut -d'"' -f4 || echo "inherited")
-  _desc=$(echo "$_input" | grep -o '"description":"[^"]*"' | cut -d'"' -f4 || echo "")
+_input=$(cat 2>/dev/null || echo "")   # consume stdin once
+
+_jq() { echo "$_input" | jq -r "$1" 2>/dev/null || echo ""; }
+
+if [ -n "$_input" ] && command -v jq >/dev/null 2>&1; then
+  _event=$(_jq '.hook_event_name // empty')
+  _agent_type=$(_jq '.tool_input.subagent_type // empty')
+  _model=$(_jq '.tool_input.model // empty')
+  _desc=$(_jq '.tool_input.description // empty')
+  _tuid=$(_jq '.tool_use_id // empty')
+  _is_err=$(_jq '.tool_response.is_error // empty')
 else
-  _agent_type="unknown"
-  _model="unknown"
-  _desc=""
+  _event=""
+  _legacy="${CLAUDE_TOOL_INPUT:-}"
+  _agent_type=$(echo "$_legacy" | grep -o '"subagent_type":"[^"]*"' | cut -d'"' -f4)
+  _model=$(echo "$_legacy" | grep -o '"model":"[^"]*"' | cut -d'"' -f4)
+  _desc=$(echo "$_legacy" | grep -o '"description":"[^"]*"' | cut -d'"' -f4)
+  _tuid=""
+  _is_err=""
 fi
 
-"$_log_script" agent_start "$_sid" "$(basename "$(pwd)")" "$_desc" "$_agent_type" "$_model" 2>/dev/null || true
+[ -n "$_agent_type" ] || _agent_type="general-purpose"
+[ -n "$_model" ] || _model="inherited"
+_proj="$(basename "$(pwd)")"
 
+case "$_event" in
+  PreToolUse)
+    "$_log_script" agent_start "$_sid" "$_proj" "$_desc" "$_agent_type" "$_model" "$_tuid" 2>/dev/null || true
+    ;;
+  PostToolUse)
+    _status="done"
+    if [ -n "$_is_err" ] && [ "$_is_err" != "false" ]; then _status="failed"; fi
+    "$_log_script" agent_stop "$_sid" "$_proj" "$_desc" "$_agent_type" "$_status" "$_tuid" 2>/dev/null || true
+    ;;
+  *)
+    # Event undeterminable (legacy single-wiring or missing field): record the
+    # dispatch as a completed run so agent_type is at least captured. Log the
+    # raw payload to a debug file to inform future hardening.
+    echo "$(date '+%F %T') unknown-event payload=$(echo "$_input" | head -c 300)" \
+      >> "$HOME/.claude/logs/agent_hook_debug.log" 2>/dev/null || true
+    "$_log_script" agent_stop "$_sid" "$_proj" "$_desc" "$_agent_type" "done" "$_tuid" 2>/dev/null || true
+    ;;
+esac
 exit 0

--- a/.claude/scripts/backfill_agent_runs_270.sh
+++ b/.claude/scripts/backfill_agent_runs_270.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# backfill_agent_runs_270.sh — One-time heuristic backfill for issue #270.
+#
+# Heuristic for ended_at (computed per session, ordered by started_at using LEAD):
+#   1. If there is a next agent_runs row in the same session:
+#        ended_at = LEAST(next_started_at, started_at + 600s)
+#   2. Else if sessions.ended_at exists and is after started_at:
+#        ended_at = LEAST(sessions.ended_at, started_at + 600s)
+#   3. Else:
+#        ended_at = started_at + 60s
+#
+# Uses a CTE with LEAD() for next-row look-ahead. CASE (not COALESCE+LEAST)
+# handles NULL fallthrough correctly.
+#
+# Idempotent: only touches rows where status='running' AND (backfilled IS NULL
+# OR backfilled=false). Safe to re-run.
+#
+# Usage: backfill_agent_runs_270.sh [db_path]
+#   Default db_path: ~/.claude/logs/unified.duckdb
+#
+# Do NOT run against the live DB without orchestrator approval — test only.
+
+set -uo pipefail
+
+DB="${1:-$HOME/.claude/logs/unified.duckdb}"
+
+if [ ! -f "$DB" ]; then
+  echo "ERROR: DB not found: $DB" >&2
+  exit 1
+fi
+
+TS=$(date '+%Y%m%d_%H%M%S')
+BACKUP="${DB}.pre270.${TS}.bak"
+
+echo "Backing up $DB -> $BACKUP"
+cp -a "$DB" "$BACKUP"
+echo "Backup created."
+
+echo "Running migration ALTERs..."
+duckdb "$DB" -c "
+  ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS tool_use_id VARCHAR;
+  ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS backfilled BOOLEAN DEFAULT false;
+"
+
+echo "Running backfill..."
+duckdb "$DB" -c "
+  WITH windowed AS (
+    SELECT
+      ar.id,
+      ar.started_at,
+      ar.session_id,
+      LEAD(ar.started_at) OVER (
+        PARTITION BY ar.session_id ORDER BY ar.started_at
+      ) AS next_started_at,
+      s.ended_at AS sess_ended_at
+    FROM agent_runs ar
+    LEFT JOIN sessions s ON s.session_id = ar.session_id
+    WHERE ar.status = 'running'
+      AND (ar.backfilled IS NULL OR ar.backfilled = false)
+  )
+  UPDATE agent_runs
+  SET
+    ended_at = CASE
+      WHEN w.next_started_at IS NOT NULL
+        THEN LEAST(w.next_started_at, w.started_at + INTERVAL 600 SECOND)
+      WHEN w.sess_ended_at IS NOT NULL AND w.sess_ended_at > w.started_at
+        THEN LEAST(w.sess_ended_at, w.started_at + INTERVAL 600 SECOND)
+      ELSE
+        w.started_at + INTERVAL 60 SECOND
+    END,
+    duration_sec = EXTRACT(EPOCH FROM (
+      CASE
+        WHEN w.next_started_at IS NOT NULL
+          THEN LEAST(w.next_started_at, w.started_at + INTERVAL 600 SECOND)
+        WHEN w.sess_ended_at IS NOT NULL AND w.sess_ended_at > w.started_at
+          THEN LEAST(w.sess_ended_at, w.started_at + INTERVAL 600 SECOND)
+        ELSE
+          w.started_at + INTERVAL 60 SECOND
+      END - w.started_at
+    )),
+    status = 'done',
+    backfilled = true
+  FROM windowed w
+  WHERE agent_runs.id = w.id;
+"
+
+echo ""
+echo "Summary after backfill:"
+duckdb "$DB" -c "
+  SELECT status, backfilled, COUNT(*) AS n
+  FROM agent_runs
+  GROUP BY status, backfilled
+  ORDER BY status, backfilled;
+"

--- a/.claude/scripts/log_session.sh
+++ b/.claude/scripts/log_session.sh
@@ -56,25 +56,48 @@ case "$ACTION" in
   agent_start)
     AGENT_TYPE="${5:-unknown}"
     MODEL="${6:-unknown}"
+    TOOL_USE_ID="${7:-}"
     duckdb "$DB" -c "
-      INSERT INTO agent_runs (session_id, agent_type, model, started_at, prompt_preview, status)
+      INSERT INTO agent_runs (session_id, agent_type, model, started_at, prompt_preview, status, tool_use_id)
       VALUES ('$SESSION_ID', '$AGENT_TYPE', '$MODEL', current_timestamp,
-              '$(echo "$SUMMARY" | head -c 200 | sed "s/'/''/g")', 'running');
+              '$(echo "$SUMMARY" | head -c 200 | sed "s/'/''/g")', 'running',
+              NULLIF('$TOOL_USE_ID',''));
     " 2>/dev/null || true
     ;;
   agent_stop)
     AGENT_TYPE="${5:-unknown}"
-    STATUS="${6:-completed}"
-    duckdb "$DB" -c "
-      UPDATE agent_runs
-      SET ended_at = current_timestamp,
-          duration_sec = EXTRACT(EPOCH FROM (current_timestamp - started_at)),
-          status = '$STATUS'
-      WHERE session_id = '$SESSION_ID'
-        AND agent_type = '$AGENT_TYPE'
-        AND status = 'running'
-      ORDER BY started_at DESC LIMIT 1;
-    " 2>/dev/null || true
+    STATUS="${6:-done}"
+    TOOL_USE_ID="${7:-}"
+    PROMPT_PV="$(echo "$SUMMARY" | head -c 200 | sed "s/'/''/g")"
+    # Helper: strip duckdb timing/loading noise, keep only real data lines
+    _dq_filter() {
+      grep -v '^Run Time' | grep -v '^loaded ' | grep -v '^memory:' \
+        | grep -v '^unified:' | grep -v '^backfill_test:' | grep -v '^$'
+    }
+    _hit=""
+    if [ -n "$TOOL_USE_ID" ]; then
+      _hit=$(duckdb "$DB" -noheader -list -c "
+        UPDATE agent_runs SET ended_at=current_timestamp,
+          duration_sec=EXTRACT(EPOCH FROM (current_timestamp-started_at)), status='$STATUS'
+        WHERE tool_use_id='$TOOL_USE_ID' AND status='running' RETURNING id;" 2>/dev/null \
+        | _dq_filter || echo "")
+    fi
+    if [ -z "$_hit" ]; then
+      _hit=$(duckdb "$DB" -noheader -list -c "
+        UPDATE agent_runs SET ended_at=current_timestamp,
+          duration_sec=EXTRACT(EPOCH FROM (current_timestamp-started_at)), status='$STATUS'
+        WHERE id=(SELECT id FROM agent_runs WHERE session_id='$SESSION_ID'
+          AND agent_type='$AGENT_TYPE' AND status='running'
+          ORDER BY started_at DESC LIMIT 1) RETURNING id;" 2>/dev/null \
+        | _dq_filter || echo "")
+    fi
+    if [ -z "$_hit" ]; then
+      duckdb "$DB" -c "
+        INSERT INTO agent_runs (session_id, agent_type, model, started_at, ended_at,
+          duration_sec, prompt_preview, status, tool_use_id)
+        VALUES ('$SESSION_ID','$AGENT_TYPE','inherited',current_timestamp,
+          current_timestamp,0,'$PROMPT_PV','$STATUS',NULLIF('$TOOL_USE_ID',''));" 2>/dev/null || true
+    fi
     ;;
   *)
     echo "Usage: log_session.sh start|stop|error|hook|agent_start|agent_stop [session_id] [project] [summary] [extra_args...]" >&2

--- a/.claude/scripts/migrate_agent_runs_270.sql
+++ b/.claude/scripts/migrate_agent_runs_270.sql
@@ -1,0 +1,3 @@
+-- Migration for #270: additive columns on agent_runs. Idempotent.
+ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS tool_use_id VARCHAR;
+ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS backfilled BOOLEAN DEFAULT false;

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -556,6 +556,16 @@
                         "timeout": 5
                     }
                 ]
+            },
+            {
+                "matcher": "Agent",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "~/.claude/hooks/log_agent_run.sh",
+                        "timeout": 5
+                    }
+                ]
             }
         ],
         "PostToolUse": [

--- a/.claude/tests/test_agent_run_hook.sh
+++ b/.claude/tests/test_agent_run_hook.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# test_agent_run_hook.sh — Hermetic tests for log_agent_run.sh + log_session.sh
+# Tests use a temp HOME so the hook's hardcoded $HOME/.claude/... paths are safe.
+# Requires: duckdb, jq on PATH.
+
+set -uo pipefail
+
+WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$WT/.claude/hooks/log_agent_run.sh"
+LOG_SCRIPT="$WT/.claude/scripts/log_session.sh"
+BACKFILL="$WT/.claude/scripts/backfill_agent_runs_270.sh"
+
+PASS=0
+FAIL=0
+
+# duckdb in this environment prints timing/loading noise to stdout; strip it.
+# We keep only lines that look like actual data (not "Run Time", "loaded ...", "unified:", etc.)
+dq() {
+  local db="$1" sql="$2"
+  duckdb "$db" -noheader -list -c "$sql" 2>/dev/null \
+    | grep -v '^Run Time' \
+    | grep -v '^loaded ' \
+    | grep -v '^memory:' \
+    | grep -v '^unified:' \
+    | grep -v '^backfill_test:' \
+    | grep -v '^$'
+}
+
+assert() {
+  local desc="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "        expected: [$expected]"
+    echo "        got:      [$result]"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_nonempty() {
+  local desc="$1" result="$2"
+  if [ -n "$result" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected non-empty, got empty)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_empty() {
+  local desc="$1" result="$2"
+  if [ -z "$result" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected empty, got [$result])"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Setup temp HOME
+# --------------------------------------------------------------------------
+T=$(mktemp -d)
+mkdir -p "$T/.claude/logs"
+mkdir -p "$T/.claude/scripts"
+mkdir -p "$T/.claude/hooks"
+
+cp "$LOG_SCRIPT" "$T/.claude/scripts/log_session.sh"
+chmod +x "$T/.claude/scripts/log_session.sh"
+cp "$HOOK" "$T/.claude/hooks/log_agent_run.sh"
+chmod +x "$T/.claude/hooks/log_agent_run.sh"
+
+TESTDB="$T/.claude/logs/unified.duckdb"
+
+# Create minimal schema
+duckdb "$TESTDB" -c "
+  CREATE SEQUENCE IF NOT EXISTS agent_seq START 1;
+  CREATE TABLE IF NOT EXISTS agent_runs (
+    id INTEGER DEFAULT nextval('agent_seq'),
+    session_id VARCHAR,
+    agent_type VARCHAR DEFAULT 'unknown',
+    model VARCHAR DEFAULT 'inherited',
+    started_at TIMESTAMP DEFAULT current_timestamp,
+    ended_at TIMESTAMP,
+    duration_sec DOUBLE,
+    prompt_preview VARCHAR,
+    status VARCHAR DEFAULT 'running',
+    tool_use_id VARCHAR,
+    backfilled BOOLEAN DEFAULT false
+  );
+  CREATE TABLE IF NOT EXISTS sessions (
+    session_id VARCHAR PRIMARY KEY,
+    project VARCHAR,
+    started_at TIMESTAMP DEFAULT current_timestamp,
+    ended_at TIMESTAMP,
+    duration_min DOUBLE,
+    summary VARCHAR
+  );
+  INSERT INTO sessions (session_id, project, started_at)
+  VALUES ('test-session', 'test-proj', current_timestamp);
+" 2>/dev/null
+
+echo "test-session" > "$T/.claude/logs/.current_session"
+
+echo ""
+echo "=== Test group 1: PreToolUse -> agent_start ==="
+
+PRE_PAYLOAD='{"hook_event_name":"PreToolUse","tool_name":"Agent","tool_use_id":"toolu_TEST1","tool_input":{"subagent_type":"fixer","model":"sonnet","description":"demo"}}'
+
+printf '%s' "$PRE_PAYLOAD" | HOME="$T" bash "$T/.claude/hooks/log_agent_run.sh"
+
+ROW_COUNT=$(dq "$TESTDB" "SELECT COUNT(*) FROM agent_runs;")
+assert "PreToolUse: exactly 1 row inserted" "$ROW_COUNT" "1"
+
+AGENT_TYPE=$(dq "$TESTDB" "SELECT agent_type FROM agent_runs WHERE tool_use_id='toolu_TEST1';")
+assert "PreToolUse: agent_type='fixer'" "$AGENT_TYPE" "fixer"
+
+STATUS=$(dq "$TESTDB" "SELECT status FROM agent_runs WHERE tool_use_id='toolu_TEST1';")
+assert "PreToolUse: status='running'" "$STATUS" "running"
+
+TUID=$(dq "$TESTDB" "SELECT tool_use_id FROM agent_runs WHERE tool_use_id='toolu_TEST1';")
+assert "PreToolUse: tool_use_id='toolu_TEST1'" "$TUID" "toolu_TEST1"
+
+# ended_at should be NULL — duckdb prints NULL for null values in -list mode
+ENDED_RAW=$(dq "$TESTDB" "SELECT CAST(ended_at AS VARCHAR) FROM agent_runs WHERE tool_use_id='toolu_TEST1';")
+assert "PreToolUse: ended_at IS NULL" "$ENDED_RAW" "NULL"
+
+echo ""
+echo "=== Test group 2: PostToolUse -> agent_stop (same tool_use_id, no error) ==="
+
+POST_PAYLOAD='{"hook_event_name":"PostToolUse","tool_name":"Agent","tool_use_id":"toolu_TEST1","tool_input":{"subagent_type":"fixer","model":"sonnet","description":"demo"},"tool_response":{"is_error":false}}'
+
+printf '%s' "$POST_PAYLOAD" | HOME="$T" bash "$T/.claude/hooks/log_agent_run.sh"
+
+ROW_COUNT2=$(dq "$TESTDB" "SELECT COUNT(*) FROM agent_runs;")
+assert "PostToolUse: still exactly 1 row (updated, not inserted)" "$ROW_COUNT2" "1"
+
+STATUS2=$(dq "$TESTDB" "SELECT status FROM agent_runs WHERE tool_use_id='toolu_TEST1';")
+assert "PostToolUse: status='done'" "$STATUS2" "done"
+
+ENDED2=$(dq "$TESTDB" "SELECT CAST(ended_at AS VARCHAR) FROM agent_runs WHERE tool_use_id='toolu_TEST1';")
+# ended_at should be a timestamp string, not NULL
+if [ "$ENDED2" != "NULL" ] && [ -n "$ENDED2" ]; then
+  echo "  PASS: PostToolUse: ended_at NOT NULL"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: PostToolUse: ended_at NOT NULL (got: $ENDED2)"
+  FAIL=$((FAIL + 1))
+fi
+
+DURATION=$(dq "$TESTDB" "SELECT CAST(duration_sec AS VARCHAR) FROM agent_runs WHERE tool_use_id='toolu_TEST1';")
+if [ "$DURATION" != "NULL" ] && [ -n "$DURATION" ]; then
+  echo "  PASS: PostToolUse: duration_sec NOT NULL"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: PostToolUse: duration_sec NOT NULL (got: $DURATION)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== Test group 3: PostToolUse with NEW tool_use_id + is_error=true (self-contained INSERT) ==="
+
+POST_ERR='{"hook_event_name":"PostToolUse","tool_name":"Agent","tool_use_id":"toolu_NEWERR","tool_input":{"subagent_type":"r-debugger","model":"sonnet","description":"error run"},"tool_response":{"is_error":true}}'
+
+printf '%s' "$POST_ERR" | HOME="$T" bash "$T/.claude/hooks/log_agent_run.sh"
+
+ROW_COUNT3=$(dq "$TESTDB" "SELECT COUNT(*) FROM agent_runs;")
+assert "Error PostToolUse: 2 rows total (new INSERT)" "$ROW_COUNT3" "2"
+
+STATUS3=$(dq "$TESTDB" "SELECT status FROM agent_runs WHERE tool_use_id='toolu_NEWERR';")
+assert "Error PostToolUse: status='failed'" "$STATUS3" "failed"
+
+ENDED3=$(dq "$TESTDB" "SELECT CAST(ended_at AS VARCHAR) FROM agent_runs WHERE tool_use_id='toolu_NEWERR';")
+if [ "$ENDED3" != "NULL" ] && [ -n "$ENDED3" ]; then
+  echo "  PASS: Error PostToolUse: ended_at NOT NULL"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: Error PostToolUse: ended_at NOT NULL (got: $ENDED3)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== Test group 4: backfill script ==="
+
+BFDIR=$(mktemp -d)
+BFDB="$BFDIR/backfill_test.duckdb"
+
+duckdb "$BFDB" -c "
+  CREATE SEQUENCE IF NOT EXISTS agent_seq2 START 1;
+  CREATE TABLE agent_runs (
+    id INTEGER DEFAULT nextval('agent_seq2'),
+    session_id VARCHAR,
+    agent_type VARCHAR DEFAULT 'unknown',
+    model VARCHAR DEFAULT 'inherited',
+    started_at TIMESTAMP DEFAULT current_timestamp,
+    ended_at TIMESTAMP,
+    duration_sec DOUBLE,
+    prompt_preview VARCHAR,
+    status VARCHAR DEFAULT 'running',
+    tool_use_id VARCHAR,
+    backfilled BOOLEAN DEFAULT false
+  );
+  CREATE TABLE sessions (
+    session_id VARCHAR PRIMARY KEY,
+    project VARCHAR,
+    started_at TIMESTAMP DEFAULT current_timestamp,
+    ended_at TIMESTAMP,
+    duration_min DOUBLE,
+    summary VARCHAR
+  );
+  INSERT INTO sessions VALUES ('sess-A','proj',current_timestamp - INTERVAL 3600 SECOND, current_timestamp - INTERVAL 60 SECOND, 59, 'done');
+  INSERT INTO agent_runs (session_id, agent_type, started_at, status)
+  VALUES
+    ('sess-A','fixer',   current_timestamp - INTERVAL 3600 SECOND, 'running'),
+    ('sess-A','critic',  current_timestamp - INTERVAL 1800 SECOND, 'running'),
+    ('sess-A','reviewer',current_timestamp - INTERVAL 900 SECOND,  'running');
+  INSERT INTO sessions VALUES ('sess-B','proj2',current_timestamp - INTERVAL 500 SECOND, NULL, NULL, NULL);
+  INSERT INTO agent_runs (session_id, agent_type, started_at, status)
+  VALUES ('sess-B','quick-fix', current_timestamp - INTERVAL 500 SECOND, 'running');
+" 2>/dev/null
+
+bash "$BACKFILL" "$BFDB" > /dev/null 2>&1
+
+BF_DONE=$(dq "$BFDB" "SELECT COUNT(*) FROM agent_runs WHERE status='done' AND backfilled=true;")
+assert "Backfill: all 4 rows become done+backfilled" "$BF_DONE" "4"
+
+BF_RUNNING=$(dq "$BFDB" "SELECT COUNT(*) FROM agent_runs WHERE status='running';")
+assert "Backfill: 0 rows still running" "$BF_RUNNING" "0"
+
+BF_ENDED=$(dq "$BFDB" "SELECT COUNT(*) FROM agent_runs WHERE ended_at IS NOT NULL;")
+assert "Backfill: all 4 rows have ended_at NOT NULL" "$BF_ENDED" "4"
+
+# --------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixes #270 — every row in `agent_runs` stuck at `status='running'`, `ended_at=NULL`, `agent_type='unknown'`.

**Root cause (three compounding bugs):**
1. `log_agent_run.sh` was wired as PostToolUse-only but called `agent_start` (never `agent_stop`).
2. It read `CLAUDE_TOOL_INPUT` env var — which is always empty in the modern hook interface that delivers payload on stdin.
3. `log_session.sh` agent_stop used `UPDATE … ORDER BY … LIMIT 1` which DuckDB rejects silently (invalid syntax).

**Two-event hook design:**
- PreToolUse(Agent) → `agent_start`: inserts row with `status='running'`, `tool_use_id` for precise match later.
- PostToolUse(Agent) → `agent_stop`: three-tier update — (1) match by `tool_use_id`, (2) fallback to session+agent_type, (3) self-contained INSERT if no start row exists (e.g. orphaned PostToolUse).

**Schema additions (idempotent):**
- `agent_runs.tool_use_id VARCHAR` — enables precise start/stop pairing.
- `agent_runs.backfilled BOOLEAN DEFAULT false` — marks rows touched by the one-time backfill.

**Files changed:**
- `.claude/hooks/log_agent_run.sh` — rewritten; reads stdin JSON, dispatches on `hook_event_name`
- `.claude/scripts/log_session.sh` — `agent_start` + `agent_stop` cases updated
- `.claude/settings.json` — added PreToolUse(Agent) entry
- `.claude/scripts/migrate_agent_runs_270.sql` — idempotent ALTER TABLEs
- `.claude/scripts/backfill_agent_runs_270.sh` — heuristic backfill with LEAD() window function, backs up DB first
- `.claude/tests/test_agent_run_hook.sh` — 15 hermetic assertions, all pass

**Orchestrator follow-ups after merge (NOT in this PR):**
1. Run `migrate_agent_runs_270.sql` against live `~/.claude/logs/unified.duckdb`.
2. Run `backfill_agent_runs_270.sh` against the live DB.
3. Sync `.claude/hooks/log_agent_run.sh` and `.claude/scripts/log_session.sh` to `~/.claude/` (live location).

## Test plan

- [x] `bash .claude/tests/test_agent_run_hook.sh` — 15 assertions, 0 failures, exit 0
- [x] JSON validity: `jq empty .claude/settings.json` exits 0
- [x] Backfill script tested against temp DuckDB with 4 seeded running rows → all become `done+backfilled`
- [ ] After merge: orchestrator runs live migration + backfill + file sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)