### PR TITLE
feat(roborev-etl): heuristic finding lineage (#286)

### DIFF
--- a/.claude/scripts/roborev_metrics_etl.R
+++ b/.claude/scripts/roborev_metrics_etl.R
@@ -1029,6 +1029,191 @@ build_cadence_efficacy <- function(jobs, poll_log_data, since_date) {
   do.call(rbind, result_rows)
 }
 
+# ── Build roborev_finding_lineage (#286) ──────────────────────────────────
+#
+# Heuristic lineage: group review jobs into re-review chains using available
+# signals, since parent_job_id is never populated by roborev today (#286).
+#
+# Signal priority (applied per job, strongest first):
+#   1. parent_job_id IS NOT NULL → trust it (forward-compatible)
+#   2. patch_id set → group by (repo_id, patch_id)
+#   3. commit_id reviewed >1× in same repo+branch → group by (repo_id, branch, commit_id)
+#   4. solo → chain of length 1
+#
+# Returns a data.frame with columns:
+#   finding_id, attempt_n, lineage_method, job_id, created_at, verdict_bool,
+#   closed, chain_size, is_closing_attempt
+#
+# "finding_id" = reviews.id (the review row is the canonical finding record;
+# jobs without a review row are excluded — they have no finding yet).
+
+build_finding_lineage <- function(read_con, since_date, repo_clause) {
+  since_str_local <- format(since_date, "%Y-%m-%d")
+
+  # Pull all job+review pairs in the window (left join — jobs without reviews
+  # are excluded: no finding, no lineage row).
+  sql_lineage_src <- sprintf("
+    SELECT
+      rv.id             AS finding_id,
+      rj.id             AS job_id,
+      rj.repo_id,
+      rj.commit_id,
+      rj.branch,
+      rj.patch_id,
+      rj.parent_job_id,
+      rj.enqueued_at,
+      rv.created_at,
+      rv.verdict_bool,
+      rv.closed
+    FROM src.reviews rv
+    JOIN src.review_jobs rj ON rj.id = rv.job_id
+    JOIN src.repos rp ON rp.id = rj.repo_id
+    WHERE date(rj.enqueued_at) >= DATE '%s'
+    %s
+    ORDER BY rj.enqueued_at
+  ", since_str_local, repo_clause)
+
+  src_df <- tryCatch(
+    dbGetQuery(read_con, sql_lineage_src),
+    error = function(e) {
+      log_msg("WARN: lineage source query failed: ", conditionMessage(e))
+      data.frame()
+    }
+  )
+
+  empty_df <- data.frame(
+    finding_id         = integer(),
+    attempt_n          = integer(),
+    lineage_method     = character(),
+    job_id             = integer(),
+    created_at         = as.POSIXct(character()),
+    verdict_bool       = integer(),
+    closed             = integer(),
+    chain_size         = integer(),
+    is_closing_attempt = logical(),
+    stringsAsFactors   = FALSE
+  )
+
+  if (nrow(src_df) == 0L) {
+    cat("roborev_metrics_etl.R: no reviews in window — finding_lineage will be empty\n")
+    return(empty_df)
+  }
+
+  # ── Assign each row its group_key and lineage_method ──────────────────────
+  # Build lookup: which commit_ids are reviewed more than once within the same
+  # repo+branch (the commit_branch signal)?
+  multi_commit_key <- function(df) {
+    # Group key = paste(repo_id, branch, commit_id)
+    keys <- paste(df$repo_id, df$branch, df$commit_id, sep = "|")
+    counts <- table(keys)
+    names(counts)[counts > 1L]
+  }
+  multi_keys <- multi_commit_key(src_df)
+
+  group_key   <- character(nrow(src_df))
+  lin_method  <- character(nrow(src_df))
+
+  for (i in seq_len(nrow(src_df))) {
+    row <- src_df[i, ]
+    if (!is.na(row$parent_job_id) && row$parent_job_id > 0L) {
+      # Priority 1: explicit parent_job_id (not currently populated by roborev)
+      group_key[[i]]  <- paste0("pjid|", row$repo_id, "|", row$parent_job_id)
+      lin_method[[i]] <- "parent_job_id"
+    } else if (!is.na(row$patch_id) && nzchar(row$patch_id)) {
+      # Priority 2: patch_id groups
+      group_key[[i]]  <- paste0("patch|", row$repo_id, "|", row$patch_id)
+      lin_method[[i]] <- "patch_id"
+    } else {
+      # Priority 3: commit_branch grouping (only when commit_id appears >1 time)
+      ck <- paste(row$repo_id, row$branch, row$commit_id, sep = "|")
+      if (!is.na(row$commit_id) && ck %in% multi_keys) {
+        group_key[[i]]  <- paste0("cb|", ck)
+        lin_method[[i]] <- "commit_branch"
+      } else {
+        # Priority 4: solo (unique group per finding)
+        group_key[[i]]  <- paste0("solo|", row$finding_id)
+        lin_method[[i]] <- "solo"
+      }
+    }
+  }
+
+  src_df$group_key  <- group_key
+  src_df$lin_method <- lin_method
+
+  # ── Sort chronologically within each group, assign attempt_n ─────────────
+  # Sort globally first, then by group so attempt_n reflects enqueue order.
+  ord <- order(src_df$group_key, src_df$enqueued_at)
+  src_sorted <- src_df[ord, ]
+
+  # Compute within-group rank (attempt_n)
+  attempt_n   <- integer(nrow(src_sorted))
+  chain_size  <- integer(nrow(src_sorted))
+  group_rle   <- rle(src_sorted$group_key)
+
+  pos <- 1L
+  for (grp_len in group_rle$lengths) {
+    attempt_n[pos:(pos + grp_len - 1L)]  <- seq_len(grp_len)
+    chain_size[pos:(pos + grp_len - 1L)] <- grp_len
+    pos <- pos + grp_len
+  }
+
+  src_sorted$attempt_n  <- attempt_n
+  src_sorted$chain_size <- chain_size
+
+  # is_closing_attempt: the LAST row in a chain that has closed=1
+  # (a chain may have closed=0 throughout if still open; then no row is TRUE)
+  is_closing <- logical(nrow(src_sorted))
+  pos <- 1L
+  for (grp_len in group_rle$lengths) {
+    grp_rows <- pos:(pos + grp_len - 1L)
+    # Find the last row in this group that has closed=1
+    closed_in_grp <- which(src_sorted$closed[grp_rows] == 1L)
+    if (length(closed_in_grp) > 0L) {
+      last_closed_pos <- grp_rows[max(closed_in_grp)]
+      is_closing[last_closed_pos] <- TRUE
+    }
+    pos <- pos + grp_len
+  }
+  src_sorted$is_closing_attempt <- is_closing
+
+  # ── Parse created_at timestamps ───────────────────────────────────────────
+  parse_ts_safe <- function(x) {
+    tryCatch({
+      x_norm <- sub("([+-][0-9]{2}):([0-9]{2})$", "\\1\\2", x)
+      x_norm <- sub("Z$", "+0000", x_norm)
+      ts <- as.POSIXct(x_norm, tz = "UTC", format = "%Y-%m-%dT%H:%M:%S%z")
+      still_na <- which(is.na(ts) & !is.na(x))
+      if (length(still_na) > 0L) {
+        ts[still_na] <- as.POSIXct(x_norm[still_na], tz = "UTC",
+                                    format = "%Y-%m-%d %H:%M:%S")
+      }
+      ts
+    }, error = function(e) as.POSIXct(NA_real_, origin = "1970-01-01"))
+  }
+
+  created_at_ts <- parse_ts_safe(src_sorted$created_at)
+
+  data.frame(
+    finding_id         = as.integer(src_sorted$finding_id),
+    attempt_n          = as.integer(src_sorted$attempt_n),
+    lineage_method     = src_sorted$lin_method,
+    job_id             = as.integer(src_sorted$job_id),
+    created_at         = created_at_ts,
+    verdict_bool       = as.integer(src_sorted$verdict_bool),
+    closed             = as.integer(coalesce_int(src_sorted$closed, 0L)),
+    chain_size         = as.integer(src_sorted$chain_size),
+    is_closing_attempt = as.logical(src_sorted$is_closing_attempt),
+    stringsAsFactors   = FALSE
+  )
+}
+
+# Helper: coerce to integer with NA-safe default
+coalesce_int <- function(x, default = 0L) {
+  x <- as.integer(x)
+  x[is.na(x)] <- default
+  x
+}
+
 # ── Build tables ───────────────────────────────────────────────────────────
 
 daily_df     <- build_daily_metrics(jobs_raw, reviews_raw)
@@ -1048,6 +1233,17 @@ cat(sprintf(
   nrow(agent_perf_df), nrow(threshold_df), nrow(cadence_df)
 ))
 
+# Slice 3: heuristic finding lineage (#286)
+lineage_df <- build_finding_lineage(read_con, since, repo_clause)
+
+cat(sprintf(
+  "roborev_metrics_etl.R: built %d finding_lineage rows (%d chains)\n",
+  nrow(lineage_df),
+  if (nrow(lineage_df) > 0L) length(unique(
+    paste(lineage_df$finding_id[lineage_df$attempt_n == 1L])
+  )) else 0L
+))
+
 # ── Dry-run: print summary and exit 0 ─────────────────────────────────────
 
 if (mode == "dry-run") {
@@ -1058,11 +1254,12 @@ if (mode == "dry-run") {
   cat(sprintf("  roborev_agent_performance: %d rows\n", nrow(agent_perf_df)))
   cat(sprintf("  roborev_threshold_changes: %d rows\n", nrow(threshold_df)))
   cat(sprintf("  roborev_cadence_efficacy:  %d rows\n", nrow(cadence_df)))
+  cat(sprintf("  roborev_finding_lineage:   %d rows\n", nrow(lineage_df)))
   cat("--- end dry-run ---\n")
   log_msg(sprintf(
-    "dry-run: daily=%d lifecycle=%d agent_perf=%d threshold=%d cadence=%d",
+    "dry-run: daily=%d lifecycle=%d agent_perf=%d threshold=%d cadence=%d lineage=%d",
     nrow(daily_df), nrow(lifecycle_df), nrow(agent_perf_df),
-    nrow(threshold_df), nrow(cadence_df)
+    nrow(threshold_df), nrow(cadence_df), nrow(lineage_df)
   ))
   quit(status = 0L)
 }
@@ -1156,18 +1353,19 @@ tryCatch({
   upsert_table(duck_con, "roborev_agent_performance", agent_perf_df)
   upsert_table(duck_con, "roborev_threshold_changes", threshold_df)
   upsert_table(duck_con, "roborev_cadence_efficacy",  cadence_df)
+  upsert_table(duck_con, "roborev_finding_lineage",   lineage_df)
 
   dbCommit(duck_con)
 
   log_msg(sprintf(
-    "apply: daily=%d lifecycle=%d agent_perf=%d threshold=%d cadence=%d mode=apply since=%s",
+    "apply: daily=%d lifecycle=%d agent_perf=%d threshold=%d cadence=%d lineage=%d mode=apply since=%s",
     nrow(daily_df), nrow(lifecycle_df), nrow(agent_perf_df),
-    nrow(threshold_df), nrow(cadence_df), format(since, "%Y-%m-%d")
+    nrow(threshold_df), nrow(cadence_df), nrow(lineage_df), format(since, "%Y-%m-%d")
   ))
   cat(sprintf(
-    "roborev_metrics_etl.R: done — daily=%d lifecycle=%d agent_perf=%d threshold=%d cadence=%d\n",
+    "roborev_metrics_etl.R: done — daily=%d lifecycle=%d agent_perf=%d threshold=%d cadence=%d lineage=%d\n",
     nrow(daily_df), nrow(lifecycle_df), nrow(agent_perf_df),
-    nrow(threshold_df), nrow(cadence_df)
+    nrow(threshold_df), nrow(cadence_df), nrow(lineage_df)
   ))
 }, error = function(e) {
   tryCatch(dbRollback(duck_con), error = function(e2) NULL)

--- a/.claude/scripts/roborev_metrics_schema.sql
+++ b/.claude/scripts/roborev_metrics_schema.sql
@@ -1,14 +1,16 @@
 -- roborev_metrics_schema.sql
--- CREATE TABLE IF NOT EXISTS for all 5 roborev_* tables in unified.duckdb.
+-- CREATE TABLE IF NOT EXISTS for all 7 roborev_* tables in unified.duckdb.
 --
 -- SCHEMAS FROZEN — llmtelemetry#144 depends on these column names and types.
 -- Do NOT modify column names or types without a coordinated bump across both repos.
 -- Tracked in llm#226.
 --
--- All 5 tables are created on every ETL invocation (idempotent).
+-- All 7 tables are created on every ETL invocation (idempotent).
 -- Slice 1 populates: roborev_daily_metrics, roborev_review_lifecycle.
--- Slice 2 will populate: roborev_agent_performance, roborev_threshold_changes,
+-- Slice 2 populates: roborev_agent_performance, roborev_threshold_changes,
 --   roborev_cadence_efficacy.
+-- Slice 3 (#286) populates: roborev_finding_lineage;
+--   view roborev_finding_lineage_summary is rebuilt as CREATE OR REPLACE VIEW.
 
 -- ── roborev_daily_metrics ─────────────────────────────────────────────────
 -- Per-day × per-repo rollup.
@@ -96,3 +98,54 @@ CREATE TABLE IF NOT EXISTS roborev_cadence_efficacy (
   reviews_created_via_hook   INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (date, repo)
 );
+
+-- ── roborev_finding_lineage ───────────────────────────────────────────────
+-- Heuristic re-review chain. One row per (finding/review, attempt position).
+-- Lineage is derived from observable signals only — no parent_job_id exists yet
+-- (see llm#286 for the upstream ask). Priority of lineage_method:
+--   1. parent_job_id  (forward-compatible when roborev starts populating it)
+--   2. patch_id       (same patch re-reviewed across jobs, 31% set)
+--   3. commit_branch  (same repo+branch+commit_id reviewed >1 time)
+--   4. solo           (single-attempt finding, no re-review detected)
+-- PK: (finding_id, attempt_n) — finding_id = reviews.id
+CREATE TABLE IF NOT EXISTS roborev_finding_lineage (
+  finding_id          BIGINT    NOT NULL,
+  attempt_n           INTEGER   NOT NULL,
+  lineage_method      VARCHAR   NOT NULL,
+  job_id              BIGINT    NOT NULL,
+  created_at          TIMESTAMP,
+  verdict_bool        INTEGER,
+  closed              INTEGER   NOT NULL DEFAULT 0,
+  chain_size          INTEGER   NOT NULL DEFAULT 1,
+  is_closing_attempt  BOOLEAN   NOT NULL DEFAULT FALSE,
+  PRIMARY KEY (finding_id, attempt_n)
+);
+
+-- ── roborev_finding_lineage_summary (view) ────────────────────────────────
+-- Per-finding summary: attempt count, time-to-close, verdict chain.
+-- Rebuilt as CREATE OR REPLACE VIEW on each ETL run (views are cheap to recreate).
+CREATE OR REPLACE VIEW roborev_finding_lineage_summary AS
+SELECT
+  fl.finding_id,
+  (SELECT rp.name
+   FROM roborev_review_lifecycle rl
+   JOIN roborev_finding_lineage fl2 ON fl2.finding_id = rl.review_id
+                                    AND fl2.attempt_n = 1
+   WHERE fl2.finding_id = fl.finding_id
+   LIMIT 1) AS repo,
+  MIN(fl.lineage_method)                            AS lineage_method,
+  COUNT(*)                                          AS n_attempts,
+  MIN(fl.created_at)                                AS created_at_first,
+  MAX(CASE WHEN fl.closed = 1 THEN fl.created_at END) AS closed_at_last,
+  ROUND(
+    EXTRACT(EPOCH FROM
+      (MAX(CASE WHEN fl.closed = 1 THEN fl.created_at END) - MIN(fl.created_at))
+    ) / 3600.0,
+    2
+  )                                                 AS time_to_close_hrs,
+  STRING_AGG(
+    CASE WHEN fl.verdict_bool = 1 THEN 'clean' ELSE 'fail' END,
+    '→' ORDER BY fl.attempt_n
+  )                                                 AS verdict_chain
+FROM roborev_finding_lineage fl
+GROUP BY fl.finding_id;

--- a/tests/testthat/test-roborev-lineage.R
+++ b/tests/testthat/test-roborev-lineage.R
@@ -1,0 +1,308 @@
+# tests/testthat/test-roborev-lineage.R
+#
+# Regression tests for roborev_finding_lineage ETL.
+# Tracks llm#286.
+#
+# Tests verify:
+#   1. Each lineage_method is assigned correctly on synthetic data.
+#   2. chain_size is consistent within a chain (all rows share the same value).
+#   3. Summary counts (n_attempts) match raw row counts per finding chain.
+#   4. Idempotence: re-running build_finding_lineage produces identical rows.
+#
+# Strategy: source only the two pure-function blocks from the ETL script
+# (build_finding_lineage + coalesce_int, lines ~1032-1215).
+# These blocks have no I/O side effects and depend only on:
+#   - a DBI connection pointing at an in-memory SQLite fixture
+#   - the log_msg helper (stubbed below)
+#   - since_date / repo_clause (plain strings)
+
+library(testthat)
+library(DBI)
+library(duckdb)
+
+# ── Source the lineage function block ─────────────────────────────────────
+#
+# Two separate eval blocks:
+#   Block 1: lines 100-108  — log_msg helper (required by build_finding_lineage)
+#   Block 2: lines 1032-end — build_finding_lineage + coalesce_int
+#
+# We source log_msg from the script rather than stubbing it, so the dependency
+# is explicit and the stub doesn't drift if the signature changes.
+
+.log_msg_start  <- 100L   # log_msg <- function(...)
+.log_msg_end    <- 108L   # closing } of log_msg
+.etl_fn_start   <- 1032L  # "# ── Build roborev_finding_lineage"
+.etl_fn_end     <- 1215L  # closing } of coalesce_int
+
+etl_script <- file.path(pkgload::pkg_path(),
+                         ".claude", "scripts", "roborev_metrics_etl.R")
+
+skip_if_not(file.exists(etl_script), "ETL script not found at expected path")
+
+all_lines <- readLines(etl_script)
+
+# log_file is referenced inside log_msg — provide a tempfile so it doesn't
+# try to write to ~/.claude/logs/ during tests.
+log_file <- tempfile(fileext = ".log")
+
+eval(parse(text = paste(all_lines[.log_msg_start:.log_msg_end], collapse = "\n")),
+     envir = globalenv())
+eval(parse(text = paste(all_lines[.etl_fn_start:.etl_fn_end],  collapse = "\n")),
+     envir = globalenv())
+
+# ── Fixture builder ───────────────────────────────────────────────────────
+#
+# 5-review synthetic SQLite database covering all 4 lineage methods:
+#
+#   job  rv  repo_id  commit_id  branch  patch_id              parent_job_id
+#   1    1   1        10         main    patch-AAA             NULL    → patch_id
+#   2    2   1        10         main    patch-AAA             NULL    → patch_id (chain w/ rv1)
+#   3    3   1        11         main    NULL                  NULL    → commit_branch
+#   4    4   1        11         main    NULL                  NULL    → commit_branch (chain w/ rv3)
+#   5    5   1        12         main    NULL                  NULL    → solo
+#
+# Plus a 6th entry exercising parent_job_id (not NULL):
+#   job  rv  repo_id  commit_id  branch  patch_id  parent_job_id
+#   6    6   2        20         main    NULL       6            → parent_job_id
+#   (parent_job_id self-references for simplicity; the code doesn't validate)
+
+make_lineage_fixture <- function(dir) {
+  skip_if_not_installed("duckdb")
+  db_path <- file.path(dir, "lineage_fixture.db")
+
+  # Use DuckDB to create the SQLite file via the sqlite extension
+  con <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  DBI::dbExecute(con, "LOAD sqlite")
+  DBI::dbExecute(con, sprintf("ATTACH '%s' AS fix (TYPE sqlite)", db_path))
+
+  DBI::dbExecute(con, "CREATE TABLE fix.repos (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+  DBI::dbExecute(con, "INSERT INTO fix.repos VALUES (1, 'llm'), (2, 'mycare')")
+
+  DBI::dbExecute(con, "
+    CREATE TABLE fix.review_jobs (
+      id INTEGER PRIMARY KEY,
+      repo_id INTEGER NOT NULL,
+      commit_id INTEGER,
+      branch TEXT DEFAULT 'main',
+      patch_id TEXT,
+      parent_job_id INTEGER,
+      enqueued_at TEXT NOT NULL
+    )
+  ")
+
+  jobs <- data.frame(
+    id            = 1:6,
+    repo_id       = c(1L, 1L, 1L, 1L, 1L, 2L),
+    commit_id     = c(10L, 10L, 11L, 11L, 12L, 20L),
+    branch        = c("main", "main", "main", "main", "main", "main"),
+    patch_id      = c("patch-AAA", "patch-AAA", NA, NA, NA, NA),
+    parent_job_id = c(NA, NA, NA, NA, NA, 6L),
+    enqueued_at   = c(
+      "2026-05-01 10:00:00",
+      "2026-05-01 10:05:00",
+      "2026-05-01 11:00:00",
+      "2026-05-01 11:05:00",
+      "2026-05-01 12:00:00",
+      "2026-05-01 13:00:00"
+    ),
+    stringsAsFactors = FALSE
+  )
+
+  for (i in seq_len(nrow(jobs))) {
+    row <- jobs[i, ]
+    pid_sql <- if (is.na(row$patch_id)) "NULL" else sprintf("'%s'", row$patch_id)
+    pjid_sql <- if (is.na(row$parent_job_id)) "NULL" else as.character(row$parent_job_id)
+    DBI::dbExecute(con, sprintf(
+      "INSERT INTO fix.review_jobs
+       (id, repo_id, commit_id, branch, patch_id, parent_job_id, enqueued_at)
+       VALUES (%d, %d, %d, '%s', %s, %s, '%s')",
+      row$id, row$repo_id, row$commit_id, row$branch,
+      pid_sql, pjid_sql, row$enqueued_at
+    ))
+  }
+
+  DBI::dbExecute(con, "
+    CREATE TABLE fix.reviews (
+      id INTEGER PRIMARY KEY,
+      job_id INTEGER NOT NULL,
+      closed INTEGER DEFAULT 0,
+      verdict_bool INTEGER,
+      created_at TEXT DEFAULT '2026-05-01 10:00:00',
+      output TEXT DEFAULT ''
+    )
+  ")
+
+  reviews <- data.frame(
+    id           = 1:6,
+    job_id       = 1:6,
+    closed       = c(0L, 1L, 0L, 1L, 0L, 1L),
+    verdict_bool = c(0L, 1L, 0L, 0L, 0L, 1L),
+    created_at   = c(
+      "2026-05-01 10:01:00",
+      "2026-05-01 10:06:00",
+      "2026-05-01 11:01:00",
+      "2026-05-01 11:06:00",
+      "2026-05-01 12:01:00",
+      "2026-05-01 13:01:00"
+    ),
+    stringsAsFactors = FALSE
+  )
+
+  for (i in seq_len(nrow(reviews))) {
+    row <- reviews[i, ]
+    DBI::dbExecute(con, sprintf(
+      "INSERT INTO fix.reviews (id, job_id, closed, verdict_bool, created_at)
+       VALUES (%d, %d, %d, %d, '%s')",
+      row$id, row$job_id, row$closed, row$verdict_bool, row$created_at
+    ))
+  }
+
+  db_path
+}
+
+# Open a DBI connection to the fixture's SQLite file via DuckDB's sqlite ext
+open_fixture_con <- function(db_path) {
+  con <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+  DBI::dbExecute(con, "LOAD sqlite")
+  DBI::dbExecute(con, sprintf("ATTACH '%s' AS src (TYPE sqlite, READ_ONLY)", db_path))
+  con
+}
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+test_that("lineage_method assigned correctly for all 4 cases", {
+  skip_if_not_installed("duckdb")
+
+  tmp    <- withr::local_tempdir()
+  db     <- make_lineage_fixture(tmp)
+  con    <- open_fixture_con(db)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  since  <- as.Date("2026-05-01")
+  result <- build_finding_lineage(con, since, "")
+
+  expect_equal(nrow(result), 6L)
+
+  get_method <- function(rv_id) result$lineage_method[result$finding_id == rv_id]
+
+  # rv1 + rv2: same patch_id → patch_id
+  expect_equal(get_method(1L), "patch_id",      info = "rv1 patch_id method")
+  expect_equal(get_method(2L), "patch_id",      info = "rv2 patch_id method")
+
+  # rv3 + rv4: same repo+branch+commit_id, no patch_id → commit_branch
+  expect_equal(get_method(3L), "commit_branch", info = "rv3 commit_branch method")
+  expect_equal(get_method(4L), "commit_branch", info = "rv4 commit_branch method")
+
+  # rv5: unique commit_id, no patch_id, no parent_job_id → solo
+  expect_equal(get_method(5L), "solo",          info = "rv5 solo method")
+
+  # rv6: parent_job_id set → parent_job_id (priority 1)
+  expect_equal(get_method(6L), "parent_job_id", info = "rv6 parent_job_id method")
+})
+
+test_that("chain_size is consistent within each chain", {
+  skip_if_not_installed("duckdb")
+
+  tmp    <- withr::local_tempdir()
+  db     <- make_lineage_fixture(tmp)
+  con    <- open_fixture_con(db)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  since  <- as.Date("2026-05-01")
+  result <- build_finding_lineage(con, since, "")
+
+  # patch_id chain: rv1 + rv2 → chain_size = 2
+  cs_patch <- result$chain_size[result$lineage_method == "patch_id"]
+  expect_true(all(cs_patch == 2L),
+              info = "All patch_id chain rows must have chain_size=2")
+
+  # commit_branch chain: rv3 + rv4 → chain_size = 2
+  cs_cb <- result$chain_size[result$lineage_method == "commit_branch"]
+  expect_true(all(cs_cb == 2L),
+              info = "All commit_branch chain rows must have chain_size=2")
+
+  # solo chain: rv5 → chain_size = 1
+  cs_solo <- result$chain_size[result$lineage_method == "solo"]
+  expect_true(all(cs_solo == 1L),
+              info = "Solo chain must have chain_size=1")
+
+  # parent_job_id chain: rv6 → chain_size = 1 (only one row in the group)
+  cs_pjid <- result$chain_size[result$lineage_method == "parent_job_id"]
+  expect_true(all(cs_pjid == 1L),
+              info = "parent_job_id singleton chain must have chain_size=1")
+})
+
+test_that("summary counts match raw row counts per chain", {
+  skip_if_not_installed("duckdb")
+
+  tmp    <- withr::local_tempdir()
+  db     <- make_lineage_fixture(tmp)
+  con    <- open_fixture_con(db)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  since  <- as.Date("2026-05-01")
+  result <- build_finding_lineage(con, since, "")
+
+  # chain_size should equal the number of rows with the same group
+  # (for each row, chain_size == count of rows sharing the same group).
+  # Verify by cross-checking: for patch_id chains, two distinct finding_ids
+  # → each chain has 2 rows and chain_size=2.
+  patch_rows  <- result[result$lineage_method == "patch_id", ]
+  expect_equal(nrow(patch_rows), 2L,
+               info = "Exactly 2 rows in patch_id chain")
+  expect_equal(unique(patch_rows$chain_size), 2L,
+               info = "chain_size=2 for both patch_id rows")
+
+  cb_rows <- result[result$lineage_method == "commit_branch", ]
+  expect_equal(nrow(cb_rows), 2L,
+               info = "Exactly 2 rows in commit_branch chain")
+  expect_equal(unique(cb_rows$chain_size), 2L,
+               info = "chain_size=2 for both commit_branch rows")
+})
+
+test_that("is_closing_attempt marks last closed row in each chain", {
+  skip_if_not_installed("duckdb")
+
+  tmp    <- withr::local_tempdir()
+  db     <- make_lineage_fixture(tmp)
+  con    <- open_fixture_con(db)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  since  <- as.Date("2026-05-01")
+  result <- build_finding_lineage(con, since, "")
+
+  # rv2 is the closing attempt of the patch_id chain (rv1=open, rv2=closed)
+  r2 <- result[result$finding_id == 2L, ]
+  expect_true(r2$is_closing_attempt,
+              info = "rv2 (last closed in patch_id chain) must be is_closing_attempt=TRUE")
+
+  r1 <- result[result$finding_id == 1L, ]
+  expect_false(r1$is_closing_attempt,
+               info = "rv1 (open, first in chain) must be is_closing_attempt=FALSE")
+
+  # rv5: solo, still open → no closing attempt in chain
+  r5 <- result[result$finding_id == 5L, ]
+  expect_false(r5$is_closing_attempt,
+               info = "rv5 (solo, open) must be is_closing_attempt=FALSE")
+})
+
+test_that("idempotence: two runs produce identical rows", {
+  skip_if_not_installed("duckdb")
+
+  tmp    <- withr::local_tempdir()
+  db     <- make_lineage_fixture(tmp)
+  con    <- open_fixture_con(db)
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  since  <- as.Date("2026-05-01")
+
+  res1 <- build_finding_lineage(con, since, "")
+  res2 <- build_finding_lineage(con, since, "")
+
+  expect_equal(nrow(res1), nrow(res2))
+  expect_equal(res1$lineage_method, res2$lineage_method)
+  expect_equal(res1$attempt_n,      res2$attempt_n)
+  expect_equal(res1$chain_size,     res2$chain_size)
+  expect_equal(res1$is_closing_attempt, res2$is_closing_attempt)
+})


### PR DESCRIPTION
## Summary

- Adds `roborev_finding_lineage` table and `roborev_finding_lineage_summary` view to `unified.duckdb` via the metrics ETL (`roborev_metrics_etl.R`)
- Derives re-review chains heuristically from observable SQLite signals — a stopgap until roborev populates `parent_job_id` or `closures` (see #286)
- Adds 5 regression tests in `tests/testthat/test-roborev-lineage.R` covering all 4 lineage methods, chain_size consistency, summary counts, `is_closing_attempt` logic, and idempotence
- Unblocks the attempts-to-close metric in #284

## 4-tier priority logic

The ETL assigns each review to a lineage chain using the strongest available signal, in order:

| Priority | Signal | Condition |
|---|---|---|
| 1 | `parent_job_id` | Not NULL — forward-compatible once roborev populates it |
| 2 | `patch_id` | Same `(repo_id, patch_id)` across multiple jobs |
| 3 | `commit_branch` | Same `(repo_id, branch, commit_id)` reviewed >1 time |
| 4 | `solo` | No grouping signal — chain of length 1 |

**Current data (as of 2026-05-28):** `parent_job_id` is 0/4808 populated, `patch_id` is 31% set (1559/4808). The dry-run over the last 7 days produced 58 lineage rows covering 57 chains (1 two-attempt chain detected via `commit_branch`).

## New schema objects

**`roborev_finding_lineage`** — one row per (finding, attempt):
- `finding_id` — `reviews.id`
- `attempt_n` — 1-indexed position within the chain
- `lineage_method` — one of `parent_job_id` / `patch_id` / `commit_branch` / `solo`
- `chain_size` — total attempts in this chain
- `is_closing_attempt` — TRUE iff this is the last `closed=1` row in the chain

**`roborev_finding_lineage_summary`** (view) — one row per finding:
- `n_attempts`, `created_at_first`, `closed_at_last`, `time_to_close_hrs`, `verdict_chain` (e.g. `fail→fail→clean`)

## Test results

```
tests/testthat/test-roborev-lineage.R
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 23 ]

tests/testthat/test-roborev-etl-lifecycle.R (regression)
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 23 ]
```

## Upstream feedback (Deliverable B)

What roborev should ideally populate to make lineage exact rather than heuristic:

1. **`parent_job_id`** on every re-review / `roborev refine` iteration — lightweight, directly yields attempt counts, forward-compatible with priority-1 in our ETL (which already handles it)
2. **`closures` rows** when a finding is resolved — currently 0/4808 populated; would give authoritative close-time and closure type

Until either is populated, the `patch_id` signal (31% coverage) gives partial lineage for the most active re-review workflows. The `commit_branch` signal catches the remaining multi-attempt cases.

## Post-merge verification

After the next scheduled ETL run (`--apply` mode), verify with:
```sql
SELECT lineage_method, COUNT(*) AS chains, AVG(chain_size) AS avg_size
FROM roborev_finding_lineage
WHERE attempt_n = 1
GROUP BY lineage_method
ORDER BY chains DESC;
```

Closes #286 (heuristic stopgap delivered; upstream ask documented in issue body).
References #284 (attempts-to-close metric unblocked once data accrues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
