### PR TITLE
feat(roborev-etl): populate closed_at + close_reason in roborev_review_lifecycle (#310)

### DIFF
--- a/.claude/scripts/roborev_metrics_etl.R
+++ b/.claude/scripts/roborev_metrics_etl.R
@@ -131,18 +131,26 @@ read_con <- tryCatch(
 on.exit(tryCatch(dbDisconnect(read_con, shutdown = TRUE), error = function(e) NULL),
         add = TRUE)
 
-# Install and load SQLite extension
-tryCatch({
-  dbExecute(read_con, "INSTALL sqlite")
-  dbExecute(read_con, "LOAD sqlite")
+# Load SQLite extension.  In DuckDB >= 1.1.0 the sqlite extension is bundled
+# and LOAD succeeds without INSTALL.  INSTALL fetches from the network and may
+# fail in offline environments (launchd jobs, Nix shells without curl).
+# Strategy: try LOAD first; fall back to INSTALL+LOAD only if LOAD fails.
+invisible(tryCatch({
+  tryCatch({
+    invisible(dbExecute(read_con, "LOAD sqlite"))
+  }, error = function(e_load) {
+    # Bundled LOAD failed — try downloading the extension
+    invisible(dbExecute(read_con, "INSTALL sqlite"))
+    invisible(dbExecute(read_con, "LOAD sqlite"))
+  })
 }, error = function(e) {
   graceful_exit(paste("DuckDB sqlite extension unavailable:", conditionMessage(e)))
-})
+}))
 
 # Attach the SQLite DB read-only
 tryCatch({
-  dbExecute(read_con,
-            sprintf("ATTACH '%s' AS src (TYPE sqlite, READ_ONLY)", REVIEWS_DB))
+  invisible(dbExecute(read_con,
+            sprintf("ATTACH '%s' AS src (TYPE sqlite, READ_ONLY)", REVIEWS_DB)))
 }, error = function(e) {
   graceful_exit(paste("cannot attach reviews.db:", conditionMessage(e)))
 })
@@ -178,6 +186,9 @@ tryCatch({
              c("id", "job_id", "closed", "verdict_bool", "output"))
   check_cols(read_con, "src", "repos",
              c("id", "name"))
+  # responses table holds auto-closed marker comments — required for close_reason
+  check_cols(read_con, "src", "responses",
+             c("id", "job_id", "response"))
 }, error = function(e) {
   graceful_exit(paste("Schema validation failed:", conditionMessage(e)))
 })
@@ -224,7 +235,8 @@ sql_reviews <- sprintf("
     rv.closed,
     rv.verdict_bool,
     rv.output,
-    rv.created_at
+    rv.created_at,
+    rv.updated_at
   FROM src.reviews rv
   JOIN src.review_jobs rj ON rj.id = rv.job_id
   JOIN src.repos rp ON rp.id = rj.repo_id
@@ -241,8 +253,35 @@ reviews_raw <- tryCatch(
   }
 )
 
-cat(sprintf("roborev_metrics_etl.R: read %d jobs, %d reviews from reviews.db\n",
-            nrow(jobs_raw), nrow(reviews_raw)))
+# ── Read latest auto-closed marker per job from responses table ───────────
+# Only retrieve the most recent auto-closed: marker per job_id (MAX(id) proxy
+# for latest).  This is the canonical close reason for a review.
+# NOTE: DuckDB sqlite extension reads through WAL automatically; do NOT use
+# RSQLite here as it may miss WAL entries.
+
+sql_markers <- "
+  SELECT
+    rsp.job_id,
+    rsp.response AS marker
+  FROM src.responses rsp
+  WHERE rsp.response LIKE 'auto-closed:%'
+  AND rsp.id IN (
+    SELECT MAX(id) FROM src.responses
+    WHERE response LIKE 'auto-closed:%'
+    GROUP BY job_id
+  )
+"
+
+markers_raw <- tryCatch(
+  dbGetQuery(read_con, sql_markers),
+  error = function(e) {
+    log_msg("WARN: could not query responses (markers): ", conditionMessage(e))
+    data.frame(job_id = integer(), marker = character(), stringsAsFactors = FALSE)
+  }
+)
+
+cat(sprintf("roborev_metrics_etl.R: read %d jobs, %d reviews, %d closure markers from reviews.db\n",
+            nrow(jobs_raw), nrow(reviews_raw), nrow(markers_raw)))
 
 # ── Parse autoclose counter JSON ───────────────────────────────────────────
 
@@ -395,9 +434,59 @@ build_daily_metrics <- function(jobs, reviews) {
   do.call(rbind, result_rows)
 }
 
+# ── Derive close_reason from auto-closed marker text ──────────────────────
+#
+# Priority (applied to the LATEST marker per job):
+#   1. "auto-closed: severity<=<band> ..." → "severity-<band>"  (e.g. "severity-medium")
+#   2. "auto-closed: clean verdict ..." + verdict_bool=1  → "clean-verdict"
+#   3. "auto-closed: clean verdict ..." + verdict_bool=0  → "clean-verdict-pre-fix"
+#      (these were closed by the buggy pre-#311 path that called clean-verdict
+#       on a non-clean review)
+#   4. closed=1, no marker, verdict_bool=1 → "clean-verdict-pre-fix"
+#      (pre-autoclose manual closes of clean reviews)
+#   5. closed=1, no marker, verdict_bool=0 → "manual"
+#      (pre-autoclose manual closes, or closes from before any scripted path)
+#   6. closed=0 → NA (open review)
+#
+# Vocabulary (5 values + NA):
+#   "clean-verdict"       — autoclose: review passed, severity markers absent
+#   "clean-verdict-pre-fix" — autoclose ran but closed a non-clean review (pre-#311),
+#                             OR a clean review closed manually before autoclose existed
+#   "severity-<band>"     — autoclose because max severity <= configured threshold
+#                           band is the literal word: low/medium/high/critical
+#   "manual"              — closed=1, no auto-closed marker, verdict_bool=0
+#   NA                    — open (closed=0)
+
+derive_close_reason <- function(marker, verdict_bool, is_closed) {
+  # marker: character(1) or NA; verdict_bool: integer(1) or NA; is_closed: logical(1)
+  if (!is_closed) return(NA_character_)
+
+  if (!is.na(marker)) {
+    if (grepl("^auto-closed: severity<=", marker, perl = TRUE)) {
+      # Extract band between "severity<=" and the next space/bracket
+      band <- sub("^auto-closed: severity<=(\\w+).*", "\\1", marker, perl = TRUE)
+      return(paste0("severity-", tolower(band)))
+    }
+    if (grepl("^auto-closed: clean verdict", marker, perl = TRUE)) {
+      if (!is.na(verdict_bool) && verdict_bool == 1L) {
+        return("clean-verdict")
+      }
+      return("clean-verdict-pre-fix")
+    }
+    # Unknown marker format — treat as manual
+    return("manual")
+  }
+
+  # No marker at all
+  if (!is.na(verdict_bool) && verdict_bool == 1L) {
+    return("clean-verdict-pre-fix")
+  }
+  "manual"
+}
+
 # ── Build roborev_review_lifecycle ─────────────────────────────────────────
 
-build_review_lifecycle <- function(jobs, reviews) {
+build_review_lifecycle <- function(jobs, reviews, markers) {
   empty_df <- data.frame(
     review_id                    = integer(),
     job_id                       = integer(),
@@ -428,9 +517,37 @@ build_review_lifecycle <- function(jobs, reviews) {
                   drop = FALSE]
   merged <- merge(reviews, jb, by = "job_id", all.x = TRUE)
 
+  # Join the latest closure marker per job (left join — NAs for open/unmarked reviews)
+  if (!is.null(markers) && nrow(markers) > 0L) {
+    merged <- merge(merged, markers, by = "job_id", all.x = TRUE)
+  } else {
+    merged$marker <- NA_character_
+  }
+
   parse_ts <- function(x) {
-    tryCatch(as.POSIXct(x, tz = "UTC", format = "%Y-%m-%d %H:%M:%S"),
-             error = function(e) as.POSIXct(NA_real_, origin = "1970-01-01"))
+    # Handles these timestamp formats (all observed in reviews.db):
+    #   "2026-05-27T18:17:12+01:00"  RFC 3339 with colon offset  → +0100 (after norm)
+    #   "2026-05-27T18:17:12+0100"   ISO 8601 compact offset
+    #   "2026-05-27T13:02:32Z"       UTC shorthand (Z suffix)    → +0000 (after norm)
+    #   "2026-05-27 18:17:12"        plain space-separated (UTC assumed)
+    #
+    # R's %z expects "+HHMM" (no colon).  Normalise before parsing.
+    # IMPORTANT: x is a vector — handle element-by-element fallback.
+    tryCatch({
+      # 1. Replace RFC 3339 colon-offset "+HH:MM" → "+HHMM"
+      x_norm <- sub("([+-][0-9]{2}):([0-9]{2})$", "\\1\\2", x)
+      # 2. Replace trailing "Z" with "+0000"
+      x_norm <- sub("Z$", "+0000", x_norm)
+      # Try ISO 8601 with offset first
+      ts <- as.POSIXct(x_norm, tz = "UTC", format = "%Y-%m-%dT%H:%M:%S%z")
+      # Element-wise fallback: for any position still NA, try space-separated
+      still_na <- which(is.na(ts) & !is.na(x))
+      if (length(still_na) > 0L) {
+        ts_fb <- as.POSIXct(x_norm[still_na], tz = "UTC", format = "%Y-%m-%d %H:%M:%S")
+        ts[still_na] <- ts_fb
+      }
+      ts
+    }, error = function(e) as.POSIXct(NA_real_, origin = "1970-01-01"))
   }
 
   finished <- parse_ts(merged$finished_at)
@@ -444,8 +561,27 @@ build_review_lifecycle <- function(jobs, reviews) {
   severity_max <- vapply(merged$output, parse_max_severity,
                          character(1L), USE.NAMES = FALSE)
 
-  close_reason <- ifelse(!is.na(merged$closed) & merged$closed == 1L,
-                         "manual", NA_character_)
+  # ── Populate closed_at and close_reason ─────────────────────────────────
+  #
+  # closed_at: reviews.updated_at when closed=1.  The autoclose scripts always
+  # touch updated_at when flipping closed=1, so non-null is the norm.  If
+  # updated_at is null or unparseable, fall back to NA (do not fabricate).
+  #
+  # close_reason: derived by derive_close_reason() from the latest marker.
+
+  is_closed <- !is.na(merged$closed) & merged$closed == 1L
+
+  closed_at_raw <- ifelse(is_closed, merged$updated_at, NA_character_)
+  closed_at     <- parse_ts(closed_at_raw)
+
+  close_reason <- mapply(
+    derive_close_reason,
+    marker      = merged$marker,
+    verdict_bool = merged$verdict_bool,
+    is_closed   = is_closed,
+    SIMPLIFY    = TRUE,
+    USE.NAMES   = FALSE
+  )
 
   data.frame(
     review_id                    = as.integer(merged$review_id),
@@ -461,7 +597,7 @@ build_review_lifecycle <- function(jobs, reviews) {
     duration_s                   = duration,
     verdict                      = verdict,
     severity_max                 = severity_max,
-    closed_at                    = as.POSIXct(NA_real_, origin = "1970-01-01"),
+    closed_at                    = closed_at,
     close_reason                 = close_reason,
     autoclose_threshold_at_close = NA_character_,   # Slice 2
     stringsAsFactors             = FALSE
@@ -896,7 +1032,7 @@ build_cadence_efficacy <- function(jobs, poll_log_data, since_date) {
 # ── Build tables ───────────────────────────────────────────────────────────
 
 daily_df     <- build_daily_metrics(jobs_raw, reviews_raw)
-lifecycle_df <- build_review_lifecycle(jobs_raw, reviews_raw)
+lifecycle_df <- build_review_lifecycle(jobs_raw, reviews_raw, markers_raw)
 
 cat(sprintf("roborev_metrics_etl.R: built %d daily_metrics rows, %d lifecycle rows\n",
             nrow(daily_df), nrow(lifecycle_df)))

--- a/tests/testthat/test-roborev-etl-lifecycle.R
+++ b/tests/testthat/test-roborev-etl-lifecycle.R
@@ -1,0 +1,286 @@
+# Tests for roborev_review_lifecycle closed_at + close_reason population.
+# Tracks llm#310.
+#
+# Tests verify:
+#   1. derive_close_reason() logic: all 5 vocabulary values + NA
+#   2. build_review_lifecycle() integration: closed_at / close_reason populated
+#   3. Idempotence: running twice yields identical results
+#   4. No silent NULLs: all closed=1 reviews have non-NA closed_at + close_reason
+#
+# Strategy: source only lines 350-585 of the ETL script (the pure function
+# block — SEVERITY constants + parse_max_severity + derive_close_reason +
+# build_review_lifecycle).  These lines have no I/O side effects.
+
+library(testthat)
+
+# ── Load ETL function block ─────────────────────────────────────────────────
+
+.etl_fn_start <- 358L   # SEVERITY_PATTERN <- line (first assignment, no leading comment)
+.etl_fn_end   <- 605L   # closing } of build_review_lifecycle
+
+etl_script <- file.path(pkgload::pkg_path(),
+                         ".claude", "scripts", "roborev_metrics_etl.R")
+
+skip_if_not(file.exists(etl_script), "ETL script not found at expected path")
+
+all_lines <- readLines(etl_script)
+fn_block  <- all_lines[.etl_fn_start:.etl_fn_end]
+eval(parse(text = paste(fn_block, collapse = "\n")), envir = globalenv())
+
+# ── DuckDB / SQLite fixture ─────────────────────────────────────────────────
+#
+# 7 review cases (see test descriptions for expected close_reason):
+#   rv=1 job=1  closed=1 verdict=1  marker: clean verdict (id=1)      → clean-verdict
+#   rv=2 job=2  closed=1 verdict=0  marker: severity<=medium (id=2)   → severity-medium
+#   rv=3 job=3  closed=1 verdict=0  marker: clean verdict (id=3)      → clean-verdict-pre-fix
+#   rv=4 job=4  closed=1 verdict=1  no marker                         → clean-verdict-pre-fix
+#   rv=5 job=5  closed=1 verdict=0  no marker                         → manual
+#   rv=6 job=6  closed=0 verdict=0  no marker                         → NA (open)
+#   rv=7 job=7  closed=1 verdict=0  two markers; latest=severity<=low → severity-low
+
+make_fixture <- function(dir) {
+  skip_if_not_installed("duckdb")
+  db_path <- file.path(dir, "reviews_fixture.db")
+
+  con <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  DBI::dbExecute(con, "LOAD sqlite")
+  DBI::dbExecute(con, sprintf("ATTACH '%s' AS fix (TYPE sqlite)", db_path))
+
+  DBI::dbExecute(con, "CREATE TABLE fix.repos (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+  DBI::dbExecute(con, "INSERT INTO fix.repos VALUES (1, 'llm')")
+
+  DBI::dbExecute(con, "
+    CREATE TABLE fix.review_jobs (
+      id INTEGER PRIMARY KEY,
+      repo_id INTEGER,
+      agent TEXT DEFAULT 'claude-code',
+      model TEXT,
+      branch TEXT DEFAULT 'main',
+      status TEXT DEFAULT 'done',
+      enqueued_at TEXT,
+      started_at TEXT,
+      finished_at TEXT,
+      source TEXT,
+      token_usage TEXT
+    )
+  ")
+  for (i in 1:7) {
+    DBI::dbExecute(con, sprintf(
+      "INSERT INTO fix.review_jobs (id, repo_id, enqueued_at, started_at, finished_at)
+       VALUES (%d, 1, '2026-05-27 10:00:00', '2026-05-27 10:00:01', '2026-05-27 10:00:10')",
+      i
+    ))
+  }
+
+  DBI::dbExecute(con, "
+    CREATE TABLE fix.reviews (
+      id INTEGER PRIMARY KEY,
+      job_id INTEGER,
+      agent TEXT DEFAULT 'claude-code',
+      prompt TEXT DEFAULT '',
+      output TEXT DEFAULT '',
+      created_at TEXT DEFAULT '2026-05-27 10:00:00',
+      closed INTEGER DEFAULT 0,
+      verdict_bool INTEGER,
+      updated_at TEXT
+    )
+  ")
+  cases <- data.frame(
+    id           = 1:7,
+    job_id       = 1:7,
+    closed       = c(1L, 1L, 1L, 1L, 1L, 0L, 1L),
+    verdict_bool = c(1L, 0L, 0L, 1L, 0L, 0L, 0L),
+    updated_at   = c(
+      "2026-05-27T18:00:00+01:00",
+      "2026-05-27T18:00:00+01:00",
+      "2026-05-27T18:00:00+01:00",
+      "2026-05-27T18:00:00+01:00",
+      "2026-05-27T18:00:00+01:00",
+      NA_character_,
+      "2026-05-27T18:00:00+01:00"
+    ),
+    stringsAsFactors = FALSE
+  )
+  for (i in seq_len(nrow(cases))) {
+    upd <- if (is.na(cases$updated_at[i])) "NULL" else
+      sprintf("'%s'", cases$updated_at[i])
+    DBI::dbExecute(con, sprintf(
+      "INSERT INTO fix.reviews (id, job_id, closed, verdict_bool, updated_at)
+       VALUES (%d, %d, %d, %d, %s)",
+      cases$id[i], cases$job_id[i], cases$closed[i], cases$verdict_bool[i], upd
+    ))
+  }
+
+  DBI::dbExecute(con, "
+    CREATE TABLE fix.responses (
+      id INTEGER PRIMARY KEY,
+      job_id INTEGER,
+      responder TEXT DEFAULT 'autoclose',
+      response TEXT NOT NULL,
+      created_at TEXT DEFAULT '2026-05-27 18:00:00'
+    )
+  ")
+  DBI::dbExecute(con, "INSERT INTO fix.responses VALUES
+    (1, 1, 'autoclose', 'auto-closed: clean verdict [run:2026-05-27T17:00:00Z]', '2026-05-27 18:00:00'),
+    (2, 2, 'autoclose', 'auto-closed: severity<=medium [config:global] [run:2026-05-27T17:00:00Z]', '2026-05-27 18:00:00'),
+    (3, 3, 'autoclose', 'auto-closed: clean verdict [run:2026-05-27T16:00:00Z]', '2026-05-27 17:00:00'),
+    (4, 7, 'autoclose', 'auto-closed: clean verdict [run:2026-05-27T15:00:00Z]', '2026-05-27 16:00:00'),
+    (5, 7, 'autoclose', 'auto-closed: severity<=low [config:global] [run:2026-05-27T17:00:00Z]', '2026-05-27 18:00:00')")
+
+  db_path
+}
+
+read_fixture <- function(db_path) {
+  con <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  DBI::dbExecute(con, "LOAD sqlite")
+  DBI::dbExecute(con, sprintf("ATTACH '%s' AS src (TYPE sqlite, READ_ONLY)", db_path))
+
+  jobs <- DBI::dbGetQuery(con, "
+    SELECT rj.id AS job_id, rp.name AS repo,
+           rj.agent, rj.model, rj.branch, rj.status,
+           rj.enqueued_at, rj.started_at, rj.finished_at, rj.source
+    FROM src.review_jobs rj JOIN src.repos rp ON rp.id = rj.repo_id
+  ")
+  reviews <- DBI::dbGetQuery(con, "
+    SELECT rv.id AS review_id, rv.job_id, rv.closed, rv.verdict_bool,
+           rv.output, rv.created_at, rv.updated_at
+    FROM src.reviews rv
+  ")
+  markers <- DBI::dbGetQuery(con, "
+    SELECT rsp.job_id, rsp.response AS marker
+    FROM src.responses rsp
+    WHERE rsp.response LIKE 'auto-closed:%'
+    AND rsp.id IN (
+      SELECT MAX(id) FROM src.responses
+      WHERE response LIKE 'auto-closed:%'
+      GROUP BY job_id
+    )
+  ")
+  list(jobs = jobs, reviews = reviews, markers = markers)
+}
+
+# ── derive_close_reason unit tests ─────────────────────────────────────────
+
+test_that("derive_close_reason: clean-verdict marker + verdict_bool=1 → clean-verdict", {
+  expect_equal(
+    derive_close_reason("auto-closed: clean verdict [run:2026-05-27T17:00:00Z]", 1L, TRUE),
+    "clean-verdict"
+  )
+})
+
+test_that("derive_close_reason: severity<=medium marker → severity-medium", {
+  expect_equal(
+    derive_close_reason("auto-closed: severity<=medium [config:global] [run:2026-05-27T17:00:00Z]", 0L, TRUE),
+    "severity-medium"
+  )
+})
+
+test_that("derive_close_reason: severity<=low marker → severity-low", {
+  expect_equal(
+    derive_close_reason("auto-closed: severity<=low [config:flag] [run:2026-05-21T19:29:11Z]", 0L, TRUE),
+    "severity-low"
+  )
+})
+
+test_that("derive_close_reason: clean-verdict marker + verdict_bool=0 → clean-verdict-pre-fix", {
+  expect_equal(
+    derive_close_reason("auto-closed: clean verdict [run:2026-05-27T16:00:00Z]", 0L, TRUE),
+    "clean-verdict-pre-fix"
+  )
+})
+
+test_that("derive_close_reason: no marker + verdict_bool=1 → clean-verdict-pre-fix", {
+  expect_equal(derive_close_reason(NA_character_, 1L, TRUE), "clean-verdict-pre-fix")
+})
+
+test_that("derive_close_reason: no marker + verdict_bool=0 → manual", {
+  expect_equal(derive_close_reason(NA_character_, 0L, TRUE), "manual")
+})
+
+test_that("derive_close_reason: open review (is_closed=FALSE) → NA", {
+  expect_equal(
+    derive_close_reason("auto-closed: clean verdict [run:2026-05-27T17:00:00Z]", 1L, FALSE),
+    NA_character_
+  )
+  expect_equal(derive_close_reason(NA_character_, NA_integer_, FALSE), NA_character_)
+})
+
+# ── build_review_lifecycle integration tests ──────────────────────────────
+
+test_that("build_review_lifecycle: all closed=1 have non-null closed_at + close_reason", {
+  skip_if_not_installed("duckdb")
+
+  tmp    <- withr::local_tempdir()
+  db     <- make_fixture(tmp)
+  tables <- read_fixture(db)
+  res    <- build_review_lifecycle(tables$jobs, tables$reviews, tables$markers)
+
+  closed_ids <- tables$reviews$review_id[tables$reviews$closed == 1L]
+  closed_res <- res[res$review_id %in% closed_ids, ]
+
+  expect_true(all(!is.na(closed_res$closed_at)),
+              info = "All closed reviews must have non-null closed_at")
+  expect_true(all(!is.na(closed_res$close_reason)),
+              info = "All closed reviews must have non-null close_reason")
+})
+
+test_that("build_review_lifecycle: correct close_reason per fixture case", {
+  skip_if_not_installed("duckdb")
+
+  tmp    <- withr::local_tempdir()
+  db     <- make_fixture(tmp)
+  tables <- read_fixture(db)
+  res    <- build_review_lifecycle(tables$jobs, tables$reviews, tables$markers)
+
+  get_reason <- function(id) res$close_reason[res$review_id == id]
+
+  expect_equal(get_reason(1L), "clean-verdict",
+               info = "rv1: clean-verdict marker + verdict=1")
+  expect_equal(get_reason(2L), "severity-medium",
+               info = "rv2: severity<=medium marker")
+  expect_equal(get_reason(3L), "clean-verdict-pre-fix",
+               info = "rv3: clean-verdict marker + verdict=0 (pre-#311)")
+  expect_equal(get_reason(4L), "clean-verdict-pre-fix",
+               info = "rv4: no marker + verdict=1")
+  expect_equal(get_reason(5L), "manual",
+               info = "rv5: no marker + verdict=0")
+  expect_true(is.na(get_reason(6L)),
+              info = "rv6: open → NA")
+  expect_equal(get_reason(7L), "severity-low",
+               info = "rv7: latest marker is severity<=low (response id=5 > id=4)")
+})
+
+test_that("build_review_lifecycle: closed_at parsed correctly from TZ-offset timestamp", {
+  skip_if_not_installed("duckdb")
+
+  tmp    <- withr::local_tempdir()
+  db     <- make_fixture(tmp)
+  tables <- read_fixture(db)
+  res    <- build_review_lifecycle(tables$jobs, tables$reviews, tables$markers)
+
+  r1 <- res[res$review_id == 1L, ]
+  expect_false(is.na(r1$closed_at), info = "rv1 closed_at must not be NA")
+  # "2026-05-27T18:00:00+01:00" == 17:00:00 UTC
+  expect_equal(format(r1$closed_at, "%H:%M:%S", tz = "UTC"), "17:00:00",
+               info = "closed_at must be 17:00:00 UTC (18:00 +01:00)")
+
+  r6 <- res[res$review_id == 6L, ]
+  expect_true(is.na(r6$closed_at), info = "rv6 (open) closed_at must be NA")
+})
+
+test_that("build_review_lifecycle: idempotent — two runs produce identical results", {
+  skip_if_not_installed("duckdb")
+
+  tmp    <- withr::local_tempdir()
+  db     <- make_fixture(tmp)
+  tables <- read_fixture(db)
+
+  res1 <- build_review_lifecycle(tables$jobs, tables$reviews, tables$markers)
+  res2 <- build_review_lifecycle(tables$jobs, tables$reviews, tables$markers)
+
+  expect_equal(nrow(res1), nrow(res2))
+  expect_equal(res1$close_reason, res2$close_reason)
+  expect_equal(as.numeric(res1$closed_at), as.numeric(res2$closed_at))
+})


### PR DESCRIPTION
## Summary

- Populates the previously-null `closed_at` and `close_reason` columns in `roborev_review_lifecycle` (Phase 2 of #310)
- Adds `derive_close_reason()` mapping marker text + verdict boolean onto the 5-value vocabulary: `clean-verdict`, `clean-verdict-pre-fix`, `severity-<band>`, `manual`, `NA`
- Handles all 3 timestamp formats stored in `reviews.updated_at`: RFC 3339 `+HH:MM`, UTC `Z` suffix, and plain `YYYY-MM-DD HH:MM:SS` (element-wise fallback)
- ETL is idempotent: re-running replaces existing rows via the existing `INSERT OR REPLACE` / upsert path
- Adds 23 unit + integration tests (23 PASS, 0 FAIL, 0 SKIP)

## Verification (against `/tmp/unified_test.duckdb` copy of live DB)

```sql
SELECT
  COUNT(*) AS total,
  COUNT(closed_at) AS has_closed_at,
  COUNT(close_reason) AS has_close_reason,
  COUNT(CASE WHEN closed = TRUE AND closed_at IS NULL THEN 1 END) AS still_missing
FROM roborev_review_lifecycle;
-- total: 4541 | has_closed_at: 3852 | has_close_reason: 3852 | still_missing: 0

SELECT close_reason, COUNT(*) FROM roborev_review_lifecycle
WHERE closed = TRUE GROUP BY 1 ORDER BY 2 DESC;
-- manual: 2162 | clean-verdict: 802 | severity-medium: 609 | clean-verdict-pre-fix: 279
```

## Test plan

- [x] 23 PASS, 0 FAIL, 0 SKIP (`devtools::test(filter="roborev-etl-lifecycle")`)
- [x] All 5 close_reason vocabulary values covered + NA (open review)
- [x] 7-case SQLite fixture built via DuckDB sqlite extension (no RSQLite dependency)
- [x] Functions loaded from line range 358–605 of ETL (pure block, no I/O side effects)
- [x] Verification query confirms 0 rows with `closed=1` and `closed_at IS NULL`

Closes #310
Related: #226 (closure analytics unblocked), #311, #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)