### PR TITLE
chore(session-stop): end SKIP_SESSION_END_REFINE soak (#202)

### DIFF
--- a/.claude/hooks/session_stop.sh
+++ b/.claude/hooks/session_stop.sh
@@ -185,9 +185,9 @@ _REFINE_SENTINEL="${CLAUDE_RUNTIME_ROOT}/.bye-session-end-refine"
 _REFINE_SCRIPT="$CLAUDE_DIR/scripts/session_end_refine.sh"
 if [ -f "$_REFINE_SENTINEL" ] && [ -x "$_REFINE_SCRIPT" ]; then
   rm -f "$_REFINE_SENTINEL"  # consume sentinel immediately — one-shot
-  # Default SKIP=1 for the first 7 days of soak — per #196 rollout plan.
-  # After 7 days of clean dry-run-equivalent logs, remove the env-var prefix.
-  SKIP_SESSION_END_REFINE=1 nohup "$_REFINE_SCRIPT" >/dev/null 2>&1 &
+  # Soak ended 2026-05-27 (7 days after PR #196 merged 2026-05-20). Prefix removed per #202.
+  # Opt-out: set SKIP_SESSION_END_REFINE=1 before /bye, or add session_end_refine=false to .roborev.toml
+  nohup "$_REFINE_SCRIPT" >/dev/null 2>&1 &
 fi
 
 # ── Entity propagation (projects only) — #137 Phase 3 minimal cut ─────

--- a/.claude/rules/roborev-resolution.md
+++ b/.claude/rules/roborev-resolution.md
@@ -186,16 +186,16 @@ Long-term fix: a periodic poller (tracked in #148) that fetches each watched rep
 
 The session-end refine runs automatically when the user types `/bye`.
 
-### Rollout: SKIP defaulted ON (7-day soak)
+### Rollout: SKIP defaulted ON (7-day soak) — COMPLETE
 
-For the first 7 days after deployment, `session_stop.sh` invokes `session_end_refine.sh` with `SKIP_SESSION_END_REFINE=1` prefixed, so each call exits early with `result=skipped` and only the bookkeeping logs are written. This lets us observe:
+The 7-day soak ran from 2026-05-20 (PR #196 merged) to 2026-05-27. During the soak, `session_stop.sh` invoked `session_end_refine.sh` with `SKIP_SESSION_END_REFINE=1` prefixed so each call exited early with `result=skipped`. The log confirmed:
 
-- That `session_init.sh` Phase 14 wrote the start-SHA file
-- That `session_stop.sh` actually fires the script at /bye
-- That the cwd-detection / project-name sanitisation logic finds the right project
-- That nothing else in `/bye` got slower
+- `session_init.sh` Phase 14 wrote the start-SHA file correctly
+- `session_stop.sh` fired the script at each `/bye`
+- cwd-detection and project-name sanitisation found the right project
+- Nothing in `/bye` became noticeably slower
 
-After 7 clean days, **remove the `SKIP_SESSION_END_REFINE=1` prefix from session_stop.sh** in a follow-up commit. The opt-out env var remains available per-session (set in shell rc files or one-off).
+The `SKIP_SESSION_END_REFINE=1` prefix was removed in PR #202 (merged 2026-05-27). The refine now runs by default at every `/bye`. The opt-out env var remains available per-session.
 
 ### What runs
 


### PR DESCRIPTION
## Summary

- Removes `SKIP_SESSION_END_REFINE=1` prefix from the `nohup` invocation in `.claude/hooks/session_stop.sh` — the 7-day soak (PR #196, merged 2026-05-20) ended on 2026-05-27
- Updates `.claude/rules/roborev-resolution.md` to record that the soak is complete and the refine runs by default

Closes #202.

## What changed

**`.claude/hooks/session_stop.sh`** (lines 188–190):

```diff
-  # Default SKIP=1 for the first 7 days of soak — per #196 rollout plan.
-  # After 7 days of clean dry-run-equivalent logs, remove the env-var prefix.
-  SKIP_SESSION_END_REFINE=1 nohup "$_REFINE_SCRIPT" >/dev/null 2>&1 &
+  # Soak ended 2026-05-27 (7 days after PR #196 merged 2026-05-20). Prefix removed per #202.
+  # Opt-out: set SKIP_SESSION_END_REFINE=1 before /bye, or add session_end_refine=false to .roborev.toml
+  nohup "$_REFINE_SCRIPT" >/dev/null 2>&1 &
```

**`.claude/rules/roborev-resolution.md`**: "Rollout: SKIP defaulted ON (7-day soak)" section updated to record the soak is complete.

## Soak log review

`~/.claude/logs/session_end_refine.log` showed consistent `result=skipped reason=SKIP_SESSION_END_REFINE` entries across 2026-05-20 through 2026-05-27, confirming:
- `session_init.sh` Phase 14 wrote start-SHA files correctly
- `session_stop.sh` fired the script at every `/bye`
- Project-name sanitisation found the right project
- No errors during the dry-run-equivalent path

## Opt-out still works

The consumer logic in `.claude/scripts/session_end_refine.sh` (lines 60–61) is unchanged. Both opt-outs remain functional:

| Mechanism | How | Scope |
|-----------|-----|-------|
| Env var | `SKIP_SESSION_END_REFINE=1` before `/bye` | Session-level |
| TOML flag | `session_end_refine = false` in `.roborev.toml` | Per-project |

## Related

- #202 — this issue
- PR #196 — introduced the soak
