### PR TITLE
fix(self-review): count query logs real number, not 'unknown'

### DIFF
--- a/.claude/scripts/self_review_stage1.sh
+++ b/.claude/scripts/self_review_stage1.sh
@@ -100,7 +100,7 @@ run_write() {
     local status="${PIPESTATUS[0]}"
     if (( status == 0 )); then
         local count
-        count="$(duck_run "${db_path}" -c \
+        count="$(duck_run "${db_path}" -init /dev/null -noheader -list -c \
             "SELECT COUNT(*) FROM self_review_findings_stage1" \
             2>/dev/null | grep -E '^[[:space:]]*[0-9]+' | tr -d ' ' || echo 'unknown')"
         log "INFO: Total cumulative findings in table: ${count}"


### PR DESCRIPTION
## Summary

`run_write()` in `.claude/scripts/self_review_stage1.sh` used a bare `duckdb` call to fetch the cumulative row count after a write. The `~/.duckdbrc` file prints extension-load noise on every startup, so the result landed inside a box-drawn table and the existing `grep -E '^[[:space:]]*[0-9]+'` found nothing, logging `unknown`.

Fix: add `-init /dev/null -noheader -list` to this single COUNT query (matching the `#270` ETL pattern). The dry-run pipe and write redirect are unchanged — they may rely on extensions loaded by `.duckdbrc`.

## Verification

- `bash -n`: clean (no output)
- `SELFTEST=1 bash`: `6 PASS, 0 FAIL`
- Live DB count query: `5` (bare number, no noise)

Refs JohnGavin/llm#235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)