### PR TITLE
fix(roborev): close by job_id not review_id (#312)

### DIFF
--- a/.claude/scripts/roborev_severity_autoclose.sh
+++ b/.claude/scripts/roborev_severity_autoclose.sh
@@ -177,6 +177,29 @@ The code has some issues but nothing specific is flagged here." "$THRESHOLD_FOR_
   _run_case_clean "clean-verdict-prefix" "0" "No issues found. All checks passed." "CLOSE_CLEAN"
   _run_case_clean "findings-verdict-bool-0" "0" "## Review Findings\n- **Severity**: Low" "SKIP"
 
+  # Case 10: job_id field parsing — candidate row with distinct id and job_id
+  # Asserts that field 6 (job_id) is parsed correctly and is NOT equal to field 1 (review_id).
+  # This guards against the regression described in llm#312 where close was called with
+  # rv.id instead of rv.job_id (the two id spaces overlap so the wrong review was closed).
+  _run_case_job_id_parse() {
+    local label="$1"
+    # Construct a tab-separated candidate row: id=100, output=..., root=..., repo=..., verdict=0, job_id=999
+    local _test_row="100	No issues found.	/some/path	testrepo	0	999"
+    local _parsed_id
+    local _parsed_job_id
+    _parsed_id=$(echo "$_test_row" | cut -f1)
+    _parsed_job_id=$(echo "$_test_row" | cut -f6)
+    # job_id must be 999, not 100 (review id)
+    if [ "$_parsed_job_id" = "999" ] && [ "$_parsed_id" = "100" ] && [ "$_parsed_job_id" != "$_parsed_id" ]; then
+      PASS=$((PASS+1))
+      echo "  PASS [$label]: job_id=$_parsed_job_id correctly parsed from field 6 (review_id=$_parsed_id)"
+    else
+      FAIL=$((FAIL+1))
+      echo "  FAIL [$label]: expected job_id=999 review_id=100, got job_id=$_parsed_job_id review_id=$_parsed_id"
+    fi
+  }
+  _run_case_job_id_parse "job_id-field6-parse"
+
   TOTAL=$((PASS+FAIL))
   echo ""
   if [ "$FAIL" -eq 0 ]; then
@@ -633,8 +656,8 @@ fi
 
 # Fetch all open reviews with repo info (both findings and clean verdicts)
 REVIEW_ROWS=()
-while IFS=$'\t' read -r _id _output _root _repo _verdict; do
-  [ -n "$_id" ] && REVIEW_ROWS+=("${_id}	${_output}	${_root}	${_repo}	${_verdict}")
+while IFS=$'\t' read -r _id _output _root _repo _verdict _job_id; do
+  [ -n "$_id" ] && REVIEW_ROWS+=("${_id}	${_output}	${_root}	${_repo}	${_verdict}	${_job_id}")
 done < <(
   /usr/bin/python3 - "$ROBOREV_DB" "$FILTER_REPO" <<'PYEOF'
 import sqlite3, sys
@@ -645,7 +668,7 @@ repo_filter = sys.argv[2] if len(sys.argv) > 2 else ''
 con = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True)
 
 sql = """
-    SELECT rv.id, rv.output, rp.root_path, rp.name, rv.verdict_bool
+    SELECT rv.id, rv.output, rp.root_path, rp.name, rv.verdict_bool, rv.job_id
     FROM reviews rv
     JOIN review_jobs rj ON rj.id = rv.job_id
     JOIN repos rp ON rp.id = rj.repo_id
@@ -663,7 +686,7 @@ rows = con.execute(sql, params).fetchall()
 con.close()
 for row in rows:
     output = (row[1] or '').replace('\t', ' ').replace('\n', ' ')
-    print(f"{row[0]}\t{output}\t{row[2]}\t{row[3]}\t{row[4]}")
+    print(f"{row[0]}\t{output}\t{row[2]}\t{row[3]}\t{row[4]}\t{row[5]}")
 PYEOF
 )
 
@@ -688,6 +711,7 @@ for _row in "${REVIEW_ROWS[@]}"; do
   _root=$(echo "$_row"     | cut -f3)
   _repo=$(echo "$_row"     | cut -f4)
   _verdict=$(echo "$_row"  | cut -f5)
+  _job_id=$(echo "$_row"   | cut -f6)
 
   # Determine effective threshold + source for this repo
   _eff_threshold=""
@@ -727,20 +751,20 @@ for _row in "${REVIEW_ROWS[@]}"; do
     # Clean review: close unconditionally (no threshold check needed)
     if [ "$MODE" = "apply" ]; then
       _close_ok=0
-      if "$ROBOREV_BIN" close "$_id" >/dev/null 2>&1; then
+      if "$ROBOREV_BIN" close "$_job_id" >/dev/null 2>&1; then
         _close_ok=1
       fi
       if [ "$_close_ok" -eq 1 ]; then
         _marker="auto-closed: clean verdict [run:${RUN_TS}]"
-        "$ROBOREV_BIN" comment "$_id" "$_marker" >/dev/null 2>&1 || true
+        "$ROBOREV_BIN" comment "$_job_id" "$_marker" >/dev/null 2>&1 || true
         ACTION="CLOSE_CLEAN"
         TOTAL_CLOSED=$((TOTAL_CLOSED+1))
         CLOSED_BY_REPO["$_repo"]=$(( ${CLOSED_BY_REPO["$_repo"]:-0} + 1 ))
-        log "${ACTION} review_id=${_id} repo=${_repo}"
-        echo "  CLOSE_CLEAN review_id=${_id} repo=${_repo}"
+        log "${ACTION} review_id=${_id} job_id=${_job_id} repo=${_repo}"
+        echo "  CLOSE_CLEAN review_id=${_id} job_id=${_job_id} repo=${_repo}"
       else
-        log "CLOSE_CLEAN_FAIL review_id=${_id} repo=${_repo}"
-        echo "  CLOSE_CLEAN_FAIL review_id=${_id} repo=${_repo} (roborev close failed)"
+        log "CLOSE_CLEAN_FAIL review_id=${_id} job_id=${_job_id} repo=${_repo}"
+        echo "  CLOSE_CLEAN_FAIL review_id=${_id} job_id=${_job_id} repo=${_repo} (roborev close failed)"
         TOTAL_SKIPPED=$((TOTAL_SKIPPED+1))
         SKIPPED_BY_REPO["$_repo"]=$(( ${SKIPPED_BY_REPO["$_repo"]:-0} + 1 ))
       fi
@@ -749,8 +773,8 @@ for _row in "${REVIEW_ROWS[@]}"; do
       ACTION="CLOSE_CLEAN"
       TOTAL_CLOSED=$((TOTAL_CLOSED+1))
       CLOSED_BY_REPO["$_repo"]=$(( ${CLOSED_BY_REPO["$_repo"]:-0} + 1 ))
-      log "DRY_RUN_CLOSE_CLEAN review_id=${_id} repo=${_repo}"
-      echo "  [dry-run] CLOSE_CLEAN review_id=${_id} repo=${_repo}"
+      log "DRY_RUN_CLOSE_CLEAN review_id=${_id} job_id=${_job_id} repo=${_repo}"
+      echo "  [dry-run] CLOSE_CLEAN review_id=${_id} job_id=${_job_id} repo=${_repo}"
     fi
     continue
   fi
@@ -770,23 +794,24 @@ for _row in "${REVIEW_ROWS[@]}"; do
     log "${ACTION} review_id=${_id} repo=${_repo} max_severity=$(_sev_name "$_max_ord") threshold=off source=${_eff_source}"
     echo "  SKIP_THRESHOLD_OFF review_id=${_id} repo=${_repo} max=$(_sev_name "$_max_ord")"
   elif [ "$_max_ord" -le "$_t_ord" ]; then
-    # Close
+    # Close — use job_id for roborev close/comment (fix #312: roborev close expects
+    # job_id not review_id; job:review is 1:1 so this closes exactly the right review)
     if [ "$MODE" = "apply" ]; then
       _close_ok=0
-      if "$ROBOREV_BIN" close "$_id" >/dev/null 2>&1; then
+      if "$ROBOREV_BIN" close "$_job_id" >/dev/null 2>&1; then
         _close_ok=1
       fi
       if [ "$_close_ok" -eq 1 ]; then
         _marker="auto-closed: severity<=${_eff_threshold} [config:${_eff_source}] [run:${RUN_TS}]"
-        "$ROBOREV_BIN" comment "$_id" "$_marker" >/dev/null 2>&1 || true
+        "$ROBOREV_BIN" comment "$_job_id" "$_marker" >/dev/null 2>&1 || true
         ACTION="CLOSE"
         TOTAL_CLOSED=$((TOTAL_CLOSED+1))
         CLOSED_BY_REPO["$_repo"]=$(( ${CLOSED_BY_REPO["$_repo"]:-0} + 1 ))
-        log "${ACTION} review_id=${_id} repo=${_repo} max_severity=$(_sev_name "$_max_ord") threshold=${_eff_threshold} source=${_eff_source}"
-        echo "  CLOSE review_id=${_id} repo=${_repo} max=$(_sev_name "$_max_ord") threshold=${_eff_threshold}"
+        log "${ACTION} review_id=${_id} job_id=${_job_id} repo=${_repo} max_severity=$(_sev_name "$_max_ord") threshold=${_eff_threshold} source=${_eff_source}"
+        echo "  CLOSE review_id=${_id} job_id=${_job_id} repo=${_repo} max=$(_sev_name "$_max_ord") threshold=${_eff_threshold}"
       else
-        log "CLOSE_FAIL review_id=${_id} repo=${_repo}"
-        echo "  CLOSE_FAIL review_id=${_id} repo=${_repo} (roborev close failed)"
+        log "CLOSE_FAIL review_id=${_id} job_id=${_job_id} repo=${_repo}"
+        echo "  CLOSE_FAIL review_id=${_id} job_id=${_job_id} repo=${_repo} (roborev close failed)"
         TOTAL_SKIPPED=$((TOTAL_SKIPPED+1))
         SKIPPED_BY_REPO["$_repo"]=$(( ${SKIPPED_BY_REPO["$_repo"]:-0} + 1 ))
       fi
@@ -795,8 +820,8 @@ for _row in "${REVIEW_ROWS[@]}"; do
       ACTION="CLOSE"
       TOTAL_CLOSED=$((TOTAL_CLOSED+1))
       CLOSED_BY_REPO["$_repo"]=$(( ${CLOSED_BY_REPO["$_repo"]:-0} + 1 ))
-      log "DRY_RUN_CLOSE review_id=${_id} repo=${_repo} max_severity=$(_sev_name "$_max_ord") threshold=${_eff_threshold} source=${_eff_source}"
-      echo "  [dry-run] CLOSE review_id=${_id} repo=${_repo} max=$(_sev_name "$_max_ord") threshold=${_eff_threshold}"
+      log "DRY_RUN_CLOSE review_id=${_id} job_id=${_job_id} repo=${_repo} max_severity=$(_sev_name "$_max_ord") threshold=${_eff_threshold} source=${_eff_source}"
+      echo "  [dry-run] CLOSE review_id=${_id} job_id=${_job_id} repo=${_repo} max=$(_sev_name "$_max_ord") threshold=${_eff_threshold}"
     fi
   else
     ACTION="SKIP_ABOVE_THRESHOLD"


### PR DESCRIPTION
## Summary

Fixes #312 (and the same bug inherited by #311): `roborev_severity_autoclose.sh` was
calling `roborev close <rv.id>` but `roborev close` expects a **job_id**. Because the
two id-spaces overlap, the wrong review was silently closed.

Confirmed safe: job:review is **1:1** across all 4523 jobs in the DB — passing job_id
to `roborev close` closes exactly the intended review, with no sibling over-close risk.

## Changes (4)

1. **Python candidate query** (`SELECT` around line ~648): added `rv.job_id` as the 6th
   column; emitted as field 6 in the tab-separated `print()` f-string.

2. **Bash `while read` + `for _row` loop**: added `_job_id` as the 6th read variable;
   appended to the tab-joined row string; extracted via `cut -f6` in the loop.

3. **Both close branches now use `$_job_id`**:
   - Clean-verdict branch: `roborev close "$_job_id"` and `roborev comment "$_job_id"`
   - Severity-based close branch: same.
   - Log/echo lines retain `review_id=${_id}` for traceability AND add `job_id=${_job_id}`.
   - A code comment in the severity branch explicitly references #312.

4. **Self-test**: added case `job_id-field6-parse` — constructs a candidate row with
   distinct `id=100` / `job_id=999` and asserts field-6 parsing returns `999` (not `100`).

## Self-test output (11/11 PASS)

```
  PASS [pure-High]: got SKIP
  PASS [pure-Medium]: got CLOSE
  PASS [pure-Low]: got CLOSE
  PASS [mixed-High+Medium]: got SKIP
  PASS [mixed-Medium+Low]: got CLOSE
  PASS [no-severity-markers]: got SKIP
  PASS [empty-output]: got SKIP
  PASS [clean-verdict-bool]: got CLOSE_CLEAN
  PASS [clean-verdict-prefix]: got CLOSE_CLEAN
  PASS [findings-verdict-bool-0]: got SKIP
  PASS [job_id-field6-parse]: job_id=999 correctly parsed from field 6 (review_id=100)

11/11 PASS
```

## llm dry-run snippet (showing both review_id= and job_id=)

Selected lines confirming fix (note review_id ≠ job_id throughout, and the
specific case review_id=4521 job_id=4760 that proved the original bug):

```
  [dry-run] CLOSE review_id=33 job_id=34 repo=llm max=low threshold=medium
  [dry-run] CLOSE review_id=175 job_id=304 repo=llm max=medium threshold=medium
  [dry-run] CLOSE_CLEAN review_id=185 job_id=314 repo=llm
  [dry-run] CLOSE_CLEAN review_id=4521 job_id=4760 repo=llm

roborev_severity_autoclose [dry-run]: would-close=223 skip=34 parse-fail=0 (pass --apply to execute)
```

`review_id=4521` has `job_id=4760` — these are distinct, confirming the old code
would have closed job 4521 (a different review) instead of job 4760 (review 4521).

## Verification

- `bash -n`: PASS (no syntax errors)
- Self-test `ROBOREV_SEVAUTOCLOSE_SELFTEST=1`: **11/11 PASS**
- Dry-run `--repo llm` (default mode, no `--apply`): every CLOSE line shows `review_id=` and `job_id=`
- **NO `--apply` was run** — no live DB writes executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
