### PR TITLE
fix(skills): SKILL.md front-matter strict-YAML compatibility (#230)

### DIFF
--- a/.claude/hooks/skill_quality_onwrite.sh
+++ b/.claude/hooks/skill_quality_onwrite.sh
@@ -68,7 +68,16 @@ elif [ "$WORDS" -gt 3500 ]; then
   WARNINGS=$((WARNINGS + 1))
 fi
 
-# 6. Check MANIFEST entry
+# 6. Check strict-YAML compatibility (Codex / serde_yaml parser — see llm#230)
+CHECKER_SCRIPT="$(dirname "$(dirname "$FILE")")/scripts/check_skill_frontmatter.sh"
+if [ -x "$CHECKER_SCRIPT" ]; then
+  if ! bash "$CHECKER_SCRIPT" "$(dirname "$(dirname "$FILE")")/skills" > /dev/null 2>&1; then
+    echo "SKILL WARN [$SKILL_NAME]: Front matter fails strict YAML (Codex-incompatible). Run check_skill_frontmatter.sh to diagnose."
+    WARNINGS=$((WARNINGS + 1))
+  fi
+fi
+
+# 7. Check MANIFEST entry
 MANIFEST="$(dirname "$(dirname "$FILE")")/MANIFEST.md"
 if [ -f "$MANIFEST" ]; then
   if ! grep -q "$SKILL_NAME" "$MANIFEST"; then

--- a/.claude/scripts/check_skill_frontmatter.sh
+++ b/.claude/scripts/check_skill_frontmatter.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# check_skill_frontmatter.sh — Validate SKILL.md front matter against strict YAML 1.2
+#
+# Usage: ./check_skill_frontmatter.sh [skills_dir]
+#   skills_dir defaults to .claude/skills relative to the repo root
+#
+# Exits 0 if all SKILL.md files have valid strict-YAML front matter.
+# Exits 1 if any file fails, printing the file path and error.
+#
+# Designed to be called from skill_quality_onwrite.sh or run manually before commit.
+# See llm#230 for motivation (Codex uses serde_yaml / YAML 1.2 strict parser).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$SCRIPT_DIR/../..")"
+
+SKILLS_DIR="${1:-$REPO_ROOT/.claude/skills}"
+
+if [ ! -d "$SKILLS_DIR" ]; then
+  echo "ERROR: skills directory not found: $SKILLS_DIR" >&2
+  exit 1
+fi
+
+FAIL_COUNT=0
+OK_COUNT=0
+
+while IFS= read -r -d '' skill_file; do
+  # Skip .system and generated directories
+  case "$skill_file" in
+    */.system/*|*/generated/*) continue ;;
+  esac
+
+  result=$(/usr/bin/python3 - "$skill_file" <<'PYEOF'
+import sys, yaml
+
+path = sys.argv[1]
+with open(path) as f:
+    content = f.read()
+
+if not content.startswith('---'):
+    print(f"NO_FM: no front matter")
+    sys.exit(1)
+
+end = content.find('\n---', 3)
+if end == -1:
+    print(f"NO_END: no closing ---")
+    sys.exit(1)
+
+fm = content[3:end].strip()
+try:
+    yaml.safe_load(fm)
+    sys.exit(0)
+except Exception as e:
+    print(str(e))
+    sys.exit(1)
+PYEOF
+  ) && true
+
+  exit_code=$?
+  short="${skill_file#$SKILLS_DIR/}"
+
+  if [ $exit_code -eq 0 ]; then
+    OK_COUNT=$((OK_COUNT + 1))
+  else
+    echo "FAIL: $short" >&2
+    echo "  $result" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+done < <(find "$SKILLS_DIR" -name 'SKILL.md' -print0)
+
+echo "check_skill_frontmatter: OK=$OK_COUNT FAIL=$FAIL_COUNT"
+
+if [ $FAIL_COUNT -gt 0 ]; then
+  echo "Fix: wrap description values in double-quotes so Triggers: is not parsed as a YAML key." >&2
+  exit 1
+fi
+
+exit 0

--- a/.claude/skills/adversarial-qa/SKILL.md
+++ b/.claude/skills/adversarial-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adversarial-qa
-description: Use when performing attack-based testing on R package exported functions, running adversarial QA before PRs, or stress-testing edge cases, invalid inputs, and boundary conditions in R code. Triggers: adversarial testing, QA review, attack vectors, fuzz testing, edge cases, PR quality gate.
+description: "Use when performing attack-based testing on R package exported functions, running adversarial QA before PRs, or stress-testing edge cases, invalid inputs, and boundary conditions in R code. Triggers: adversarial testing, QA review, attack vectors, fuzz testing, edge cases, PR quality gate."
 ---
 # Adversarial QA Skill
 

--- a/.claude/skills/ai-assisted-analysis/SKILL.md
+++ b/.claude/skills/ai-assisted-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-assisted-analysis
-description: Use when collaborating with LLMs on statistical analysis, validating AI-generated code or model assumptions, or integrating Claude/GPT into a reproducible analysis workflow. Triggers: AI-assisted analysis, LLM collaboration, statistical workflow, Gelman workflow, AI code review.
+description: "Use when collaborating with LLMs on statistical analysis, validating AI-generated code or model assumptions, or integrating Claude/GPT into a reproducible analysis workflow. Triggers: AI-assisted analysis, LLM collaboration, statistical workflow, Gelman workflow, AI code review."
 ---
 # AI-Assisted Statistical Analysis
 

--- a/.claude/skills/analysis-rationale-logging/SKILL.md
+++ b/.claude/skills/analysis-rationale-logging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analysis-rationale-logging
-description: Use when documenting why analysis decisions were made, creating audit trails for modeling choices, addressing the garden of forking paths problem, or logging scientific reasoning alongside technical execution. Triggers: rationale logging, decision audit, analysis choices, forking paths.
+description: "Use when documenting why analysis decisions were made, creating audit trails for modeling choices, addressing the garden of forking paths problem, or logging scientific reasoning alongside technical execution. Triggers: rationale logging, decision audit, analysis choices, forking paths."
 ---
 # Analysis Rationale Logging
 

--- a/.claude/skills/browser-user-testing/SKILL.md
+++ b/.claude/skills/browser-user-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-user-testing
-description: Use when testing deployed websites, pkgdown sites, Shiny apps, or dashboards using browser automation with user personas. Triggers: user testing, browser testing, persona testing, UX review, site walkthrough, pkgdown testing.
+description: "Use when testing deployed websites, pkgdown sites, Shiny apps, or dashboards using browser automation with user personas. Triggers: user testing, browser testing, persona testing, UX review, site walkthrough, pkgdown testing."
 ---
 # Browser-Based User Testing with Personas
 

--- a/.claude/skills/ci-workflows-github-actions/SKILL.md
+++ b/.claude/skills/ci-workflows-github-actions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-workflows-github-actions
-description: Use when setting up or debugging GitHub Actions workflows for R packages, configuring Nix-based CI, r-universe testing, WASM compilation, code coverage, or pkgctx API documentation. Triggers: CI, GitHub Actions, workflows, r-universe, WASM, coverage, deployment.
+description: "Use when setting up or debugging GitHub Actions workflows for R packages, configuring Nix-based CI, r-universe testing, WASM compilation, code coverage, or pkgctx API documentation. Triggers: CI, GitHub Actions, workflows, r-universe, WASM, coverage, deployment."
 ---
 # CI Workflows with GitHub Actions
 

--- a/.claude/skills/code-review-workflow/SKILL.md
+++ b/.claude/skills/code-review-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review-workflow
-description: Use when requesting or performing code reviews on R package PRs, using gh/gert for review workflows, or evaluating code quality in pull requests. Triggers: code review, PR review, pull request feedback, review workflow.
+description: "Use when requesting or performing code reviews on R package PRs, using gh/gert for review workflows, or evaluating code quality in pull requests. Triggers: code review, PR review, pull request feedback, review workflow."
 ---
 # Code Review Workflow for R Packages
 

--- a/.claude/skills/context-control/SKILL.md
+++ b/.claude/skills/context-control/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context-control
-description: Use when managing Claude Code context window limits, compacting conversations, preserving important information across compactions, or optimizing session productivity. Triggers: context window, compaction, context management, session productivity, memory limits.
+description: "Use when managing Claude Code context window limits, compacting conversations, preserving important information across compactions, or optimizing session productivity. Triggers: context window, compaction, context management, session productivity, memory limits."
 ---
 # Context Control Guide
 

--- a/.claude/skills/crew-operations/SKILL.md
+++ b/.claude/skills/crew-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crew-operations
-description: Use when configuring crew worker pools, debugging crew auto-scaling, setting up crew logging and monitoring, or troubleshooting distributed worker issues in production. Triggers: crew, worker pools, auto-scaling, crew logging, crew monitoring, distributed workers.
+description: "Use when configuring crew worker pools, debugging crew auto-scaling, setting up crew logging and monitoring, or troubleshooting distributed worker issues in production. Triggers: crew, worker pools, auto-scaling, crew logging, crew monitoring, distributed workers."
 ---
 # crew Operational Patterns
 

--- a/.claude/skills/data-transformation-stack/SKILL.md
+++ b/.claude/skills/data-transformation-stack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-transformation-stack
-description: Use when building data pipelines with DuckDB, Arrow, or dbt, reading JSON/CSV/Parquet without loading into R memory, or orchestrating SQL transformations. Triggers: DuckDB, Arrow, dbt, Parquet, data pipeline, SQL transformation, data wrangling.
+description: "Use when building data pipelines with DuckDB, Arrow, or dbt, reading JSON/CSV/Parquet without loading into R memory, or orchestrating SQL transformations. Triggers: DuckDB, Arrow, dbt, Parquet, data pipeline, SQL transformation, data wrangling."
 ---
 # Data Transformation Stack: DuckDB, Arrow, and dbt
 

--- a/.claude/skills/data-validation-pointblank/SKILL.md
+++ b/.claude/skills/data-validation-pointblank/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-validation-pointblank
-description: Use when implementing data contracts, automated validation with pointblank, integrating validation into targets pipelines, or setting up data quality checks with crew. Triggers: pointblank, data validation, data contracts, data quality, validation rules.
+description: "Use when implementing data contracts, automated validation with pointblank, integrating validation into targets pipelines, or setting up data quality checks with crew. Triggers: pointblank, data validation, data contracts, data quality, validation rules."
 ---
 # Data Validation with pointblank
 

--- a/.claude/skills/dplyr-1.1-patterns/SKILL.md
+++ b/.claude/skills/dplyr-1.1-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dplyr-1.1-patterns
-description: Use when writing or modernizing dplyr code with 1.1+ features including .by= per-operation grouping, pick() for tidy-select, reframe() for multi-row summaries, join_by() for flexible joins, consecutive_id() for run-length grouping. Triggers: dplyr, .by, pick, reframe, join_by, consecutive_id.
+description: "Use when writing or modernizing dplyr code with 1.1+ features including .by= per-operation grouping, pick() for tidy-select, reframe() for multi-row summaries, join_by() for flexible joins, consecutive_id() for run-length grouping. Triggers: dplyr, .by, pick, reframe, join_by, consecutive_id."
 ---
 # dplyr 1.1+ Modern Patterns
 

--- a/.claude/skills/eda-workflow/SKILL.md
+++ b/.claude/skills/eda-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eda-workflow
-description: Use when performing systematic exploratory data analysis, assessing data quality before modeling, identifying data issues, or validating assumptions. Triggers: EDA, exploratory analysis, data exploration, data quality assessment, initial analysis.
+description: "Use when performing systematic exploratory data analysis, assessing data quality before modeling, identifying data issues, or validating assumptions. Triggers: EDA, exploratory analysis, data exploration, data quality assessment, initial analysis."
 ---
 # Exploratory Data Analysis Workflow
 

--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: executing-plans
-description: Use when executing implementation plans created with writing-plans, running tasks in batches with checkpoints, or tracking progress through a multi-step plan. Triggers: execute plan, run plan, plan execution, task batches, checkpoints.
+description: "Use when executing implementation plans created with writing-plans, running tasks in batches with checkpoints, or tracking progress through a multi-step plan. Triggers: execute plan, run plan, plan execution, task batches, checkpoints."
 ---
 # Executing Implementation Plans
 

--- a/.claude/skills/gdc-genomics/SKILL.md
+++ b/.claude/skills/gdc-genomics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gdc-genomics
-description: Use when working with GDC (Genomic Data Commons) data, genomics pipelines, or cancer genomics analysis in R. Triggers: GDC, genomics, cancer data, genomic data commons, bioinformatics, mutation data.
+description: "Use when working with GDC (Genomic Data Commons) data, genomics pipelines, or cancer genomics analysis in R. Triggers: GDC, genomics, cancer data, genomic data commons, bioinformatics, mutation data."
 ---
 # GDC Genomics Spec-Bundled Skill
 

--- a/.claude/skills/gemini-cli-codebase-analysis/SKILL.md
+++ b/.claude/skills/gemini-cli-codebase-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini-cli-codebase-analysis
-description: Use when analyzing large codebases that exceed Claude context limits, performing whole-codebase searches, or leveraging Gemini CLI for architectural understanding. Triggers: Gemini CLI, large codebase, codebase analysis, architecture review, cross-file search.
+description: "Use when analyzing large codebases that exceed Claude context limits, performing whole-codebase searches, or leveraging Gemini CLI for architectural understanding. Triggers: Gemini CLI, large codebase, codebase analysis, architecture review, cross-file search."
 ---
 # Gemini CLI for Large Codebase Analysis
 

--- a/.claude/skills/hooks-automation/SKILL.md
+++ b/.claude/skills/hooks-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hooks-automation
-description: Use when configuring Claude Code hooks for automated linting, type checking, testing, or validation workflows triggered before or after tool calls. Triggers: hooks, automation, pre-commit, post-tool, linting hooks, validation hooks.
+description: "Use when configuring Claude Code hooks for automated linting, type checking, testing, or validation workflows triggered before or after tool calls. Triggers: hooks, automation, pre-commit, post-tool, linting hooks, validation hooks."
 ---
 # Hooks Automation Guide
 

--- a/.claude/skills/huggingface-r/SKILL.md
+++ b/.claude/skills/huggingface-r/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huggingface-r
-description: Use when integrating Hugging Face models in R, downloading pre-trained models, loading tokenizers, working with safetensors format, or building ML/AI workflows from R. Triggers: Hugging Face, HuggingFace, transformers, safetensors, tokenizers, ML models in R.
+description: "Use when integrating Hugging Face models in R, downloading pre-trained models, loading tokenizers, working with safetensors format, or building ML/AI workflows from R. Triggers: Hugging Face, HuggingFace, transformers, safetensors, tokenizers, ML models in R."
 ---
 # Hugging Face Integration for R
 

--- a/.claude/skills/lazy-evaluation-guide/SKILL.md
+++ b/.claude/skills/lazy-evaluation-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lazy-evaluation-guide
-description: Use when working with lazy evaluation in R, clarifying the seven meanings of lazy (promises, futures, database queries, package data loading, build systems, test optimization, regex quantifiers). Triggers: lazy evaluation, promises, NSE, non-standard evaluation, deferred evaluation, lazy testing, lazytest.
+description: "Use when working with lazy evaluation in R, clarifying the seven meanings of lazy (promises, futures, database queries, package data loading, build systems, test optimization, regex quantifiers). Triggers: lazy evaluation, promises, NSE, non-standard evaluation, deferred evaluation, lazy testing, lazytest."
 ---
 # Lazy Evaluation in R - A Taxonomy
 

--- a/.claude/skills/llm-package-context/SKILL.md
+++ b/.claude/skills/llm-package-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-package-context
-description: Use when generating compact API specifications from R/Python packages for LLM consumption, using pkgctx tool, or managing central context caches. Triggers: pkgctx, package context, API spec, LLM context, token reduction, function signatures.
+description: "Use when generating compact API specifications from R/Python packages for LLM consumption, using pkgctx tool, or managing central context caches. Triggers: pkgctx, package context, API spec, LLM context, token reduction, function signatures."
 ---
 # LLM Package Context with pkgctx
 

--- a/.claude/skills/mcp-servers/SKILL.md
+++ b/.claude/skills/mcp-servers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-servers
-description: Use when configuring, troubleshooting, or extending MCP (Model Context Protocol) servers for Claude Code, adding specialized tools or resources. Triggers: MCP, Model Context Protocol, MCP server, MCP tools, server configuration.
+description: "Use when configuring, troubleshooting, or extending MCP (Model Context Protocol) servers for Claude Code, adding specialized tools or resources. Triggers: MCP, Model Context Protocol, MCP server, MCP tools, server configuration."
 ---
 # MCP (Model Context Protocol) Servers Guide
 

--- a/.claude/skills/missing-data-handling/SKILL.md
+++ b/.claude/skills/missing-data-handling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: missing-data-handling
-description: Use when handling NA values in R, implementing missing data patterns across base R and tidyverse, ensuring database interoperability with NULLs, or writing defensive code for missing values. Triggers: NA, missing data, NULL, na.rm, complete.cases, missing values.
+description: "Use when handling NA values in R, implementing missing data patterns across base R and tidyverse, ensuring database interoperability with NULLs, or writing defensive code for missing values. Triggers: NA, missing data, NULL, na.rm, complete.cases, missing values."
 ---
 # Missing Data Handling in R
 

--- a/.claude/skills/mlops-deployment/SKILL.md
+++ b/.claude/skills/mlops-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mlops-deployment
-description: Use when deploying ML models to production using pins, vetiver, and plumber, implementing model versioning, serving APIs, monitoring, or rollback. Triggers: MLOps, model deployment, vetiver, pins, model serving, model monitoring, production ML.
+description: "Use when deploying ML models to production using pins, vetiver, and plumber, implementing model versioning, serving APIs, monitoring, or rollback. Triggers: MLOps, model deployment, vetiver, pins, model serving, model monitoring, production ML."
 ---
 # MLOps Deployment
 

--- a/.claude/skills/model-evaluation-calibration/SKILL.md
+++ b/.claude/skills/model-evaluation-calibration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-evaluation-calibration
-description: Use when evaluating model performance with proper scoring rules, assessing calibration of probability estimates, or implementing time-aware backtesting. Triggers: model evaluation, calibration, scoring rules, backtesting, probability calibration, cross-validation.
+description: "Use when evaluating model performance with proper scoring rules, assessing calibration of probability estimates, or implementing time-aware backtesting. Triggers: model evaluation, calibration, scoring rules, backtesting, probability calibration, cross-validation."
 ---
 # Model Evaluation & Calibration
 

--- a/.claude/skills/modeling-baselines/SKILL.md
+++ b/.claude/skills/modeling-baselines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: modeling-baselines
-description: Use when starting predictive modeling to enforce baseline-first workflow, comparing ML models against simple GLM/GLMM baselines, or preventing premature complexity. Triggers: baseline model, GLM baseline, model comparison, modeling workflow, simple model first.
+description: "Use when starting predictive modeling to enforce baseline-first workflow, comparing ML models against simple GLM/GLMM baselines, or preventing premature complexity. Triggers: baseline model, GLM baseline, model comparison, modeling workflow, simple model first."
 ---
 # Modeling Baselines
 

--- a/.claude/skills/nix-rix-r-environment/SKILL.md
+++ b/.claude/skills/nix-rix-r-environment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nix-rix-r-environment
-description: Use when setting up reproducible R environments with Nix and rix, troubleshooting Nix shell issues, managing R package dependencies in Nix, or detecting environment drift. Triggers: Nix, rix, Nix shell, reproducible environment, nix-shell, R environment, segfault.
+description: "Use when setting up reproducible R environments with Nix and rix, troubleshooting Nix shell issues, managing R package dependencies in Nix, or detecting environment drift. Triggers: Nix, rix, Nix shell, reproducible environment, nix-shell, R environment, segfault."
 ---
 # Nix and Rix for Reproducible R Environments
 

--- a/.claude/skills/parallel-processing/SKILL.md
+++ b/.claude/skills/parallel-processing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-processing
-description: Use when implementing parallel processing with the nanonext/mirai/crew stack, configuring async sockets, parallel evaluation, or worker pool management for targets pipelines. Triggers: parallel, mirai, crew, nanonext, async, workers, parallel targets.
+description: "Use when implementing parallel processing with the nanonext/mirai/crew stack, configuring async sockets, parallel evaluation, or worker pool management for targets pipelines. Triggers: parallel, mirai, crew, nanonext, async, workers, parallel targets."
 ---
 # Parallel Processing with nanonext/mirai/crew
 

--- a/.claude/skills/per-project-claude-md/SKILL.md
+++ b/.claude/skills/per-project-claude-md/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: per-project-claude-md
-description: Use when setting up a per-project CLAUDE.md for a new R package or analysis project. Creates a slim project-level config that points to global rules and adds project-specific overrides. Triggers: per-project config, project CLAUDE.md, project-level claude config, project overrides.
+description: "Use when setting up a per-project CLAUDE.md for a new R package or analysis project. Creates a slim project-level config that points to global rules and adds project-specific overrides. Triggers: per-project config, project CLAUDE.md, project-level claude config, project overrides."
 ---
 # Per-Project CLAUDE.md Skill
 

--- a/.claude/skills/pkgdown-deployment/SKILL.md
+++ b/.claude/skills/pkgdown-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pkgdown-deployment
-description: Use when deploying R package documentation with pkgdown and GitHub Pages, using the hybrid Nix + native R workflow, or troubleshooting bslib/Bootstrap 5 in Nix. Triggers: pkgdown, GitHub Pages, package website, documentation site, pkgdown deploy.
+description: "Use when deploying R package documentation with pkgdown and GitHub Pages, using the hybrid Nix + native R workflow, or troubleshooting bslib/Bootstrap 5 in Nix. Triggers: pkgdown, GitHub Pages, package website, documentation site, pkgdown deploy."
 ---
 # Pkgdown Deployment with Hybrid Nix + Native R
 

--- a/.claude/skills/plumber2-web-api/SKILL.md
+++ b/.claude/skills/plumber2-web-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plumber2-web-api
-description: Use when building web APIs with plumber2, implementing async/promise-based endpoints, or integrating mirai for high-concurrency R web services. Triggers: plumber2, web API, REST API, plumber, API endpoints, async API.
+description: "Use when building web APIs with plumber2, implementing async/promise-based endpoints, or integrating mirai for high-concurrency R web services. Triggers: plumber2, web API, REST API, plumber, API endpoints, async API."
 ---
 # Web APIs with plumber2
 

--- a/.claude/skills/project-review/SKILL.md
+++ b/.claude/skills/project-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-review
-description: Use when reviewing R projects for technical debt, identifying simplification opportunities, assessing code quality, or planning cleanup work. Triggers: project review, technical debt, code cleanup, simplification, code quality assessment.
+description: "Use when reviewing R projects for technical debt, identifying simplification opportunities, assessing code quality, or planning cleanup work. Triggers: project review, technical debt, code cleanup, simplification, code quality assessment."
 ---
 # Project Review and Technical Debt Assessment
 

--- a/.claude/skills/project-telemetry/SKILL.md
+++ b/.claude/skills/project-telemetry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-telemetry
-description: Use when implementing project logging with the logger package, creating telemetry vignettes with targets, tracking pipeline metrics, or monitoring project health. Triggers: telemetry, logging, metrics, project health, pipeline monitoring, logger package.
+description: "Use when implementing project logging with the logger package, creating telemetry vignettes with targets, tracking pipeline metrics, or monitoring project health. Triggers: telemetry, logging, metrics, project health, pipeline monitoring, logger package."
 ---
 # Project Telemetry and Logging
 

--- a/.claude/skills/quality-gates/SKILL.md
+++ b/.claude/skills/quality-gates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-gates
-description: Use when applying numeric scoring for commit/PR/merge gates, evaluating Bronze/Silver/Gold quality levels, or enforcing quality checks at PR steps 4, 6, and 8. Triggers: quality gate, scoring, Bronze/Silver/Gold, PR quality, commit gate, merge gate.
+description: "Use when applying numeric scoring for commit/PR/merge gates, evaluating Bronze/Silver/Gold quality levels, or enforcing quality checks at PR steps 4, 6, and 8. Triggers: quality gate, scoring, Bronze/Silver/Gold, PR quality, commit gate, merge gate."
 ---
 # Quality Gates Skill
 

--- a/.claude/skills/quarto-dynamic-content/SKILL.md
+++ b/.claude/skills/quarto-dynamic-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarto-dynamic-content
-description: Use when generating dynamic content in Quarto documents including tabsets from data, parameterized sections, or programmatically created R chunks for reports and dashboards. Triggers: dynamic Quarto, tabsets, parameterized, programmatic chunks, dynamic content.
+description: "Use when generating dynamic content in Quarto documents including tabsets from data, parameterized sections, or programmatically created R chunks for reports and dashboards. Triggers: dynamic Quarto, tabsets, parameterized, programmatic chunks, dynamic content."
 ---
 # Quarto Dynamic Content Generation
 

--- a/.claude/skills/r-cmd-check-fixes/SKILL.md
+++ b/.claude/skills/r-cmd-check-fixes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r-cmd-check-fixes
-description: Use when fixing R CMD check errors and warnings, setting up new R packages, or resolving common check issues with standard solutions. Triggers: R CMD check, check errors, check warnings, NOTES, package check, devtools::check.
+description: "Use when fixing R CMD check errors and warnings, setting up new R packages, or resolving common check issues with standard solutions. Triggers: R CMD check, check errors, check warnings, NOTES, package check, devtools::check."
 ---
 # R CMD Check Common Fixes
 

--- a/.claude/skills/r-package-workflow/SKILL.md
+++ b/.claude/skills/r-package-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r-package-workflow
-description: Use when developing R packages following the structured 9-step PR workflow integrating architecture planning, test-driven development, and systematic debugging. Triggers: R package, package development, PR workflow, package workflow, new feature, bug fix.
+description: "Use when developing R packages following the structured 9-step PR workflow integrating architecture planning, test-driven development, and systematic debugging. Triggers: R package, package development, PR workflow, package workflow, new feature, bug fix."
 ---
 # R Package Development Workflow
 

--- a/.claude/skills/requirements-spec/SKILL.md
+++ b/.claude/skills/requirements-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requirements-spec
-description: Use when planning complex tasks involving 5+ files or 3+ modules to create a MUST/SHOULD/MAY requirements specification that catches ambiguity before coding begins. Triggers: requirements, spec, complex task, scope definition, ambiguity.
+description: "Use when planning complex tasks involving 5+ files or 3+ modules to create a MUST/SHOULD/MAY requirements specification that catches ambiguity before coding begins. Triggers: requirements, spec, complex task, scope definition, ambiguity."
 argument-hint: "[task description]"
 ---
 # Requirements Specification

--- a/.claude/skills/shiny-async-patterns/SKILL.md
+++ b/.claude/skills/shiny-async-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shiny-async-patterns
-description: Use when implementing non-blocking async operations in Shiny apps using ExtendedTask (Shiny 1.8.1+), crew integration, or keeping UI responsive during long computations. Triggers: Shiny async, ExtendedTask, non-blocking, async Shiny, crew Shiny.
+description: "Use when implementing non-blocking async operations in Shiny apps using ExtendedTask (Shiny 1.8.1+), crew integration, or keeping UI responsive during long computations. Triggers: Shiny async, ExtendedTask, non-blocking, async Shiny, crew Shiny."
 ---
 # Shiny Async Patterns
 

--- a/.claude/skills/shinylive-deployment/SKILL.md
+++ b/.claude/skills/shinylive-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shinylive-deployment
-description: Use when deploying Shiny apps as static websites using Shinylive/WebAssembly, targeting GitHub Pages, Netlify, or static hosts for serverless Shiny. Triggers: Shinylive, WebAssembly, WASM, static Shiny, serverless Shiny, Shinylive deploy.
+description: "Use when deploying Shiny apps as static websites using Shinylive/WebAssembly, targeting GitHub Pages, Netlify, or static hosts for serverless Shiny. Triggers: Shinylive, WebAssembly, WASM, static Shiny, serverless Shiny, Shinylive deploy."
 ---
 # Shinylive Deployment Workflow
 

--- a/.claude/skills/shinylive-quarto/SKILL.md
+++ b/.claude/skills/shinylive-quarto/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shinylive-quarto
-description: Use when embedding Shinylive apps in Quarto documents, deploying server-free Shiny dashboards via Quarto and GitHub Pages, or building interactive Quarto pages with Shiny. Triggers: Shinylive Quarto, Quarto Shiny, WebR Shiny, interactive Quarto.
+description: "Use when embedding Shinylive apps in Quarto documents, deploying server-free Shiny dashboards via Quarto and GitHub Pages, or building interactive Quarto pages with Shiny. Triggers: Shinylive Quarto, Quarto Shiny, WebR Shiny, interactive Quarto."
 ---
 # Shinylive for R with Quarto Dashboard
 

--- a/.claude/skills/skillify/SKILL.md
+++ b/.claude/skills/skillify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skillify
-description: Use when extracting repeatable patterns from conversation history to create new skills. Triggers: create skill from workflow, automate pattern, capture workflow as skill, analyze conversation for patterns.
+description: "Use when extracting repeatable patterns from conversation history to create new skills. Triggers: create skill from workflow, automate pattern, capture workflow as skill, analyze conversation for patterns."
 ---
 
 # Skillify — Automate Skill Creation from Conversation History

--- a/.claude/skills/static-api-deployment/SKILL.md
+++ b/.claude/skills/static-api-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: static-api-deployment
-description: Use when deploying derived datasets as static JSON APIs, hosting analysis results or model outputs as static files, or building serverless data APIs from R packages. Triggers: static API, JSON API, static hosting, data API, serverless API.
+description: "Use when deploying derived datasets as static JSON APIs, hosting analysis results or model outputs as static files, or building serverless data APIs from R packages. Triggers: static API, JSON API, static hosting, data API, serverless API."
 ---
 # Static API Deployment Skill
 

--- a/.claude/skills/targets-pipeline-spec/SKILL.md
+++ b/.claude/skills/targets-pipeline-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: targets-pipeline-spec
-description: Use when organizing targets pipelines in R packages, setting up modular plan files, integrating crew with targets, or avoiding common targets anti-patterns. Triggers: targets, pipeline, tar_plan, targets architecture, modular plans, _targets.R.
+description: "Use when organizing targets pipelines in R packages, setting up modular plan files, integrating crew with targets, or avoiding common targets anti-patterns. Triggers: targets, pipeline, tar_plan, targets architecture, modular plans, _targets.R."
 ---
 # targets Pipeline Specification
 

--- a/.claude/skills/targets-vignettes/SKILL.md
+++ b/.claude/skills/targets-vignettes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: targets-vignettes
-description: Use when pre-calculating objects for package vignettes using targets, keeping vignettes focused on narrative while computation runs through the pipeline. Triggers: targets vignettes, pre-compute, vignette data, tar_read in vignettes.
+description: "Use when pre-calculating objects for package vignettes using targets, keeping vignettes focused on narrative while computation runs through the pipeline. Triggers: targets vignettes, pre-compute, vignette data, tar_read in vignettes."
 ---
 # Targets Pipeline for Vignette Pre-calculation
 

--- a/.claude/skills/test-driven-development/SKILL.md
+++ b/.claude/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: Use when writing tests before code in R packages, following the RED-GREEN-REFACTOR cycle with testthat, or enforcing TDD discipline for new features and bug fixes. Triggers: TDD, test first, RED-GREEN-REFACTOR, test-driven, write test first.
+description: "Use when writing tests before code in R packages, following the RED-GREEN-REFACTOR cycle with testthat, or enforcing TDD discipline for new features and bug fixes. Triggers: TDD, test first, RED-GREEN-REFACTOR, test-driven, write test first."
 ---
 # Test-Driven Development for R Packages
 

--- a/.claude/skills/tidyverse-style/SKILL.md
+++ b/.claude/skills/tidyverse-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tidyverse-style
-description: Use when applying tidyverse coding conventions, choosing between tidyverse packages, using the air formatter, or following stringr patterns in R package code. Triggers: tidyverse style, code style, air formatter, stringr, package choice, style guide.
+description: "Use when applying tidyverse coding conventions, choosing between tidyverse packages, using the air formatter, or following stringr patterns in R package code. Triggers: tidyverse style, code style, air formatter, stringr, package choice, style guide."
 ---
 # Tidyverse Style and Package Guide
 

--- a/.claude/skills/webr-multi-page-vignettes/SKILL.md
+++ b/.claude/skills/webr-multi-page-vignettes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: webr-multi-page-vignettes
-description: Use when creating interactive multi-page vignettes with WebR for browser-based R execution, building vignettes that run R code without local installation. Triggers: WebR, multi-page vignettes, browser R, interactive vignettes, WebR vignettes.
+description: "Use when creating interactive multi-page vignettes with WebR for browser-based R execution, building vignettes that run R code without local installation. Triggers: WebR, multi-page vignettes, browser R, interactive vignettes, WebR vignettes."
 ---
 # WebR Multi-Page Vignettes
 

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans
-description: Use when creating implementation plans with bite-sized tasks before coding, writing plans for implementers with minimal context, or structuring multi-step development work. Triggers: write plan, implementation plan, task planning, plan before code.
+description: "Use when creating implementation plans with bite-sized tasks before coding, writing plans for implementers with minimal context, or structuring multi-step development work. Triggers: write plan, implementation plan, task planning, plan before code."
 ---
 # Writing Implementation Plans for R Packages
 


### PR DESCRIPTION
## Summary

Fixes #230 — 47 of 68 SKILL.md files had front-matter `description` values that fail strict YAML 1.2 parsing (used by Codex via Rust `serde_yaml`), causing repeated skill-load failures at Codex startup.

- **Root cause:** unquoted single-line `description` fields containing `Triggers: ...` — the colon caused `serde_yaml` to interpret `Triggers` as a nested mapping key, producing `mapping values are not allowed in this context`.
- **Fix:** wrapped every affected `description` value in double-quotes (47 files). The 21 files already using `description: >` folded-scalar syntax were unaffected and required no changes.
- **Checker:** added `.claude/scripts/check_skill_frontmatter.sh` (standalone, ~80 lines) that scans every SKILL.md and exits non-zero if any front-matter fails `yaml.safe_load()`. Wired into `.claude/hooks/skill_quality_onwrite.sh` as a warn-only check so future SKILL.md writes are validated immediately.

## Failure patterns observed

All 47 failures were the same pattern: `Triggers:` appearing inside an unquoted description value on a single line, e.g.:

```
# BEFORE (fails serde_yaml):
description: Use when performing attack-based testing ... Triggers: adversarial testing, QA review, attack vectors, fuzz testing, edge cases, PR quality gate.
```

```
# AFTER (strict-YAML safe):
description: "Use when performing attack-based testing ... Triggers: adversarial testing, QA review, attack vectors, fuzz testing, edge cases, PR quality gate."
```

## Representative before/after

**`adversarial-qa/SKILL.md`** (line 3):
```yaml
# Before
description: Use when performing attack-based testing on R package exported functions, running adversarial QA before PRs, or stress-testing edge cases, invalid inputs, and boundary conditions in R code. Triggers: adversarial testing, QA review, attack vectors, fuzz testing, edge cases, PR quality gate.

# After
description: "Use when performing attack-based testing on R package exported functions, running adversarial QA before PRs, or stress-testing edge cases, invalid inputs, and boundary conditions in R code. Triggers: adversarial testing, QA review, attack vectors, fuzz testing, edge cases, PR quality gate."
```

**`quality-gates/SKILL.md`** (line 3):
```yaml
# Before
description: Use when applying numeric scoring for commit/PR/merge gates, evaluating Bronze/Silver/Gold quality levels, or enforcing quality checks at PR steps 4, 6, and 8. Triggers: quality gate, scoring, Bronze/Silver/Gold, PR quality, commit gate, merge gate.

# After
description: "Use when applying numeric scoring for commit/PR/merge gates, evaluating Bronze/Silver/Gold quality levels, or enforcing quality checks at PR steps 4, 6, and 8. Triggers: quality gate, scoring, Bronze/Silver/Gold, PR quality, commit gate, merge gate."
```

## Checker script

`.claude/scripts/check_skill_frontmatter.sh [skills_dir]`

- Scans all SKILL.md files under `skills_dir` (defaults to `.claude/skills` via `git rev-parse`)
- Runs `python3 yaml.safe_load()` on each front-matter block
- Exits 0 if all pass, exits 1 listing failed files and error messages
- Wired into `skill_quality_onwrite.sh` hook (PostToolUse:Edit|Write) — warn-only, never blocks

Run manually: `bash .claude/scripts/check_skill_frontmatter.sh`

## Test plan

- [x] All 68 SKILL.md files pass `yaml.safe_load()` strict parsing (verified `OK=68 FAIL=0`)
- [x] Checker script runs cleanly: `check_skill_frontmatter: OK=68 FAIL=0`
- [x] Spot-checked `adversarial-qa/SKILL.md` and `quality-gates/SKILL.md` — description field content is unchanged, only quoting added
- [x] 21 files that already used `description: >` folded scalar remain untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
