### PR TITLE
feat(agent_push_guard): block cross-worktree branch pushes (#318)

### DIFF
--- a/.claude/hooks/agent_push_guard.sh
+++ b/.claude/hooks/agent_push_guard.sh
@@ -3,21 +3,32 @@
 #
 # Blocks `git push` to main/master/release/prod when the push originates
 # from a Claude worktree (path matches .claude/worktrees/, /private/tmp/, /tmp/).
+# Also blocks pushes from a worktree to any ref that is not the worktree's
+# own current branch (guards against cross-worktree branch contamination).
 #
 # Rationale (llm#189): worktree-isolated agents have pushed to origin/main
 # despite "do NOT push" prompts, bypassing orchestrator review. This hook
 # enforces the policy at the tool-call level.
 #
-# Detection: BLOCK iff ALL three hold:
-#   1. Command is a git push or gh repo sync
-#   2. CWD or -C path is a Claude worktree
-#   3. Target ref resolves to a protected branch (main/master/release/*/prod/*)
+# Rationale (llm#318): agents have pushed to a sibling worktree's feature
+# branch instead of their own branch, causing dirty PRs and branch pollution.
+#
+# Detection: BLOCK iff ANY of the following hold from a worktree:
+#   Group A (protected-branch guard, llm#189) — ALL three:
+#     1. Command is a git push or gh repo sync
+#     2. CWD or -C path is a Claude worktree
+#     3. Target ref resolves to a protected branch (main/master/release/*/prod/*)
+#   Group B (cross-worktree guard, llm#318) — ALL three:
+#     1. Command is a git push or gh repo sync
+#     2. CWD or -C path is a Claude worktree
+#     3. Target ref was explicitly supplied AND differs from the worktree's
+#        current branch (prevents pushing to a sibling worktree's branch)
 #
 # Bypass: AGENT_PUSH_OK=1 git push ... (mirrors DESTRUCTIVE_CONFIRM= pattern)
 #
 # Self-test: CLAUDE_HOOK_SELFTEST=1 bash agent_push_guard.sh
 #
-# Source: llm#189
+# Sources: llm#189, llm#318
 
 set -euo pipefail
 
@@ -49,10 +60,16 @@ MODE="${AGENT_PUSH_GUARD_MODE:-$DEFAULT_MODE}"
 
 LOG_FILE="$HOME/.claude/logs/agent_push_blocked.log"
 WOULD_BLOCK_LOG="$HOME/.claude/logs/agent_push_would_block.log"
+CROSSBRANCH_LOG="$HOME/.claude/logs/agent_push_blocked_crossbranch.log"
 
 log_blocked() {
   mkdir -p "$(dirname "$LOG_FILE")"
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] BLOCKED push to protected branch: $1" >> "$LOG_FILE"
+}
+
+log_blocked_crossbranch() {
+  mkdir -p "$(dirname "$CROSSBRANCH_LOG")"
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] BLOCKED cross-worktree push: $1" >> "$CROSSBRANCH_LOG"
 }
 
 log_would_block() {
@@ -63,6 +80,11 @@ log_would_block() {
 log_allowed() {
   mkdir -p "$(dirname "$LOG_FILE")"
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] ALLOWED push (bypass): $1" >> "$LOG_FILE"
+}
+
+log_allowed_crossbranch_bypass() {
+  mkdir -p "$(dirname "$CROSSBRANCH_LOG")"
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ALLOWED cross-worktree push (bypass): $1" >> "$CROSSBRANCH_LOG"
 }
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -130,6 +152,39 @@ extract_target_branch() {
   fi
 }
 
+# Returns 1 (false) if the target branch was explicitly specified in the command
+# (i.e. not inferred from git). Used by the cross-worktree guard: we only block
+# when the caller explicitly named a branch that differs from HEAD — a missing
+# refspec means "push to my own tracking branch" which is always safe.
+target_was_explicit() {
+  local cmd="$1"
+  # Case A: HEAD:branch
+  echo "$cmd" | grep -qE 'HEAD:[^[:space:]]+' && return 0
+  # Case B: explicit refspec after the remote name (second word after 'push')
+  local after_push
+  after_push=$(echo "$cmd" | sed 's/.*push[[:space:]]*//')
+  local refspec
+  refspec=$(echo "$after_push" | awk '{print $2}')
+  [ -n "$refspec" ] && return 0
+  return 1
+}
+
+get_worktree_current_branch() {
+  local path="$1"
+  # Allow self-test to inject a fake current branch without needing a real git repo
+  if [ -n "${_SELFTEST_CURRENT_BRANCH:-}" ]; then
+    echo "$_SELFTEST_CURRENT_BRANCH"
+    return
+  fi
+  if [ -n "$path" ] && [ -d "$path" ]; then
+    git -C "$path" symbolic-ref --short HEAD 2>/dev/null \
+      || git -C "$path" rev-parse --abbrev-ref HEAD 2>/dev/null \
+      || echo ""
+  else
+    echo ""
+  fi
+}
+
 # Core decision function: returns "block" or "allow" with reason
 # Args: cmd, cwd
 decide() {
@@ -174,6 +229,18 @@ decide() {
   fi
 
   if ! echo "$target_branch" | grep -qE "$PROTECTED_BRANCH_PATTERN"; then
+    # Condition 4 (llm#318): cross-worktree branch guard.
+    # If the target ref was explicitly named AND differs from the worktree's
+    # own current branch, block — this is a cross-worktree contamination push.
+    # Only applies when we can determine the current branch (git accessible).
+    if target_was_explicit "$cmd"; then
+      local current_branch
+      current_branch=$(get_worktree_current_branch "$effective_path")
+      if [ -n "$current_branch" ] && [ "$target_branch" != "$current_branch" ]; then
+        echo "block-cross:$target_branch:$effective_path:$current_branch"
+        return
+      fi
+    fi
     echo "allow:feature-branch:$target_branch"
     return
   fi
@@ -188,7 +255,7 @@ decide() {
 if [ "${CLAUDE_HOOK_SELFTEST:-}" = "1" ]; then
   PASS=0
   FAIL=0
-  TOTAL=8
+  TOTAL=12
 
   # Temp log paths to avoid polluting production logs during self-test
   SELFTEST_LOG="/tmp/agent_push_selftest_blocked_$$"
@@ -203,8 +270,14 @@ if [ "${CLAUDE_HOOK_SELFTEST:-}" = "1" ]; then
     local cwd="$4"
     local result
     result=$(decide "$cmd" "$cwd")
+    local raw_action
+    raw_action=$(echo "$result" | cut -d: -f1)
+    # Normalise: "block-cross" counts as "block" for pass/fail purposes
     local actual
-    actual=$(echo "$result" | cut -d: -f1)
+    case "$raw_action" in
+      block*) actual="block" ;;
+      *)      actual="$raw_action" ;;
+    esac
     if [ "$actual" = "$expected" ]; then
       echo "$n/$TOTAL PASS  ($result)"
       PASS=$((PASS + 1))
@@ -221,8 +294,14 @@ if [ "${CLAUDE_HOOK_SELFTEST:-}" = "1" ]; then
     local mode="$3"
     local decision
     decision=$(decide "$cmd" "$cwd")
+    local raw_action
+    raw_action=$(echo "$decision" | cut -d: -f1)
+    # Normalise block-cross → block
     local action
-    action=$(echo "$decision" | cut -d: -f1)
+    case "$raw_action" in
+      block*) action="block" ;;
+      *)      action="$raw_action" ;;
+    esac
     if [ "$action" = "block" ] && [ "$mode" = "log" ]; then
       echo "allow"
     else
@@ -289,6 +368,36 @@ if [ "${CLAUDE_HOOK_SELFTEST:-}" = "1" ]; then
     "/Users/johngavin/docs_gh/llm/.claude/worktrees/agent-abc123" \
     "block"
 
+  # ── Cross-worktree guard (llm#318) ──────────────────────────────────────────
+  # Tests 9-12: worktree on branch X pushing to various targets
+  # _SELFTEST_CURRENT_BRANCH simulates the worktree being on branch "worktree-agent-abc123"
+
+  # 9: push from worktree-agent-abc123 to its OWN branch → ALLOW
+  _SELFTEST_CURRENT_BRANCH="worktree-agent-abc123" \
+  check_scenario 9 "allow" \
+    "git push origin worktree-agent-abc123" \
+    "/Users/johngavin/docs_gh/llm/.claude/worktrees/agent-abc123"
+
+  # 10: push from worktree-agent-abc123 to SIBLING branch feat/cc-20260524 → BLOCK
+  _SELFTEST_CURRENT_BRANCH="worktree-agent-abc123" \
+  check_scenario 10 "block" \
+    "git push origin feat/cc-20260524-221709" \
+    "/Users/johngavin/docs_gh/llm/.claude/worktrees/agent-abc123"
+
+  # 11: push from worktree on X to main → BLOCK (protected-branch check fires first)
+  _SELFTEST_CURRENT_BRANCH="worktree-agent-abc123" \
+  check_scenario 11 "block" \
+    "git push origin main" \
+    "/Users/johngavin/docs_gh/llm/.claude/worktrees/agent-abc123"
+
+  # 12: AGENT_PUSH_OK=1 bypass for cross-worktree push → ALLOW (bypass overrides both guards)
+  _SELFTEST_CURRENT_BRANCH="worktree-agent-abc123" \
+  check_scenario 12 "allow" \
+    "AGENT_PUSH_OK=1 git push origin feat/cc-20260524-221709" \
+    "/Users/johngavin/docs_gh/llm/.claude/worktrees/agent-abc123"
+
+  unset _SELFTEST_CURRENT_BRANCH
+
   # Cleanup temp test logs
   rm -f "$SELFTEST_LOG" "$SELFTEST_WOULD_LOG"
 
@@ -328,12 +437,61 @@ if [ "$ACTION" = "allow" ]; then
   exit 0
 fi
 
-# BLOCK path
-TARGET_BRANCH=$(echo "$DECISION" | cut -d: -f2)
-EFFECTIVE_PATH=$(echo "$DECISION" | cut -d: -f3)
-
 DISPLAY_CMD="${COMMAND:0:80}"
 [ ${#COMMAND} -gt 80 ] && DISPLAY_CMD="${DISPLAY_CMD}..."
+
+# ── Cross-worktree block path (llm#318) ─────────────────────────────────────
+if [ "$ACTION" = "block-cross" ]; then
+  TARGET_BRANCH=$(echo "$DECISION" | cut -d: -f2)
+  EFFECTIVE_PATH=$(echo "$DECISION" | cut -d: -f3)
+  CURRENT_BRANCH=$(echo "$DECISION" | cut -d: -f4)
+
+  if [ "$MODE" = "log" ]; then
+    log_would_block "cross-worktree: cmd=${DISPLAY_CMD} cwd=${EFFECTIVE_PATH} target=${TARGET_BRANCH} current=${CURRENT_BRANCH}"
+    cat >&2 <<EOF
+
+[agent_push_guard] LOG-ONLY MODE: would-block cross-worktree push.
+  Target '${TARGET_BRANCH}' != worktree branch '${CURRENT_BRANCH}'.
+  From: ${EFFECTIVE_PATH}
+Recorded to $WOULD_BLOCK_LOG — switch AGENT_PUSH_GUARD_MODE=block to enforce.
+Rule: agent-no-push-to-main.md | Issue: llm#318
+
+EOF
+    exit 0
+  fi
+
+  cat >&2 <<EOF
+
+╔═════════════════════════════════════════════════════════════════════════════╗
+║  BLOCKED — Agent worktree push to wrong branch (cross-worktree)             ║
+╠═════════════════════════════════════════════════════════════════════════════╣
+║                                                                             ║
+║  Command:         $DISPLAY_CMD
+║  Worktree path:   $EFFECTIVE_PATH
+║  Target ref:      $TARGET_BRANCH
+║  Worktree branch: $CURRENT_BRANCH
+║                                                                             ║
+║  Agents MUST push only to their own worktree branch.                        ║
+║  Pushing to a sibling worktree's branch contaminates another session.       ║
+║                                                                             ║
+║  Correct workflow:                                                           ║
+║    git push origin $CURRENT_BRANCH                                          ║
+║                                                                             ║
+║  To bypass (orchestrator/user only):                                        ║
+║    AGENT_PUSH_OK=1 git push origin $TARGET_BRANCH                           ║
+║                                                                             ║
+║  Rule: agent-no-push-to-main.md  |  Issue: llm#318                         ║
+╚═════════════════════════════════════════════════════════════════════════════╝
+
+EOF
+
+  log_blocked_crossbranch "$COMMAND (path=$EFFECTIVE_PATH, target=$TARGET_BRANCH, current=$CURRENT_BRANCH)"
+  exit 2
+fi
+
+# ── Protected-branch block path (llm#189) ───────────────────────────────────
+TARGET_BRANCH=$(echo "$DECISION" | cut -d: -f2)
+EFFECTIVE_PATH=$(echo "$DECISION" | cut -d: -f3)
 
 # Log-only mode: record what WOULD have been blocked, then allow through
 if [ "$MODE" = "log" ]; then

--- a/.claude/rules/agent-no-push-to-main.md
+++ b/.claude/rules/agent-no-push-to-main.md
@@ -1,25 +1,28 @@
 ---
 name: agent-no-push-to-main
-description: Prevents worktree-isolated agents from pushing to protected branches (main/master/release/prod).
+description: Prevents worktree-isolated agents from pushing to protected branches (main/master/release/prod) or to any branch other than their own worktree branch.
 type: enforcement
 ---
 
-# Rule: Agent Worktree — No Push to Protected Branches
+# Rule: Agent Worktree — No Push to Protected Branches or Sibling Branches
 
 ## Source
 
-llm#189 — 2026-05-18 session observation: 3 of 5 round-4 fixer agents
-auto-pushed to `origin/main` despite "do NOT push" instructions in the
-dispatch prompt. This rule enforces the boundary at the tool-call level,
-independent of prompt wording.
+- llm#189 — 2026-05-18: 3 of 5 round-4 fixer agents auto-pushed to `origin/main`
+  despite "do NOT push" prompts.
+- llm#318 — 2026-05-28: a nix-env agent pushed its commit to the orchestrator's
+  active session branch (`feat/cc-20260524-221709`) instead of its own worktree
+  branch (`worktree-agent-aab7e5cc16712b02c`), producing a dirty PR and
+  contaminating another session's working tree.
+
+Both cases are now blocked at the hook level, independent of prompt wording.
 
 ---
 
 ## When This Applies
 
 Any Bash tool call from inside a Claude worktree or ephemeral `/tmp/`
-workspace that contains `git push` or `gh repo sync` targeting a protected
-branch.
+workspace that contains `git push` or `gh repo sync`.
 
 ---
 
@@ -43,13 +46,18 @@ is now the default**.
 - In block mode: the push is rejected with exit code 2 and logged to `~/.claude/logs/agent_push_blocked.log`
 - To override the automatic default, set `AGENT_PUSH_GUARD_MODE=log` (revert to log-only) or `AGENT_PUSH_GUARD_MODE=block` (force enforce)
 
-The bypass for legitimate orchestrator pushes remains: `AGENT_PUSH_OK=1 git push origin <branch>` (per-command override, audit-logged).
+The bypass for legitimate orchestrator pushes remains: `AGENT_PUSH_OK=1 git push origin <branch>` (per-command override, audit-logged to the relevant log file).
 
 ---
 
 ## Detection Logic
 
-The hook blocks a command iff ALL THREE conditions hold simultaneously:
+The hook evaluates TWO independent block conditions. A push is blocked if
+either condition fires.
+
+### Guard A — Protected branch (llm#189)
+
+Blocks iff ALL THREE hold:
 
 | # | Condition | Detail |
 |---|---|---|
@@ -57,22 +65,39 @@ The hook blocks a command iff ALL THREE conditions hold simultaneously:
 | 2 | Effective path is a worktree | Path contains `.claude/worktrees/`, OR path is under `/private/tmp/` or `/tmp/` |
 | 3 | Target ref is protected | Ref matches `main`, `master`, `production`, `release/*`, or `prod/*` |
 
+### Guard B — Cross-worktree branch (llm#318)
+
+Blocks iff ALL THREE hold:
+
+| # | Condition | Detail |
+|---|---|---|
+| 1 | Command is a push | Same as Guard A condition 1 |
+| 2 | Effective path is a worktree | Same as Guard A condition 2 |
+| 3 | Target ref was explicitly named AND differs from the worktree's current branch | Detects pushes to a sibling worktree's branch |
+
+Guard B only fires when the caller explicitly names a push ref. A bare `git push origin` (no refspec) is always allowed because it can only push to the tracking branch, which is always the current branch.
+
+---
+
 ### Decision Table
 
-| Push from | Target | Action |
-|---|---|---|
-| Main checkout | `main` | **ALLOW** — orchestrator is pushing directly |
-| Worktree | `feat/foo` | **ALLOW** — feature branch push is the correct workflow |
-| Worktree | `main` | **BLOCK** (exit 2) |
-| `-C /tmp/scratch` | `main` | **BLOCK** — `/tmp/` treated as worktree |
-| Worktree | `release/2.0` | **BLOCK** — protected prefix |
-| Worktree | `main` (bypass) | **ALLOW** — `AGENT_PUSH_OK=1` present |
+| Push from | Target | Guard A | Guard B | Action |
+|---|---|---|---|---|
+| Main checkout | `main` | no (not worktree) | no | **ALLOW** — orchestrator is pushing directly |
+| Worktree on `worktree-agent-X` | own branch `worktree-agent-X` | no | no (same branch) | **ALLOW** — correct workflow |
+| Worktree | `feat/foo` (own branch) | no | no (same branch) | **ALLOW** |
+| Worktree on `worktree-agent-X` | `feat/cc-20260524` (sibling branch) | no | **yes** | **BLOCK** (exit 2) — cross-worktree |
+| Worktree | `main` | **yes** | — | **BLOCK** (exit 2) — protected |
+| `-C /tmp/scratch` | `main` | **yes** | — | **BLOCK** — `/tmp/` treated as worktree |
+| Worktree | `release/2.0` | **yes** | — | **BLOCK** — protected prefix |
+| Worktree | `main` (bypass) | bypassed | bypassed | **ALLOW** — `AGENT_PUSH_OK=1` present |
+| Worktree on X | sibling branch Y (bypass) | bypassed | bypassed | **ALLOW** — `AGENT_PUSH_OK=1` present |
 
 ---
 
 ## Bypass (Orchestrator / User Only)
 
-When a push to a protected branch is genuinely required from a worktree:
+When a push to a protected or cross-worktree branch is genuinely required:
 
 ```bash
 AGENT_PUSH_OK=1 git push origin <branch>
@@ -89,14 +114,14 @@ from the environment across command boundaries.
 ### What agents MUST do
 
 ```
-1. Commit work to a feature branch inside the worktree:
+1. Commit work to their feature branch inside the worktree:
      git -C /path/to/worktree commit -m "feat(hook): ..."
 
-2. Push to the feature branch (not main):
-     git -C /path/to/worktree push origin feat/your-branch
+2. Push to THEIR OWN branch (the worktree's current branch):
+     git -C /path/to/worktree push origin worktree-agent-<id>
 
 3. Open a PR via gh:
-     gh pr create --base main --head feat/your-branch --title "..."
+     gh pr create --base main --head worktree-agent-<id> --title "..."
 
 4. Stop. Orchestrator reviews and merges.
 ```
@@ -105,12 +130,58 @@ from the environment across command boundaries.
 
 ```
 Bash("git push origin main")
-  → hook detects: worktree + protected branch
+  → hook detects: worktree + protected branch (Guard A)
   → exits 2 with stderr message
   → agent sees: BLOCKED — Agent worktree push to protected branch
   → command never reaches the network
   → attempt logged to ~/.claude/logs/agent_push_blocked.log
 ```
+
+### What happens if the agent pushes to a sibling branch
+
+```
+Bash("git push origin feat/cc-20260524-221709")
+  → hook detects: worktree + explicit ref != current branch (Guard B)
+  → exits 2 with stderr message
+  → agent sees: BLOCKED — Agent worktree push to wrong branch (cross-worktree)
+  → command never reaches the network
+  → attempt logged to ~/.claude/logs/agent_push_blocked_crossbranch.log
+```
+
+---
+
+## Cross-worktree push block (llm#318)
+
+### What the incident was
+
+A nix-env agent dispatched with `isolation: "worktree"` (worktree at
+`.claude/worktrees/agent-aab7e5cc16712b02c`, branch `worktree-agent-aab7e5cc16712b02c`)
+pushed its commit to `feat/cc-20260524-221709` — the orchestrator's active
+session branch in a different worktree (`llm-feat-cc-20260524-221709`).
+
+The agent's `pwd` was correctly inside its own worktree and its current branch
+was correct, so the existing Tier-1 self-check passed and reported success.
+The push target ref, however, was the orchestrator's branch — not the agent's.
+
+The resulting PR (#315) appeared to revert recently-merged files because the
+orchestrator's session branch was stale relative to main.
+
+### The surgical fix
+
+Guard B in `agent_push_guard.sh` now computes the worktree's current branch via
+`git -C <effective_path> symbolic-ref --short HEAD` and compares it to the
+explicitly-supplied push ref. If they differ, the push is blocked with exit 2
+and logged to the cross-branch log (distinct path from the protected-branch log).
+
+### Audit logs
+
+| Log file | Contents |
+|---|---|
+| `~/.claude/logs/agent_push_blocked.log` | Pushes blocked by Guard A (protected branch) |
+| `~/.claude/logs/agent_push_blocked_crossbranch.log` | Pushes blocked by Guard B (cross-worktree) — **new in llm#318** |
+| `~/.claude/logs/agent_push_would_block.log` | Pushes that would have been blocked (log-only mode, both guards) |
+
+Keeping the two block logs separate allows auditing the two failure modes independently.
 
 ---
 
@@ -118,7 +189,8 @@ Bash("git push origin main")
 
 | Log file | Contents |
 |---|---|
-| `~/.claude/logs/agent_push_blocked.log` | Every blocked push attempt with timestamp, command, path, and target (enforce mode) |
+| `~/.claude/logs/agent_push_blocked.log` | Every blocked push attempt (Guard A — protected branch) with timestamp, command, path, and target (enforce mode) |
+| `~/.claude/logs/agent_push_blocked_crossbranch.log` | Every blocked push attempt (Guard B — cross-worktree branch) |
 | `~/.claude/logs/agent_push_would_block.log` | Pushes that would have been blocked but were allowed through (log-only mode soak) |
 
 ---
@@ -129,7 +201,11 @@ Bash("git push origin main")
 CLAUDE_HOOK_SELFTEST=1 bash ~/.claude/hooks/agent_push_guard.sh
 ```
 
-Expected output: `8/8 PASS`
+Expected output: `12/12 PASS`
+
+The 12 cases cover:
+- Cases 1–8: original protected-branch guard (Guard A) + mode checks
+- Cases 9–12: cross-worktree guard (Guard B) — own-branch allow, sibling-branch block, protected-branch-fires-first, bypass
 
 ---
 
@@ -140,4 +216,4 @@ Expected output: `8/8 PASS`
 - `bash-safety` rule — compound command guard (a different PreToolUse hook)
 - `auto-delegation` rule — "Mandatory: isolation:'worktree' for Agent dispatches with Bash"
 - Hook: `~/.claude/hooks/agent_push_guard.sh`
-- Issue: llm#189
+- Issues: llm#189, llm#318


### PR DESCRIPTION
## Summary

- Adds Guard B to `agent_push_guard.sh`: blocks pushes from a worktree when the explicitly-named target ref differs from the worktree's own current branch
- Fixes the incident from #318 where a nix-env agent pushed to the orchestrator's session branch instead of its own worktree branch
- Extends self-test from 8 to 12 cases (cases 9-12 cover the new guard)
- Updates rule doc with two-guard detection logic, expanded decision table, and new audit log path

## What changed

### `agent_push_guard.sh`

**New helpers:**
- `target_was_explicit()` — returns true if the push command has an explicit refspec (HEAD:branch, or second word after the remote name); only explicit pushes are subject to Guard B
- `get_worktree_current_branch()` — resolves current branch via `symbolic-ref --short HEAD` with `rev-parse` fallback; supports `_SELFTEST_CURRENT_BRANCH` override for self-test cases that don't have a real git repo
- `log_blocked_crossbranch()` / `log_allowed_crossbranch_bypass()` — audit to separate log file

**Guard B logic in `decide()`** (runs after Guard A's condition 3 passes, i.e. target is not a protected branch):
```
if target_was_explicit AND current_branch is known AND target != current_branch
  → echo "block-cross:$target:$effective_path:$current_branch"
```

**New block path in normal operation** handles `ACTION=block-cross` with its own error message quoting both target and current branch, logs to `agent_push_blocked_crossbranch.log`.

**Self-test expansion:** TOTAL bumped from 8 → 12, `check_scenario` normalises `block-cross` → `block` for pass/fail, `effective_action` also normalises.

### `agent-no-push-to-main.md`

- Title updated to mention sibling branches
- Detection logic section restructured into Guard A / Guard B tables
- Decision table gains cross-worktree rows
- New section "Cross-worktree push block (llm#318)" with incident description and design rationale
- Audit log table updated with new `agent_push_blocked_crossbranch.log` entry
- Self-test expected count updated to `12/12 PASS`

## Self-test output

```
1/12 PASS  (allow:not-worktree:/Users/johngavin/docs_gh/llm)
2/12 PASS  (block:main:/Users/johngavin/docs_gh/llm/.claude/worktrees/agent-abc123)
3/12 PASS  (allow:feature-branch:feat/foo)
4/12 PASS  (block:main:/tmp/scratch)
5/12 PASS  (allow:bypass)
6/12 PASS  (block:main:/Users/johngavin/docs_gh/llm/.claude/worktrees/agent-abc123)
7/12 PASS  (mode=log, effective=allow)
8/12 PASS  (mode=block, effective=block)
9/12 PASS  (allow:feature-branch:worktree-agent-abc123)
10/12 PASS  (block-cross:feat/cc-20260524-221709:/Users/johngavin/docs_gh/llm/.claude/worktrees/agent-abc123:worktree-agent-abc123)
11/12 PASS  (block:main:/Users/johngavin/docs_gh/llm/.claude/worktrees/agent-abc123)
12/12 PASS  (allow:bypass)

12/12 PASS
```

## New audit log path

`~/.claude/logs/agent_push_blocked_crossbranch.log` — distinct from the existing `agent_push_blocked.log` so the two failure modes (protected-branch vs cross-worktree) can be audited separately.

## `AGENT_PUSH_OK=1` bypass

Unchanged — the bypass check runs first in `decide()` and overrides both guards. Bypass events for cross-worktree pushes are now logged to `agent_push_blocked_crossbranch.log` via `log_allowed_crossbranch_bypass()`.

## Test plan

- [x] `bash -n .claude/hooks/agent_push_guard.sh` — syntax clean
- [x] `CLAUDE_HOOK_SELFTEST=1 bash .claude/hooks/agent_push_guard.sh` — `12/12 PASS`
- [x] Guard A (protected-branch) behaviour unchanged — cases 1-8 all pass
- [x] Guard B (cross-worktree) blocks sibling-branch push — case 10 passes
- [x] Guard B does not fire on own-branch push — case 9 passes
- [x] `AGENT_PUSH_OK=1` bypass overrides Guard B — case 12 passes

Closes #318. Related: #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
