### PR TITLE
fix(vignettes): hover-popup-demo uses here:: not pkgload:: (unblock Quarto Publish, cont. #278)

### DIFF
--- a/vignettes/hover-popup-demo.qmd
+++ b/vignettes/hover-popup-demo.qmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(
   warning   = FALSE,
   results   = "asis"
 )
-source(file.path(pkgload::pkg_path(), "R", "hover_popup_helper.R"))
+source(here::here("R", "hover_popup_helper.R"))
 ```
 
 This vignette demonstrates the hover-popup standard introduced in
@@ -87,7 +87,7 @@ Include the shared partial at the top of every vignette that uses `tt()`:
 In a knitr chunk with `results = "asis"`, source the helper and call `tt()`:
 
 ```r
-source(file.path(pkgload::pkg_path(), "R", "hover_popup_helper.R"))
+source(here::here("R", "hover_popup_helper.R"))
 cat(tt(
   "LLM",
   paste0(


### PR DESCRIPTION
Follow-up to #279 (knitr 1.51 parse fix). With the qr-footer parse error cleared, the Quarto Publish build advanced past file 2/10 and surfaced the **next** failure at file 4/10:

```
[ 4/10] vignettes/hover-popup-demo.qmd
Error in `loadNamespace()`: ! there is no package called 'pkgload'
  source(file.path(pkgload::pkg_path(), "R", "hover_popup_helper.R"))
Quitting from hover-popup-demo.qmd:102-111 [setup]
```

## Cause

`pkgload` is a dev-time tool and is **not** in the `quarto-publish.yaml` dependency list. The vignette (added by the hover-popup MVP, #246) used `pkgload::pkg_path()` to locate `R/hover_popup_helper.R`.

## Fix

Both occurrences (setup chunk + doc example) → `source(here::here("R", "hover_popup_helper.R"))`. `here` is already a CI dependency and resolves to the repo root via the DESCRIPTION marker (per the `portable-paths` rule). `tt()` is not exported, so sourcing the helper remains the intended pattern.

## Verification (local)

From the `vignettes/` render dir under the dev shell: `here::here("R", "hover_popup_helper.R")` resolves to the repo-root helper, the file sources, and `tt()` produces the expected `<span class="tt" …>` markup.

Files 1–3 (incl. closeread-infrastructure) already render clean on `main` after #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)