### PR TITLE
ci: bump GH Actions off Node 20 (#281)

### DIFF
--- a/.github/workflows/quarto-publish.yaml
+++ b/.github/workflows/quarto-publish.yaml
@@ -37,7 +37,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -119,7 +119,7 @@ jobs:
           echo "Link check complete"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
@@ -132,4 +132,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/vignette-validation.yml
+++ b/.github/workflows/vignette-validation.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check for vignettes
         id: check-vignettes

--- a/.github/workflows/wiki-sync-check.yaml
+++ b/.github/workflows/wiki-sync-check.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
Closes #281

GitHub Actions will force Node.js 24 by default starting **2026-06-02**, removing
support for Node-20-based actions. This PR bumps all Node-20 actions to their
Node-24-compatible major versions across all three workflows.

## Actions bumped

| Action | Old | New | Node 24 since | Source |
|--------|-----|-----|---------------|--------|
| `actions/checkout` | `@v4` | `@v5` | v5.0.0 | [release notes](https://github.com/actions/checkout/releases/tag/v5.0.0): "Update actions checkout to use node 24" |
| `actions/upload-pages-artifact` | `@v3` | `@v5` | v5.0.0 | [release notes](https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0): wraps `upload-artifact@v7` (Node 24) |
| `actions/deploy-pages` | `@v4` | `@v5` | v5.0.0 | [release notes](https://github.com/actions/deploy-pages/releases/tag/v5.0.0): "Update Node.js version to 24.x" |

## Workflows changed

- `.github/workflows/quarto-publish.yaml` — bumped `checkout@v4→v5`, `upload-pages-artifact@v3→v5`, `deploy-pages@v4→v5`
- `.github/workflows/vignette-validation.yml` — bumped `checkout@v4→v5`
- `.github/workflows/wiki-sync-check.yaml` — bumped `checkout@v4→v5`

## Verification

```
git grep -nE 'actions/(checkout|upload-pages-artifact|deploy-pages)@v[0-9]+' .github/
```

All results now show `@v5`.

No `actions/setup-node`, `actions/cache`, `actions/setup-python`, or `actions/github-script`
are referenced in any workflow — those were not present and did not need bumping.

## Node runtime verification

- `actions/checkout@v4` action.yml: `using: node20` — confirmed deprecated
- `actions/checkout@v5` action.yml: `using: node24` — confirmed Node 24
- `actions/deploy-pages@v4` action.yml: `using: node20` — confirmed deprecated  
- `actions/deploy-pages@v5` action.yml: `using: node24` — confirmed Node 24
- `actions/upload-pages-artifact@v3/v5` are composite actions (no direct node version); v5 wraps `upload-artifact@v7` which runs on Node 24

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
