### PR TITLE
fix(self-review): count log survives nix shellHook stdout banner

### DIFF
--- a/.claude/scripts/self_review_stage1.sh
+++ b/.claude/scripts/self_review_stage1.sh
@@ -102,7 +102,7 @@ run_write() {
         local count
         count="$(duck_run "${db_path}" -init /dev/null -noheader -list -c \
             "SELECT COUNT(*) FROM self_review_findings_stage1" \
-            2>/dev/null | grep -E '^[[:space:]]*[0-9]+' | tr -d ' ' || echo 'unknown')"
+            2>/dev/null | grep -oE '[0-9]+' | tail -n1 || echo 'unknown')"
         log "INFO: Total cumulative findings in table: ${count}"
     else
         log "ERROR: SQL execution failed (exit ${status})." >&2


### PR DESCRIPTION
grep anchored to line-start missed the count glued behind the shellHook banner; switch to trailing-digit extraction. Refs JohnGavin/llm#235.