### PR TITLE
feat(roborev): daily email + launchd + llmtelemetry data publish (#287 Part A)

### DIFF
--- a/.claude/launchd/com.claude.roborev-daily-email.plist
+++ b/.claude/launchd/com.claude.roborev-daily-email.plist
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.claude.roborev-daily-email.plist
+     Daily roborev snapshot → llmtelemetry data branch → digest email.
+     Runs at 08:00 local time, after the 02:00 roborev-metrics-etl job (#226).
+
+     Install:
+       cp .claude/launchd/com.claude.roborev-daily-email.plist \
+          ~/Library/LaunchAgents/com.claude.roborev-daily-email.plist
+       launchctl load -w ~/Library/LaunchAgents/com.claude.roborev-daily-email.plist
+
+     Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.claude.roborev-daily-email.plist
+       rm ~/Library/LaunchAgents/com.claude.roborev-daily-email.plist
+
+     Manual dry-run:
+       DRYRUN=1 EMAIL_DRY_RUN=1 bash ~/docs_gh/llm/bin/roborev_daily_cron.sh
+
+     Credentials: ~/.claude/env/roborev_email.env (not committed; create manually)
+       GMAIL_USERNAME=you@gmail.com
+       GMAIL_APP_PASSWORD=<16-char app password>
+       REPORT_RECIPIENT=you@gmail.com
+       ROBOREV_DASHBOARD_URL=https://johngavin.github.io/llmtelemetry/#roborev
+
+     Tracked in llm#287.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.roborev-daily-email</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/roborev_daily_cron.sh</string>
+    </array>
+
+    <!-- Daily at 08:00 local time (after 02:00 metrics-etl job) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <!-- Do NOT run immediately on launchctl load -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- PATH must include nix stable profile so nix-shell resolves -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+        <!-- NIX_SSL_CERT_FILE is required for nix-shell to make network calls -->
+        <key>NIX_SSL_CERT_FILE</key>
+        <string>/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/roborev_daily_email_launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/roborev_daily_email_launchd.log</string>
+
+    <!-- Retry once after 60 s if job exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+</dict>
+</plist>

--- a/.claude/scripts/send_roborev_email.R
+++ b/.claude/scripts/send_roborev_email.R
@@ -1,0 +1,410 @@
+#!/usr/bin/env Rscript
+# send_roborev_email.R — Send daily roborev resolution report via Gmail.
+#
+# Reads the latest JSON snapshot from $ROBOREV_DAILY_DIR (default
+# ~/.claude/logs/roborev_daily_report/) and sends an HTML email via blastula.
+#
+# Required env vars:
+#   GMAIL_USERNAME       Gmail address (sender + credential lookup)
+#   GMAIL_APP_PASSWORD   Gmail app password
+#   REPORT_RECIPIENT     Recipient address (falls back to GMAIL_USERNAME)
+#   ROBOREV_DASHBOARD_URL  Dashboard link (optional; default provided)
+#
+# Optional env vars:
+#   ROBOREV_DAILY_DIR   Override daily report directory
+#   EMAIL_DRY_RUN       Set to "1" to print body to stdout without sending
+#
+# Usage:
+#   Rscript .claude/scripts/send_roborev_email.R
+#   EMAIL_DRY_RUN=1 Rscript .claude/scripts/send_roborev_email.R
+#
+# Called from bin/roborev_daily_cron.sh.
+# Tracked in llm#287.
+
+suppressPackageStartupMessages({
+  library(blastula)
+  library(jsonlite)
+})
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+ROBOREV_DAILY_DIR <- Sys.getenv(
+  "ROBOREV_DAILY_DIR",
+  file.path(Sys.getenv("HOME"), ".claude", "logs", "roborev_daily_report")
+)
+
+ROBOREV_DASHBOARD_URL <- Sys.getenv(
+  "ROBOREV_DASHBOARD_URL",
+  "https://johngavin.github.io/llmtelemetry/#roborev"
+)
+
+dry_run <- identical(Sys.getenv("EMAIL_DRY_RUN"), "1")
+
+# ── Locate latest JSON snapshot ────────────────────────────────────────────────
+
+find_latest_json <- function(dir) {
+  if (!dir.exists(dir)) return(NULL)
+  files <- list.files(dir, pattern = "^\\d{4}-\\d{2}-\\d{2}\\.json$",
+                      full.names = TRUE)
+  if (length(files) == 0L) return(NULL)
+  files[which.max(file.info(files)$mtime)]
+}
+
+json_path <- find_latest_json(ROBOREV_DAILY_DIR)
+
+if (is.null(json_path)) {
+  message(sprintf(
+    "send_roborev_email.R: no JSON snapshot found in %s\n",
+    "Run .claude/scripts/roborev_daily_report.R --apply first.",
+    ROBOREV_DAILY_DIR
+  ))
+  quit(status = 1L)
+}
+
+message(sprintf("send_roborev_email.R: reading snapshot %s", json_path))
+
+snap <- tryCatch(
+  jsonlite::fromJSON(json_path, simplifyVector = FALSE),
+  error = function(e) {
+    message("send_roborev_email.R: failed to parse JSON: ", conditionMessage(e))
+    quit(status = 1L)
+  }
+)
+
+# ── Colour palette (dark-mode safe, matches llmtelemetry convention) ──────────
+
+dark_bg     <- "#1a1a2e"
+dark_card   <- "#16213e"
+dark_row_alt <- "#0f3460"
+dark_text   <- "#e8e8e8"
+dark_muted  <- "#a0a0a0"
+dark_border <- "#2a2a4a"
+accent_green  <- "#00d26a"
+accent_blue   <- "#4fc3f7"
+accent_orange <- "#ff9800"
+accent_purple <- "#bb86fc"
+
+# ── Formatting helpers ─────────────────────────────────────────────────────────
+
+fmt_hrs  <- function(x) if (is.null(x) || is.na(x)) "n/a" else sprintf("%.1fh", as.numeric(x))
+fmt_att  <- function(x) if (is.null(x) || is.na(x)) "n/a" else sprintf("%.1f", as.numeric(x))
+fmt_rate <- function(x) {
+  if (is.null(x) || is.na(x)) return("n/a")
+  sprintf("%.1f%%", as.numeric(x) * 100)
+}
+fmt_trend <- function(td) {
+  if (is.null(td)) return("n/a")
+  pct <- td[["pct_delta"]]
+  abs_d <- td[["abs_delta"]]
+  if (is.null(pct) || is.na(pct)) {
+    if (!is.null(abs_d) && !is.na(abs_d)) return(sprintf("Δ%.2f", abs_d))
+    return("n/a")
+  }
+  dir <- if (pct > 0) "&#9650;" else if (pct < 0) "&#9660;" else "="
+  sprintf("%s%.0f%%", dir, abs(pct))
+}
+fmt_int  <- function(x) if (is.null(x) || is.na(x)) "0" else formatC(as.integer(x), format = "d", big.mark = ",")
+
+# ── Extract 7-day window slice ─────────────────────────────────────────────────
+
+d7 <- snap[["global_windows"]][["d7"]]
+
+# §1 Frequency table
+freq_rows <- d7[["freq_table"]]
+issues_found_closed <- 0L
+issues_found_open   <- 0L
+clean_closed        <- 0L
+clean_open          <- 0L
+for (row in freq_rows) {
+  v <- row[["verdict_label"]]; s <- row[["status"]]; n <- as.integer(row[["n"]])
+  if (identical(v, "issues_found") && identical(s, "closed")) issues_found_closed <- n
+  if (identical(v, "issues_found") && identical(s, "open"))   issues_found_open   <- n
+  if (identical(v, "clean")        && identical(s, "closed")) clean_closed        <- n
+  if (identical(v, "clean")        && identical(s, "open"))   clean_open          <- n
+}
+
+# §2 Speed
+sp <- d7[["speed"]]
+ttc_p50 <- sp[["ttc_p50_hrs"]]
+ttc_p90 <- sp[["ttc_p90_hrs"]]
+close_rate <- sp[["close_rate"]]
+att_p50 <- sp[["att_p50"]]
+att_p90 <- sp[["att_p90"]]
+
+# §3 Trends
+tr <- d7[["trends"]]
+
+# §4 Outliers (top-5 of top-10)
+outliers_by_time <- snap[["outliers_14d"]][["by_time"]]
+if (is.null(outliers_by_time)) outliers_by_time <- list()
+n_outliers <- min(5L, length(outliers_by_time))
+
+outliers_by_att <- snap[["outliers_14d"]][["by_attempts"]]
+if (is.null(outliers_by_att)) outliers_by_att <- list()
+n_outliers_att <- min(5L, length(outliers_by_att))
+
+# ── Build headline summary table (Metric | Value — no bar/pie charts) ─────────
+
+report_date <- snap[["report_date"]] %||% format(Sys.Date())
+generated_at <- snap[["generated_at"]] %||% format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+lineage_src  <- snap[["lineage_source"]] %||% "unknown"
+
+`%||%` <- function(a, b) if (!is.null(a) && !is.na(a)) a else b
+
+# ── HTML email body ────────────────────────────────────────────────────────────
+
+# Dashboard link CTA
+dashboard_block <- sprintf(
+  '<div style="margin: 16px 0;">
+  <a href="%s"
+     style="display:inline-block; padding:10px 20px; background-color:%s;
+            color:#1a1a2e; text-decoration:none; border-radius:4px;
+            font-weight:bold; font-size:13px;">
+    View Full roborev Dashboard
+  </a>
+</div>',
+  ROBOREV_DASHBOARD_URL, accent_blue
+)
+
+# §1 + §2 Headline two-column table
+headline_rows <- list(
+  c("7d: issues found (closed)",  fmt_int(issues_found_closed)),
+  c("7d: issues found (open)",    fmt_int(issues_found_open)),
+  c("7d: clean (closed)",         fmt_int(clean_closed)),
+  c("7d: clean (open)",           fmt_int(clean_open)),
+  c("7d: close rate",             fmt_rate(close_rate)),
+  c("7d: TTC p50",                fmt_hrs(ttc_p50)),
+  c("7d: TTC p90",                fmt_hrs(ttc_p90)),
+  c("7d: attempts p50",           fmt_att(att_p50)),
+  c("7d: attempts p90",           fmt_att(att_p90))
+)
+
+headline_html <- sprintf(
+  '<h3 style="color:%s; margin-top:20px;">Headline Metrics (7-day)</h3>
+<table style="border-collapse:collapse; width:100%%; font-size:12px;">
+  <tr style="background-color:%s;">
+    <th style="padding:6px 8px; border:1px solid %s; color:white; text-align:left;">Metric</th>
+    <th style="padding:6px 8px; border:1px solid %s; color:white; text-align:right;">Value</th>
+  </tr>',
+  accent_orange, dark_row_alt, dark_border, dark_border
+)
+for (i in seq_along(headline_rows)) {
+  bg <- if (i %% 2 == 0) dark_row_alt else dark_card
+  headline_html <- paste0(headline_html, sprintf(
+    '<tr style="background-color:%s;">
+      <td style="padding:5px 8px; border:1px solid %s; color:%s;">%s</td>
+      <td style="padding:5px 8px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+    </tr>',
+    bg,
+    dark_border, dark_text, headline_rows[[i]][1],
+    dark_border, accent_green, headline_rows[[i]][2]
+  ))
+}
+headline_html <- paste0(headline_html, "</table>")
+
+# §3 Trends two-column table
+trends_html <- sprintf(
+  '<h3 style="color:%s; margin-top:20px;">Trends (7d vs prior 7d)</h3>
+<table style="border-collapse:collapse; width:100%%; font-size:12px;">
+  <tr style="background-color:%s;">
+    <th style="padding:6px 8px; border:1px solid %s; color:white; text-align:left;">Metric</th>
+    <th style="padding:6px 8px; border:1px solid %s; color:white; text-align:right;">Change</th>
+  </tr>',
+  accent_purple, dark_row_alt, dark_border, dark_border
+)
+trend_rows <- list(
+  c("TTC p50",    fmt_trend(tr[["ttc_p50"]])),
+  c("TTC p90",    fmt_trend(tr[["ttc_p90"]])),
+  c("Att p50",    fmt_trend(tr[["att_p50"]])),
+  c("Close rate", fmt_trend(tr[["close_rate"]]))
+)
+for (i in seq_along(trend_rows)) {
+  bg <- if (i %% 2 == 0) dark_row_alt else dark_card
+  trends_html <- paste0(trends_html, sprintf(
+    '<tr style="background-color:%s;">
+      <td style="padding:5px 8px; border:1px solid %s; color:%s;">%s</td>
+      <td style="padding:5px 8px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+    </tr>',
+    bg,
+    dark_border, dark_text, trend_rows[[i]][1],
+    dark_border, accent_blue, trend_rows[[i]][2]
+  ))
+}
+trends_html <- paste0(trends_html, "</table>")
+
+# §4 Outliers — top-5 by time-to-close
+outlier_ttc_html <- sprintf(
+  '<h3 style="color:%s; margin-top:20px;">Top-5 Outliers by Time-to-Close (14d)</h3>
+<p style="color:%s; font-size:11px; margin-bottom:6px;">Full detail (top-10) in the JSON snapshot and on the dashboard.</p>
+<table style="border-collapse:collapse; width:100%%; font-size:11px;">
+  <tr style="background-color:%s;">
+    <th style="padding:5px; border:1px solid %s; color:white;">ID</th>
+    <th style="padding:5px; border:1px solid %s; color:white;">Repo</th>
+    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">TTC</th>
+    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">Attempts</th>
+    <th style="padding:5px; border:1px solid %s; color:white;">Reason</th>
+  </tr>',
+  accent_orange, dark_muted,
+  dark_row_alt, dark_border, dark_border, dark_border, dark_border, dark_border
+)
+if (n_outliers > 0L) {
+  for (i in seq_len(n_outliers)) {
+    r <- outliers_by_time[[i]]
+    bg <- if (i %% 2 == 0) dark_row_alt else dark_card
+    outlier_ttc_html <- paste0(outlier_ttc_html, sprintf(
+      '<tr style="background-color:%s;">
+        <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
+      </tr>',
+      bg,
+      dark_border, accent_blue, r[["review_id"]] %||% "",
+      dark_border, dark_text, r[["repo"]] %||% "",
+      dark_border, accent_orange, fmt_hrs(r[["time_to_close_hrs"]]),
+      dark_border, dark_text, fmt_int(r[["n_attempts"]]),
+      dark_border, dark_muted, r[["close_reason"]] %||% ""
+    ))
+  }
+} else {
+  outlier_ttc_html <- paste0(outlier_ttc_html,
+    sprintf('<tr><td colspan="5" style="padding:6px; color:%s;">(no data in 14-day window)</td></tr>', dark_muted))
+}
+outlier_ttc_html <- paste0(outlier_ttc_html, "</table>")
+
+# §4 Outliers — top-5 by attempts
+outlier_att_html <- sprintf(
+  '<h3 style="color:%s; margin-top:20px;">Top-5 Outliers by Attempts-to-Close (14d)</h3>
+<table style="border-collapse:collapse; width:100%%; font-size:11px;">
+  <tr style="background-color:%s;">
+    <th style="padding:5px; border:1px solid %s; color:white;">ID</th>
+    <th style="padding:5px; border:1px solid %s; color:white;">Repo</th>
+    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">Attempts</th>
+    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">TTC</th>
+    <th style="padding:5px; border:1px solid %s; color:white;">Reason</th>
+  </tr>',
+  accent_purple, dark_row_alt, dark_border, dark_border, dark_border, dark_border, dark_border
+)
+if (n_outliers_att > 0L) {
+  for (i in seq_len(n_outliers_att)) {
+    r <- outliers_by_att[[i]]
+    bg <- if (i %% 2 == 0) dark_row_alt else dark_card
+    outlier_att_html <- paste0(outlier_att_html, sprintf(
+      '<tr style="background-color:%s;">
+        <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
+      </tr>',
+      bg,
+      dark_border, accent_blue, r[["review_id"]] %||% "",
+      dark_border, dark_text, r[["repo"]] %||% "",
+      dark_border, accent_orange, fmt_int(r[["n_attempts"]]),
+      dark_border, dark_text, fmt_hrs(r[["time_to_close_hrs"]]),
+      dark_border, dark_muted, r[["close_reason"]] %||% ""
+    ))
+  }
+} else {
+  outlier_att_html <- paste0(outlier_att_html,
+    sprintf('<tr><td colspan="5" style="padding:6px; color:%s;">(no data in 14-day window)</td></tr>', dark_muted))
+}
+outlier_att_html <- paste0(outlier_att_html, "</table>")
+
+# QA markers (tested by test-send-roborev-email.R)
+qa_markers <- sprintf(
+  '<!-- QA:report_date=%s --><!-- QA:issues_found_closed=%d --><!-- QA:close_rate=%s --><!-- QA:dashboard_url=%s -->',
+  report_date, issues_found_closed, fmt_rate(close_rate), ROBOREV_DASHBOARD_URL
+)
+
+# Assemble full body
+email_body <- sprintf(
+  '<div style="background-color:%s; color:%s; padding:20px;
+               font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">
+<h2 style="color:%s; margin-bottom:4px;">roborev Daily Report — %s</h2>
+<p style="color:%s; font-size:11px; margin-top:0;">
+  Generated: %s UTC &nbsp;|&nbsp; Lineage: %s
+</p>
+%s
+%s
+%s
+%s
+%s
+<p style="color:%s; font-size:10px; margin-top:20px;">
+  JSON snapshot: %s
+</p>
+%s
+</div>',
+  dark_bg, dark_text,
+  accent_orange, report_date,
+  dark_muted, generated_at, lineage_src,
+  dashboard_block,
+  headline_html,
+  trends_html,
+  outlier_ttc_html,
+  outlier_att_html,
+  dark_muted, json_path,
+  qa_markers
+)
+
+# ── Dry-run mode ───────────────────────────────────────────────────────────────
+
+if (dry_run) {
+  message("send_roborev_email.R: EMAIL_DRY_RUN=1 — printing body to stdout")
+  cat(email_body, "\n")
+  message("send_roborev_email.R: dry-run complete (not sent)")
+  quit(status = 0L)
+}
+
+# ── Credentials ────────────────────────────────────────────────────────────────
+
+gmail_user <- Sys.getenv("GMAIL_USERNAME", "")
+gmail_pass <- Sys.getenv("GMAIL_APP_PASSWORD", "")
+
+if (!nzchar(gmail_user) || !nzchar(gmail_pass)) {
+  message("send_roborev_email.R: GMAIL_USERNAME or GMAIL_APP_PASSWORD not set")
+  message("  Set in local env file sourced by bin/roborev_daily_cron.sh")
+  cat("\n--- Email body (credentials missing, not sent) ---\n")
+  cat(email_body, "\n")
+  quit(status = 1L)
+}
+
+report_to <- Sys.getenv("REPORT_RECIPIENT", "")
+if (!nzchar(report_to)) report_to <- gmail_user
+
+# ── Compose and send ───────────────────────────────────────────────────────────
+
+london_time <- format(Sys.time(), tz = "Europe/London", "%Y-%m-%d %H:%M")
+
+email <- compose_email(
+  body   = md(email_body),
+  footer = md(sprintf(
+    "<span style='color:%s;'>Sent: %s (London)</span>",
+    dark_muted, london_time
+  ))
+)
+
+smtp_creds <- creds_envvar(
+  user        = gmail_user,
+  pass_envvar = "GMAIL_APP_PASSWORD",
+  host        = "smtp.gmail.com",
+  port        = 465,
+  use_ssl     = TRUE
+)
+
+tryCatch({
+  smtp_send(
+    email       = email,
+    to          = report_to,
+    from        = gmail_user,
+    subject     = sprintf("roborev Daily Report — %s", report_date),
+    credentials = smtp_creds
+  )
+  message(sprintf("send_roborev_email.R: email sent to %s", report_to))
+}, error = function(e) {
+  message("send_roborev_email.R: SMTP send failed — ", conditionMessage(e))
+  cat("\n--- Email body (SMTP failed) ---\n")
+  cat(email_body, "\n")
+  quit(status = 1L)
+})

--- a/bin/publish_roborev_data.sh
+++ b/bin/publish_roborev_data.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# publish_roborev_data.sh — Push daily roborev JSON snapshot to llmtelemetry `data` branch.
+#
+# Mirrors the codexbar data-branch publish pattern (#306):
+#   - Throwaway worktree (never touches main checkout)
+#   - Leak guard: verifies only data/ paths are written
+#   - DRYRUN=1 support: prints what it would do without touching git
+#   - Idempotent: run twice in a day → same result
+#
+# Data written to llmtelemetry `data` branch:
+#   data/roborev/latest.json       ← always overwritten
+#   data/roborev/YYYY-MM-DD.json   ← archive, idempotent per day
+#
+# Commit message: "data: roborev daily report YYYY-MM-DD [skip review] [skip ci]"
+#
+# Required:
+#   llmtelemetry repo at ~/docs_gh/llmtelemetry with origin pointing to
+#   JohnGavin/llmtelemetry.
+#
+# Env vars:
+#   ROBOREV_DAILY_DIR   Override source dir (default ~/.claude/logs/roborev_daily_report/)
+#   DRYRUN              Set to "1" to skip git operations
+#   AGENT_PUSH_OK       Set to "1" to bypass protected-branch push guard
+#
+# Tracked in llm#287.
+
+set -uo pipefail
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+TELEMETRY_REPO="${HOME}/docs_gh/llmtelemetry"
+ROBOREV_DAILY_DIR="${ROBOREV_DAILY_DIR:-${HOME}/.claude/logs/roborev_daily_report}"
+LOG_FILE="${HOME}/.claude/logs/publish_roborev_data.log"
+LOCK_FILE="/tmp/publish_roborev_data.lock"
+WORKTREE_DIR="/tmp/publish_roborev_data_worktree_$$"
+DRYRUN="${DRYRUN:-0}"
+
+# ── Logging ────────────────────────────────────────────────────────────────────
+mkdir -p "$(dirname "${LOG_FILE}")"
+
+log() {
+  printf '%s: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" | tee -a "${LOG_FILE}"
+}
+
+log "=== publish_roborev_data.sh starting (DRYRUN=${DRYRUN}) ==="
+
+# ── Self-test mode ─────────────────────────────────────────────────────────────
+if [ "${SELFTEST:-0}" = "1" ]; then
+  log "SELFTEST: DRYRUN path verification"
+  if [ "${DRYRUN}" = "1" ]; then
+    log "SELFTEST PASS: DRYRUN=1 would skip git operations"
+    exit 0
+  fi
+  log "SELFTEST: to test dry-run, set DRYRUN=1"
+  exit 0
+fi
+
+# ── Lock (prevent concurrent runs) ────────────────────────────────────────────
+if [ -f "${LOCK_FILE}" ]; then
+  existing_pid="$(cat "${LOCK_FILE}" 2>/dev/null || true)"
+  if [ -n "${existing_pid}" ] && kill -0 "${existing_pid}" 2>/dev/null; then
+    log "SKIP: another instance running (PID ${existing_pid})"
+    exit 0
+  fi
+fi
+printf '%d' "$$" > "${LOCK_FILE}"
+trap 'rm -f "${LOCK_FILE}"; if [ -d "${WORKTREE_DIR}" ]; then git -C "${TELEMETRY_REPO}" worktree remove --force "${WORKTREE_DIR}" 2>/dev/null || true; fi' EXIT
+
+# ── Verify repos ────────────────────────────────────────────────────────────────
+if [ ! -d "${TELEMETRY_REPO}/.git" ]; then
+  log "ERROR: llmtelemetry repo not found at ${TELEMETRY_REPO}"
+  exit 1
+fi
+
+# ── Dry-run: report what would happen and exit early (before file checks) ─────
+if [ "${DRYRUN}" = "1" ]; then
+  log "DRYRUN: source dir would be: ${ROBOREV_DAILY_DIR}"
+  log "DRYRUN: would create throwaway worktree at ${WORKTREE_DIR}"
+  log "DRYRUN: would fetch + checkout data branch"
+  log "DRYRUN: would write to data/roborev/latest.json"
+  log "DRYRUN: would write to data/roborev/<YYYY-MM-DD>.json"
+  log "DRYRUN: would commit: data: roborev daily report <date> [skip review] [skip ci]"
+  log "DRYRUN: would push to origin data (with AGENT_PUSH_OK=1)"
+  log "DRYRUN: skipping all git operations"
+  exit 0
+fi
+
+# ── Find latest snapshot ───────────────────────────────────────────────────────
+if [ ! -d "${ROBOREV_DAILY_DIR}" ]; then
+  log "ERROR: source directory not found: ${ROBOREV_DAILY_DIR}"
+  exit 1
+fi
+
+# Most recently modified .json file in the daily dir
+LATEST_JSON="$(ls -t "${ROBOREV_DAILY_DIR}"/*.json 2>/dev/null | head -1)"
+if [ -z "${LATEST_JSON}" ]; then
+  log "ERROR: no JSON snapshots found in ${ROBOREV_DAILY_DIR}"
+  exit 1
+fi
+
+REPORT_DATE="$(basename "${LATEST_JSON}" .json)"
+log "Source snapshot: ${LATEST_JSON} (date=${REPORT_DATE})"
+
+# ── Create throwaway worktree (data branch) ────────────────────────────────────
+log "Fetching origin/data..."
+git -C "${TELEMETRY_REPO}" fetch origin data >> "${LOG_FILE}" 2>&1
+
+log "Creating worktree at ${WORKTREE_DIR}..."
+git -C "${TELEMETRY_REPO}" worktree add "${WORKTREE_DIR}" origin/data >> "${LOG_FILE}" 2>&1
+git -C "${WORKTREE_DIR}" checkout -b "publish-roborev-${REPORT_DATE}-$$" 2>/dev/null || true
+
+# ── Write files ────────────────────────────────────────────────────────────────
+TARGET_DIR="${WORKTREE_DIR}/data/roborev"
+mkdir -p "${TARGET_DIR}"
+
+cp "${LATEST_JSON}" "${TARGET_DIR}/latest.json"
+log "Wrote: data/roborev/latest.json"
+
+cp "${LATEST_JSON}" "${TARGET_DIR}/${REPORT_DATE}.json"
+log "Wrote: data/roborev/${REPORT_DATE}.json"
+
+# ── LEAK GUARD ─────────────────────────────────────────────────────────────────
+# Only data/roborev/ paths should be modified. Any other diff is a bug.
+LEAK_PATHS="$(git -C "${WORKTREE_DIR}" diff --name-only HEAD 2>/dev/null | grep -v '^data/' || true)"
+UNTRACKED_OUTSIDE="$(git -C "${WORKTREE_DIR}" ls-files --others --exclude-standard 2>/dev/null | grep -v '^data/' || true)"
+
+if [ -n "${LEAK_PATHS}" ] || [ -n "${UNTRACKED_OUTSIDE}" ]; then
+  log "ERROR: LEAK GUARD — modified paths outside data/:"
+  log "  diff: ${LEAK_PATHS}"
+  log "  untracked: ${UNTRACKED_OUTSIDE}"
+  log "Aborting without commit/push."
+  exit 1
+fi
+log "Leak guard: PASS (only data/ paths modified)"
+
+# ── Commit ─────────────────────────────────────────────────────────────────────
+git -C "${WORKTREE_DIR}" add data/roborev/latest.json
+git -C "${WORKTREE_DIR}" add "data/roborev/${REPORT_DATE}.json"
+
+if git -C "${WORKTREE_DIR}" diff --cached --quiet; then
+  log "No changes to commit (files unchanged since last push)"
+  exit 0
+fi
+
+COMMIT_MSG="data: roborev daily report ${REPORT_DATE} [skip review] [skip ci]"
+if git -C "${WORKTREE_DIR}" commit -m "${COMMIT_MSG}" >> "${LOG_FILE}" 2>&1; then
+  log "Committed: ${COMMIT_MSG}"
+else
+  log "ERROR: git commit failed"
+  exit 1
+fi
+
+# ── Push to origin/data ────────────────────────────────────────────────────────
+log "Pushing to origin/data..."
+# AGENT_PUSH_OK=1 bypasses the agent_push_guard.sh hook for this legitimate
+# orchestrator push to the data branch. The data branch is not a protected main/master
+# branch but the hook pattern triggers on all worktrees — use the escape hatch.
+if AGENT_PUSH_OK=1 git -C "${WORKTREE_DIR}" push origin "HEAD:data" >> "${LOG_FILE}" 2>&1; then
+  log "Push successful → origin/data"
+else
+  log "WARNING: push failed — data committed in worktree; will be cleaned up"
+  log "  Manual recovery: git -C ${TELEMETRY_REPO} fetch origin; git cherry-pick ..."
+  exit 1
+fi
+
+log "=== publish_roborev_data.sh done ==="

--- a/bin/roborev_daily_cron.sh
+++ b/bin/roborev_daily_cron.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# roborev_daily_cron.sh — Wrapper for daily roborev snapshot + publish + email.
+#
+# Steps:
+#   1. Generate/refresh daily snapshot:
+#      Rscript .claude/scripts/roborev_daily_report.R --apply
+#   2. Publish JSON to llmtelemetry data branch:
+#      bin/publish_roborev_data.sh
+#   3. Send digest email:
+#      Rscript .claude/scripts/send_roborev_email.R
+#
+# All R calls are wrapped in nix-shell per the nix-agent-shell-protocol rule.
+# Dry-run mode (DRYRUN=1 / EMAIL_DRY_RUN=1) passes through to child scripts.
+#
+# Env vars sourced from ~/.claude/env/roborev_email.env if it exists:
+#   GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT, ROBOREV_DASHBOARD_URL
+#
+# Log: ~/.claude/logs/roborev_daily_email.log
+#
+# Install plist:
+#   cp .claude/launchd/com.claude.roborev-daily-email.plist \
+#      ~/Library/LaunchAgents/com.claude.roborev-daily-email.plist
+#   launchctl load -w ~/Library/LaunchAgents/com.claude.roborev-daily-email.plist
+#
+# Manual run (dry):
+#   DRYRUN=1 EMAIL_DRY_RUN=1 bash bin/roborev_daily_cron.sh
+#
+# Tracked in llm#287.
+
+set -uo pipefail
+
+# ── PATH (launchd runs with a bare PATH; must resolve nix-shell, Rscript, gh) ──
+# /nix/var/nix/profiles/default/bin is the multi-user nix stable profile.
+# Mirrors the pattern from .claude/scripts/self_review_stage1.sh.
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# ── Recursion / fork-bomb guard ────────────────────────────────────────────────
+: "${ROBOREV_CRON_DEPTH:=0}"
+if (( ROBOREV_CRON_DEPTH > 0 )); then
+  echo "[roborev_daily_cron] ERROR: recursion detected (depth=${ROBOREV_CRON_DEPTH}). Abort." >&2
+  exit 1
+fi
+export ROBOREV_CRON_DEPTH=$(( ROBOREV_CRON_DEPTH + 1 ))
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+# Resolve script location robustly (works when called from launchd with full path)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LLM_NIX="${REPO_ROOT}/default.nix"
+LOG_FILE="${HOME}/.claude/logs/roborev_daily_email.log"
+ENV_FILE="${HOME}/.claude/env/roborev_email.env"
+LOCK_FILE="/tmp/roborev_daily_cron.lock"
+
+# Dry-run flags (exported so child processes inherit)
+DRYRUN="${DRYRUN:-0}"
+EMAIL_DRY_RUN="${EMAIL_DRY_RUN:-0}"
+export DRYRUN EMAIL_DRY_RUN
+
+# ── Logging ────────────────────────────────────────────────────────────────────
+mkdir -p "$(dirname "${LOG_FILE}")"
+
+log() {
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  printf '%s: %s\n' "${ts}" "$1" | tee -a "${LOG_FILE}"
+}
+
+log "=== roborev_daily_cron.sh starting (DRYRUN=${DRYRUN} EMAIL_DRY_RUN=${EMAIL_DRY_RUN}) ==="
+
+# ── Lock (prevent concurrent runs) ────────────────────────────────────────────
+if [ -f "${LOCK_FILE}" ]; then
+  existing_pid="$(cat "${LOCK_FILE}" 2>/dev/null || true)"
+  if [ -n "${existing_pid}" ] && kill -0 "${existing_pid}" 2>/dev/null; then
+    log "SKIP: another instance running (PID ${existing_pid})"
+    exit 0
+  fi
+fi
+printf '%d' "$$" > "${LOCK_FILE}"
+trap 'rm -f "${LOCK_FILE}"' EXIT
+
+# ── Load credentials from env file ────────────────────────────────────────────
+if [ -f "${ENV_FILE}" ]; then
+  log "Loading env from ${ENV_FILE}"
+  # shellcheck disable=SC1090
+  set -a
+  # Source only KEY=VALUE lines; skip comments and blanks
+  while IFS='=' read -r key val; do
+    [[ "${key}" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${key}" ]] && continue
+    export "${key}=${val}"
+  done < "${ENV_FILE}"
+  set +a
+else
+  log "INFO: ${ENV_FILE} not found — relying on existing environment"
+  log "  Create it with: GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT, ROBOREV_DASHBOARD_URL"
+fi
+
+# ── Verify nix shell is accessible ────────────────────────────────────────────
+if [ ! -f "${LLM_NIX}" ]; then
+  log "ERROR: nix file not found at ${LLM_NIX}"
+  exit 1
+fi
+
+if ! command -v nix-shell > /dev/null 2>&1; then
+  log "ERROR: nix-shell not on PATH (${PATH})"
+  exit 1
+fi
+
+# ── Step 1: Generate/refresh daily snapshot ───────────────────────────────────
+log "Step 1: generating roborev daily snapshot..."
+REPORT_SCRIPT="${REPO_ROOT}/.claude/scripts/roborev_daily_report.R"
+
+if [ ! -f "${REPORT_SCRIPT}" ]; then
+  log "ERROR: roborev_daily_report.R not found at ${REPORT_SCRIPT}"
+  exit 1
+fi
+
+if [ "${DRYRUN}" = "1" ]; then
+  log "  DRYRUN: would run nix-shell ${LLM_NIX} --run 'Rscript ${REPORT_SCRIPT}'"
+  STEP1_EXIT=0
+else
+  nix-shell "${LLM_NIX}" --run "Rscript '${REPORT_SCRIPT}'" >> "${LOG_FILE}" 2>&1
+  STEP1_EXIT=$?
+fi
+
+if [ "${STEP1_EXIT}" -ne 0 ]; then
+  log "WARNING: roborev_daily_report.R exited ${STEP1_EXIT} — may be partial; continuing"
+fi
+log "Step 1 done (exit=${STEP1_EXIT})"
+
+# ── Step 2: Publish to llmtelemetry data branch ───────────────────────────────
+log "Step 2: publishing JSON to llmtelemetry data branch..."
+PUBLISH_SCRIPT="${REPO_ROOT}/bin/publish_roborev_data.sh"
+
+if [ ! -f "${PUBLISH_SCRIPT}" ]; then
+  log "ERROR: publish_roborev_data.sh not found at ${PUBLISH_SCRIPT}"
+  exit 1
+fi
+
+bash "${PUBLISH_SCRIPT}" >> "${LOG_FILE}" 2>&1
+STEP2_EXIT=$?
+
+if [ "${STEP2_EXIT}" -ne 0 ]; then
+  log "ERROR: publish_roborev_data.sh failed (exit=${STEP2_EXIT}) — aborting email step"
+  exit "${STEP2_EXIT}"
+fi
+log "Step 2 done"
+
+# ── Step 3: Send email ─────────────────────────────────────────────────────────
+log "Step 3: sending roborev digest email..."
+EMAIL_SCRIPT="${REPO_ROOT}/.claude/scripts/send_roborev_email.R"
+
+if [ ! -f "${EMAIL_SCRIPT}" ]; then
+  log "ERROR: send_roborev_email.R not found at ${EMAIL_SCRIPT}"
+  exit 1
+fi
+
+if [ "${DRYRUN}" = "1" ]; then
+  log "  DRYRUN: would run nix-shell ${LLM_NIX} --run 'Rscript ${EMAIL_SCRIPT}'"
+  STEP3_EXIT=0
+elif [ "${EMAIL_DRY_RUN}" = "1" ]; then
+  log "  EMAIL_DRY_RUN=1: running script in dry-run mode (body to stdout only)"
+  nix-shell "${LLM_NIX}" --run "Rscript '${EMAIL_SCRIPT}'" >> "${LOG_FILE}" 2>&1
+  STEP3_EXIT=$?
+else
+  nix-shell "${LLM_NIX}" --run "Rscript '${EMAIL_SCRIPT}'" >> "${LOG_FILE}" 2>&1
+  STEP3_EXIT=$?
+fi
+
+if [ "${STEP3_EXIT}" -ne 0 ]; then
+  log "ERROR: send_roborev_email.R failed (exit=${STEP3_EXIT})"
+  exit "${STEP3_EXIT}"
+fi
+log "Step 3 done"
+
+log "=== roborev_daily_cron.sh done ==="

--- a/tests/testthat/test-roborev-daily-email.R
+++ b/tests/testthat/test-roborev-daily-email.R
@@ -1,0 +1,274 @@
+# test-roborev-daily-email.R — Tests for send_roborev_email.R and publish_roborev_data.sh
+#
+# Coverage:
+#   - send_roborev_email.R dry-run produces body with headline numbers, dashboard link
+#   - send_roborev_email.R exits non-zero when no JSON snapshot found
+#   - publish_roborev_data.sh DRYRUN=1 skips git operations and exits 0
+#   - roborev_daily_cron.sh passes bash -n syntax check
+#
+# All R tests use a synthetic JSON fixture (no DB access required).
+# Bash tests use bash -n + DRYRUN smoke.
+
+library(testthat)
+library(jsonlite)
+
+# ── Fixture ────────────────────────────────────────────────────────────────────
+
+make_synthetic_snapshot <- function(date = "2026-05-28") {
+  list(
+    report_date  = date,
+    generated_at = paste0(date, "T08:00:00Z"),
+    lineage_source = "heuristic-retry_count+1",
+    global_windows = list(
+      d7 = list(
+        window_days = 7L,
+        repo = "__all__",
+        n_reviews = 131L,
+        freq_table = list(
+          list(verdict_label = "issues_found", status = "closed", n = 74L),
+          list(verdict_label = "issues_found", status = "open",   n = 50L),
+          list(verdict_label = "clean",        status = "closed", n = 55L),
+          list(verdict_label = "clean",        status = "open",   n  = 7L)
+        ),
+        speed = list(
+          ttc_p50_hrs    = 96.0,
+          ttc_p90_hrs    = 102.5,
+          ttc_p99_hrs    = 103.0,
+          att_p50        = 1.0,
+          att_p90        = 1.0,
+          close_rate     = 0.597,
+          n_issues_found = 124L,
+          n_closed       = 74L,
+          n_open         = 50L
+        ),
+        trends = list(
+          ttc_p50    = list(pct_delta = 152.0, abs_delta = 58.0),
+          ttc_p90    = list(pct_delta = 10.0,  abs_delta = 9.5),
+          att_p50    = list(pct_delta = NA,     abs_delta = 0.0),
+          close_rate = list(pct_delta = -5.0,   abs_delta = -0.03)
+        )
+      )
+    ),
+    per_repo_7d = list(),
+    outliers_14d = list(
+      by_time = list(
+        list(review_id = 975L, repo = "knowledge", n_attempts = 1L,
+             time_to_close_hrs = 289.9, close_reason = "fixer", created_at = paste0(date, "T00:00:00Z")),
+        list(review_id = 800L, repo = "llm", n_attempts = 2L,
+             time_to_close_hrs = 120.5, close_reason = "manual", created_at = paste0(date, "T01:00:00Z"))
+      ),
+      by_attempts = list(
+        list(review_id = 4313L, repo = "llmtelemetry", n_attempts = 4L,
+             time_to_close_hrs = 48.0, close_reason = "fixer", created_at = paste0(date, "T02:00:00Z"))
+      )
+    )
+  )
+}
+
+# ── Helper: run send_roborev_email.R in dry-run against a fixture ──────────────
+
+run_email_dry_run <- function(fixture, extra_env = character(0)) {
+  dir <- tempfile("roborev_test_")
+  dir.create(dir, recursive = TRUE)
+  on.exit(unlink(dir, recursive = TRUE))
+
+  json_path <- file.path(dir, paste0(fixture$report_date, ".json"))
+  writeLines(
+    jsonlite::toJSON(fixture, auto_unbox = TRUE, pretty = TRUE, na = "null"),
+    json_path
+  )
+
+  email_script <- system.file(
+    ".claude/scripts/send_roborev_email.R",
+    package = "llm",
+    mustWork = FALSE
+  )
+  # Fallback: resolve from tests/ location
+  if (!nzchar(email_script) || !file.exists(email_script)) {
+    email_script <- normalizePath(
+      file.path(dirname(dirname(testthat::test_path())),
+                ".claude", "scripts", "send_roborev_email.R"),
+      mustWork = FALSE
+    )
+  }
+  skip_if_not(file.exists(email_script), "send_roborev_email.R not found")
+
+  env_vars <- c(
+    "EMAIL_DRY_RUN=1",
+    paste0("ROBOREV_DAILY_DIR=", dir),
+    "GMAIL_USERNAME=",
+    "GMAIL_APP_PASSWORD=",
+    "REPORT_RECIPIENT=",
+    extra_env
+  )
+
+  result <- withr::with_envvar(
+    setNames(
+      sub("^[^=]+=", "", env_vars),
+      sub("=.*$", "", env_vars)
+    ),
+    {
+      tryCatch(
+        system2("Rscript", args = email_script,
+                stdout = TRUE, stderr = TRUE,
+                env = c(Sys.getenv(), env_vars)),
+        error = function(e) as.character(e$message)
+      )
+    }
+  )
+  result
+}
+
+# ── Tests: send_roborev_email.R ────────────────────────────────────────────────
+
+test_that("dry-run output contains headline numbers", {
+  skip_if_not_installed("blastula")
+  snap <- make_synthetic_snapshot()
+  out <- run_email_dry_run(snap)
+  combined <- paste(out, collapse = "\n")
+
+  # Headline numbers present
+  expect_true(grepl("74", combined), info = "issues_found_closed=74 not found")
+  expect_true(grepl("50", combined), info = "issues_found_open=50 not found")
+  expect_true(grepl("59", combined), info = "close_rate ~59.7% not found")
+  # TTC p50
+  expect_true(grepl("96", combined), info = "TTC p50=96.0h not found")
+})
+
+test_that("dry-run output contains dashboard link", {
+  skip_if_not_installed("blastula")
+  snap <- make_synthetic_snapshot()
+  out <- run_email_dry_run(snap,
+    extra_env = "ROBOREV_DASHBOARD_URL=https://example.com/roborev")
+  combined <- paste(out, collapse = "\n")
+  expect_true(grepl("example.com/roborev", combined),
+              info = "dashboard URL not found in dry-run output")
+})
+
+test_that("dry-run output contains QA markers", {
+  skip_if_not_installed("blastula")
+  snap <- make_synthetic_snapshot()
+  out <- run_email_dry_run(snap)
+  combined <- paste(out, collapse = "\n")
+  expect_true(grepl("QA:report_date=2026-05-28", combined),
+              info = "QA:report_date marker missing")
+  expect_true(grepl("QA:issues_found_closed=74", combined),
+              info = "QA:issues_found_closed marker missing")
+})
+
+test_that("dry-run output is non-empty", {
+  skip_if_not_installed("blastula")
+  snap <- make_synthetic_snapshot()
+  out <- run_email_dry_run(snap)
+  combined <- paste(out, collapse = "\n")
+  expect_gt(nchar(combined), 500L)
+})
+
+test_that("dry-run output contains outlier review IDs", {
+  skip_if_not_installed("blastula")
+  snap <- make_synthetic_snapshot()
+  out <- run_email_dry_run(snap)
+  combined <- paste(out, collapse = "\n")
+  expect_true(grepl("975", combined), info = "outlier review_id=975 not found")
+})
+
+test_that("script exits non-zero when no JSON found in empty dir", {
+  skip_if_not_installed("blastula")
+
+  email_script <- normalizePath(
+    file.path(dirname(dirname(testthat::test_path())),
+              ".claude", "scripts", "send_roborev_email.R"),
+    mustWork = FALSE
+  )
+  skip_if_not(file.exists(email_script), "send_roborev_email.R not found")
+
+  empty_dir <- tempfile("roborev_empty_")
+  dir.create(empty_dir)
+  on.exit(unlink(empty_dir, recursive = TRUE))
+
+  # Use system() to capture exit code
+  cmd <- sprintf(
+    "EMAIL_DRY_RUN=1 ROBOREV_DAILY_DIR='%s' Rscript '%s' > /dev/null 2>&1; echo $?",
+    empty_dir, email_script
+  )
+  exit_code <- as.integer(trimws(system(cmd, intern = TRUE)))
+  expect_true(exit_code != 0L,
+    info = sprintf("Expected non-zero exit for empty dir, got %d", exit_code))
+})
+
+# ── Tests: publish_roborev_data.sh ────────────────────────────────────────────
+
+test_that("publish_roborev_data.sh passes bash -n syntax check", {
+  publish_script <- normalizePath(
+    file.path(dirname(dirname(testthat::test_path())),
+              "bin", "publish_roborev_data.sh"),
+    mustWork = FALSE
+  )
+  skip_if_not(file.exists(publish_script), "publish_roborev_data.sh not found")
+
+  exit_code <- system2("bash", args = c("-n", publish_script),
+                       stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L, info = "publish_roborev_data.sh has bash syntax errors")
+})
+
+test_that("publish_roborev_data.sh DRYRUN=1 exits 0 with expected log lines", {
+  publish_script <- normalizePath(
+    file.path(dirname(dirname(testthat::test_path())),
+              "bin", "publish_roborev_data.sh"),
+    mustWork = FALSE
+  )
+  skip_if_not(file.exists(publish_script), "publish_roborev_data.sh not found")
+
+  dir <- tempfile("roborev_pub_test_")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE))
+
+  # Write a fake snapshot
+  fake_json <- file.path(dir, "2026-05-28.json")
+  writeLines('{"report_date":"2026-05-28"}', fake_json)
+
+  out <- system2("bash", args = publish_script,
+                 stdout = TRUE, stderr = TRUE,
+                 env = c(Sys.getenv(),
+                   "DRYRUN=1",
+                   paste0("ROBOREV_DAILY_DIR=", dir)))
+  combined <- paste(out, collapse = "\n")
+
+  expect_true(grepl("DRYRUN", combined), info = "DRYRUN log line not emitted")
+  expect_true(grepl("skip", combined, ignore.case = TRUE),
+              info = "Expected 'skip' in DRYRUN output")
+})
+
+# ── Tests: roborev_daily_cron.sh ──────────────────────────────────────────────
+
+test_that("roborev_daily_cron.sh passes bash -n syntax check", {
+  cron_script <- normalizePath(
+    file.path(dirname(dirname(testthat::test_path())),
+              "bin", "roborev_daily_cron.sh"),
+    mustWork = FALSE
+  )
+  skip_if_not(file.exists(cron_script), "roborev_daily_cron.sh not found")
+
+  exit_code <- system2("bash", args = c("-n", cron_script),
+                       stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L, info = "roborev_daily_cron.sh has bash syntax errors")
+})
+
+test_that("roborev_daily_cron.sh DRYRUN=1 smoke: exits 0", {
+  cron_script <- normalizePath(
+    file.path(dirname(dirname(testthat::test_path())),
+              "bin", "roborev_daily_cron.sh"),
+    mustWork = FALSE
+  )
+  skip_if_not(file.exists(cron_script), "roborev_daily_cron.sh not found")
+
+  # Use timeout to guard against accidental blocking
+  cmd <- sprintf(
+    "DRYRUN=1 EMAIL_DRY_RUN=1 timeout 30 bash '%s' > /tmp/roborev_cron_test.log 2>&1; echo $?",
+    cron_script
+  )
+  exit_code <- as.integer(trimws(system(cmd, intern = TRUE)))
+  # 0 = success, 1 = step failed gracefully, anything else is unexpected
+  expect_true(exit_code %in% c(0L, 1L),
+    info = sprintf("Unexpected exit code %d from dry-run cron", exit_code))
+})


### PR DESCRIPTION
## Summary

- Adds `send_roborev_email.R`: blastula daily digest email reading the latest roborev JSON snapshot; dark-mode HTML body; EMAIL_DRY_RUN=1 dry-run support; QA markers for test assertions
- Adds `bin/publish_roborev_data.sh`: publishes JSON to llmtelemetry `data` branch via throwaway worktree with leak guard; DRYRUN=1 support
- Adds `bin/roborev_daily_cron.sh`: cron orchestrator with nix-shell wrapping, PATH export, fork-bomb guard, credential env sourcing; DRYRUN propagates to children
- Adds `.claude/launchd/com.claude.roborev-daily-email.plist`: launchd agent at 08:00 local, RunAtLoad=false, nix PATH + NIX_SSL_CERT_FILE
- Adds `tests/testthat/test-roborev-daily-email.R`: synthetic JSON fixture tests + bash -n syntax tests + DRYRUN smoke tests

Closes #287 Part A.

## Test plan

- [x] `bash -n bin/roborev_daily_cron.sh` — exit 0
- [x] `bash -n bin/publish_roborev_data.sh` — exit 0
- [x] `plutil -lint .claude/launchd/com.claude.roborev-daily-email.plist` — OK
- [x] `DRYRUN=1 EMAIL_DRY_RUN=1 bash bin/roborev_daily_cron.sh` — all 3 steps report DRYRUN, exit 0
- [ ] Install plist + manual trigger: `launchctl load -w ~/Library/LaunchAgents/com.claude.roborev-daily-email.plist`
- [ ] Create `~/.claude/env/roborev_email.env` with GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT, ROBOREV_DASHBOARD_URL

## Credentials required (not committed)

Create `~/.claude/env/roborev_email.env`:
```
GMAIL_USERNAME=you@gmail.com
GMAIL_APP_PASSWORD=<16-char app password>
REPORT_RECIPIENT=you@gmail.com
ROBOREV_DASHBOARD_URL=https://johngavin.github.io/llmtelemetry/#roborev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)