### PR TITLE
fix(vignettes): static qr-footer label — unblock Quarto Publish under knitr 1.51 (#278)

### DIFF
--- a/_includes/qr-footer.qmd
+++ b/_includes/qr-footer.qmd
@@ -1,5 +1,5 @@
 ```{r}
-#| label: !expr paste0("qr-footer-", tools::file_path_sans_ext(basename(knitr::current_input(dir = FALSE))))
+#| label: qr-footer
 #| echo: false
 #| message: false
 #| warning: false
@@ -7,11 +7,17 @@
 #| fig.width: 2
 #| fig.height: 2
 #| fig.align: center
-# NOTE: No static explicit label — this partial may be included in any vignette.
-# The label is derived from the vignette filename so each vignette gets a unique
-# chunk label (e.g. qr-footer-telemetry). Including the partial twice in one
-# document will fail loudly with a duplicate-label error rather than silently
-# producing wrong output. See roborev #907.
+# NOTE: Static label `qr-footer`. knitr chunk labels are scoped per-document,
+# so a fixed label never collides across the vignettes that include this
+# partial. Including it twice in ONE document still fails loudly with a
+# duplicate-label error (the desired behaviour) rather than silently producing
+# wrong output. See roborev #907.
+#
+# This previously used `#| label: !expr paste0("qr-footer-", ...)` to derive a
+# per-file label, but knitr 1.51 broke `!expr` labels: parse_block runs a
+# `%in%` duplicate-label check on the raw label BEFORE evaluating `!expr`, so
+# match() receives a language object and aborts with "'match' requires vector
+# arguments", failing Quarto Publish for every vignette. See JohnGavin/llm#278.
 # Vignette URL is derived from the current input file path so this partial
 # can be reused unchanged across every vignette. Renders a centred QR plus
 # the URL as a clickable caption. See #146.


### PR DESCRIPTION
Closes #278.

## Problem

`Quarto Publish` has failed on every push to `main` since ~2026-05-19, blocking the Pages deploy. Latest run dies at file 2/10:

```
processing file: closeread-infrastructure.qmd
Error in match(x, table, nomatch = 0L) : 'match' requires vector arguments
Calls: .main ... split_file -> ... -> parse_block -> %in%
```

## Root cause

CI now installs **knitr 1.51**, which regressed dynamic chunk labels: `parse_block` runs a `%in%` duplicate-label check on the **raw** label *before* evaluating `!expr`, so `match()` receives a language object and aborts. The construct lives in `_includes/qr-footer.qmd` (`#| label: !expr paste0("qr-footer-", ...)`), which is `{{< include >}}`-ed by 9 vignettes — so all of them fail. `index.qmd` survives only because it doesn't include the footer.

## Fix

One line: `#| label: !expr ...` → `#| label: qr-footer` (static). knitr labels are per-document, so a fixed label never collides across vignettes, and a double-include in one document still fails loudly with a duplicate-label error (the partial's original design intent, roborev #907). The label is internal-only (`echo: false`), so output is unchanged.

## Verification (local, knitr 1.51 + quarto 1.8.26)

- Minimal `#| label: !expr ...` repro → `'match' requires vector arguments` (confirms cause)
- Static `#| label: qr-footer` → parses OK
- Two static `qr-footer` labels in one doc → still fails loudly ("Duplicate chunk label")
- `!expr` on `fig-alt` → unaffected (regression is label-specific; `scrolly-config-evolution.qmd` needs no change)
- Full `closeread-infrastructure.qmd` with the include resolved → parses **and** executes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)