### PR TITLE
refactor(etl): use duckdb -init /dev/null to drop fragile output filter (#270)

### DIFF
--- a/.claude/scripts/backfill_agent_runs_270.sh
+++ b/.claude/scripts/backfill_agent_runs_270.sh
@@ -37,13 +37,13 @@ cp -a "$DB" "$BACKUP"
 echo "Backup created."
 
 echo "Running migration ALTERs..."
-duckdb "$DB" -c "
+duckdb -init /dev/null "$DB" -c "
   ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS tool_use_id VARCHAR;
   ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS backfilled BOOLEAN DEFAULT false;
 "
 
 echo "Running backfill..."
-duckdb "$DB" -c "
+duckdb -init /dev/null "$DB" -c "
   WITH windowed AS (
     SELECT
       ar.id,
@@ -86,7 +86,7 @@ duckdb "$DB" -c "
 
 echo ""
 echo "Summary after backfill:"
-duckdb "$DB" -c "
+duckdb -init /dev/null "$DB" -c "
   SELECT status, backfilled, COUNT(*) AS n
   FROM agent_runs
   GROUP BY status, backfilled

--- a/.claude/scripts/log_session.sh
+++ b/.claude/scripts/log_session.sh
@@ -17,7 +17,7 @@ fi
 
 case "$ACTION" in
   start)
-    duckdb "$DB" -c "
+    duckdb -init /dev/null "$DB" -c "
       INSERT OR REPLACE INTO sessions (session_id, project, started_at, summary)
       VALUES ('$SESSION_ID', '$PROJECT', current_timestamp, '$SUMMARY');
     " 2>/dev/null || true
@@ -29,7 +29,7 @@ case "$ACTION" in
     if [ "$SESSION_ID" = "" ] && [ -f "$HOME/.claude/logs/.current_session" ]; then
       SESSION_ID=$(cat "$HOME/.claude/logs/.current_session")
     fi
-    duckdb "$DB" -c "
+    duckdb -init /dev/null "$DB" -c "
       UPDATE sessions
       SET ended_at = current_timestamp,
           duration_min = EXTRACT(EPOCH FROM (current_timestamp - started_at)) / 60.0,
@@ -40,7 +40,7 @@ case "$ACTION" in
     ;;
   error)
     SOURCE="${5:-unknown}"
-    duckdb "$DB" -c "
+    duckdb -init /dev/null "$DB" -c "
       INSERT INTO errors (session_id, source, error_text, context)
       VALUES ('$SESSION_ID', '$SOURCE', '$(echo "$SUMMARY" | sed "s/'/''/g")', '$PROJECT');
     " 2>/dev/null || true
@@ -48,7 +48,7 @@ case "$ACTION" in
   hook)
     HOOK_NAME="${5:-unknown}"
     EVENT_TYPE="${6:-unknown}"
-    duckdb "$DB" -c "
+    duckdb -init /dev/null "$DB" -c "
       INSERT INTO hook_events (session_id, hook_name, event_type, output_preview)
       VALUES ('$SESSION_ID', '$HOOK_NAME', '$EVENT_TYPE', '$(echo "$SUMMARY" | head -c 200 | sed "s/'/''/g")');
     " 2>/dev/null || true
@@ -57,7 +57,7 @@ case "$ACTION" in
     AGENT_TYPE="${5:-unknown}"
     MODEL="${6:-unknown}"
     TOOL_USE_ID="${7:-}"
-    duckdb "$DB" -c "
+    duckdb -init /dev/null "$DB" -c "
       INSERT INTO agent_runs (session_id, agent_type, model, started_at, prompt_preview, status, tool_use_id)
       VALUES ('$SESSION_ID', '$AGENT_TYPE', '$MODEL', current_timestamp,
               '$(echo "$SUMMARY" | head -c 200 | sed "s/'/''/g")', 'running',
@@ -69,30 +69,23 @@ case "$ACTION" in
     STATUS="${6:-done}"
     TOOL_USE_ID="${7:-}"
     PROMPT_PV="$(echo "$SUMMARY" | head -c 200 | sed "s/'/''/g")"
-    # Helper: strip duckdb timing/loading noise, keep only real data lines
-    _dq_filter() {
-      grep -v '^Run Time' | grep -v '^loaded ' | grep -v '^memory:' \
-        | grep -v '^unified:' | grep -v '^backfill_test:' | grep -v '^$'
-    }
     _hit=""
     if [ -n "$TOOL_USE_ID" ]; then
-      _hit=$(duckdb "$DB" -noheader -list -c "
+      _hit=$(duckdb -init /dev/null "$DB" -noheader -list -c "
         UPDATE agent_runs SET ended_at=current_timestamp,
           duration_sec=EXTRACT(EPOCH FROM (current_timestamp-started_at)), status='$STATUS'
-        WHERE tool_use_id='$TOOL_USE_ID' AND status='running' RETURNING id;" 2>/dev/null \
-        | _dq_filter || echo "")
+        WHERE tool_use_id='$TOOL_USE_ID' AND status='running' RETURNING id;" 2>/dev/null || echo "")
     fi
     if [ -z "$_hit" ]; then
-      _hit=$(duckdb "$DB" -noheader -list -c "
+      _hit=$(duckdb -init /dev/null "$DB" -noheader -list -c "
         UPDATE agent_runs SET ended_at=current_timestamp,
           duration_sec=EXTRACT(EPOCH FROM (current_timestamp-started_at)), status='$STATUS'
         WHERE id=(SELECT id FROM agent_runs WHERE session_id='$SESSION_ID'
           AND agent_type='$AGENT_TYPE' AND status='running'
-          ORDER BY started_at DESC LIMIT 1) RETURNING id;" 2>/dev/null \
-        | _dq_filter || echo "")
+          ORDER BY started_at DESC LIMIT 1) RETURNING id;" 2>/dev/null || echo "")
     fi
     if [ -z "$_hit" ]; then
-      duckdb "$DB" -c "
+      duckdb -init /dev/null "$DB" -c "
         INSERT INTO agent_runs (session_id, agent_type, model, started_at, ended_at,
           duration_sec, prompt_preview, status, tool_use_id)
         VALUES ('$SESSION_ID','$AGENT_TYPE','inherited',current_timestamp,

--- a/.claude/tests/test_agent_run_hook.sh
+++ b/.claude/tests/test_agent_run_hook.sh
@@ -13,17 +13,9 @@ BACKFILL="$WT/.claude/scripts/backfill_agent_runs_270.sh"
 PASS=0
 FAIL=0
 
-# duckdb in this environment prints timing/loading noise to stdout; strip it.
-# We keep only lines that look like actual data (not "Run Time", "loaded ...", "unified:", etc.)
 dq() {
   local db="$1" sql="$2"
-  duckdb "$db" -noheader -list -c "$sql" 2>/dev/null \
-    | grep -v '^Run Time' \
-    | grep -v '^loaded ' \
-    | grep -v '^memory:' \
-    | grep -v '^unified:' \
-    | grep -v '^backfill_test:' \
-    | grep -v '^$'
+  duckdb -init /dev/null "$db" -noheader -list -c "$sql" 2>/dev/null
 }
 
 assert() {
@@ -77,7 +69,7 @@ chmod +x "$T/.claude/hooks/log_agent_run.sh"
 TESTDB="$T/.claude/logs/unified.duckdb"
 
 # Create minimal schema
-duckdb "$TESTDB" -c "
+duckdb -init /dev/null "$TESTDB" -c "
   CREATE SEQUENCE IF NOT EXISTS agent_seq START 1;
   CREATE TABLE IF NOT EXISTS agent_runs (
     id INTEGER DEFAULT nextval('agent_seq'),
@@ -189,7 +181,7 @@ echo "=== Test group 4: backfill script ==="
 BFDIR=$(mktemp -d)
 BFDB="$BFDIR/backfill_test.duckdb"
 
-duckdb "$BFDB" -c "
+duckdb -init /dev/null "$BFDB" -c "
   CREATE SEQUENCE IF NOT EXISTS agent_seq2 START 1;
   CREATE TABLE agent_runs (
     id INTEGER DEFAULT nextval('agent_seq2'),


### PR DESCRIPTION
## Summary

- Replaces the fragile `_dq_filter()` grep pipeline (introduced in #274) with `duckdb -init /dev/null` across all three ETL scripts
- `~/.duckdbrc` is never loaded, so there is no rc-file noise (timer lines, extension-load messages) on stdout
- The test-specific prefix `'^backfill_test:'` is removed from production code in `log_session.sh`
- `dq()` in `test_agent_run_hook.sh` is simplified to a single `duckdb -init /dev/null` call

**Root cause:** `~/.duckdbrc` runs `.timer on` and `LOAD`s several extensions, printing noise lines to stdout. The `_dq_filter()` workaround was grep-based and enumerated known prefixes — fragile by design, and one prefix (`^backfill_test:`) was test-specific cruft that leaked into production.

**Fix:** `duckdb -init /dev/null` skips `~/.duckdbrc` entirely. Verified: `duckdb -init /dev/null -noheader -list -c "SELECT 42;"` prints only `42`.

**Files changed:**
- `.claude/scripts/log_session.sh` — removed `_dq_filter()`, added `-init /dev/null` to all 6 `duckdb` calls
- `.claude/scripts/backfill_agent_runs_270.sh` — added `-init /dev/null` to all 3 `duckdb` calls
- `.claude/tests/test_agent_run_hook.sh` — simplified `dq()`, added `-init /dev/null` to schema setup calls

## Test plan

- [x] `bash .claude/tests/test_agent_run_hook.sh` — `Results: 15 passed, 0 failed`, exit 0
- [x] Confirmed `_dq_filter` and `backfill_test` no longer appear in `log_session.sh`
- [x] Follows up #274 and #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)