### PR TITLE
feat(launchd-health): weekly health email + ledger (#300)

### DIFF
--- a/.claude/launchd/com.claude.launchd-health-weekly.plist
+++ b/.claude/launchd/com.claude.launchd-health-weekly.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.launchd-health-weekly</string>
+
+    <!-- Run bin/launchd_health_weekly_cron.sh every Sunday at 09:00 local time -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_health_weekly_cron.sh</string>
+    </array>
+
+    <!-- Sunday = Weekday 0; Hour 9; Minute 0 -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/launchd_health_weekly.out</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/launchd_health_weekly.err</string>
+
+    <key>TimeOut</key>
+    <integer>300</integer>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>REPO_ROOT</key>
+        <string>/Users/johngavin/docs_gh/llm</string>
+    </dict>
+</dict>
+</plist>

--- a/.claude/scripts/launchd_health_report.R
+++ b/.claude/scripts/launchd_health_report.R
@@ -1,0 +1,635 @@
+#!/usr/bin/env Rscript
+# launchd_health_report.R — Generate weekly scheduled-task health report.
+#
+# Parses ~/Library/LaunchAgents/*.plist files, reads the launchd_runs ledger,
+# enumerates GitHub Actions cloud crons, and emits a Markdown report suitable
+# for embedding in an HTML email.
+#
+# Args (command-line):
+#   --out PATH      Write markdown to PATH (default: stdout)
+#   --dry-run       Alias for --out /dev/stdout; also skips ledger write
+#
+# Env:
+#   LAUNCHD_LEDGER   Path to DuckDB ledger (default: ~/.claude/logs/launchd_runs.duckdb)
+#   CLOUD_REPOS      Comma-separated list of GitHub repos to inspect (default: see below)
+#
+# Tracked in llm#300.
+
+# ── Arg parsing ────────────────────────────────────────────────────────────────
+args <- commandArgs(trailingOnly = TRUE)
+
+out_path <- NULL
+dry_run  <- FALSE
+
+i <- 1L
+while (i <= length(args)) {
+  switch(args[i],
+    "--out"     = { out_path <- args[i + 1L]; i <- i + 2L },
+    "--dry-run" = { dry_run <- TRUE; i <- i + 1L },
+    { i <- i + 1L }
+  )
+}
+
+if (dry_run && is.null(out_path)) out_path <- "/dev/stdout"
+if (is.null(out_path)) out_path <- "/dev/stdout"
+
+# ── Dependencies ───────────────────────────────────────────────────────────────
+suppressPackageStartupMessages({
+  library(jsonlite)
+})
+
+# Optional DuckDB for ledger reads (graceful fallback if absent)
+has_duckdb <- requireNamespace("duckdb", quietly = TRUE)
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+LAUNCH_AGENTS_DIR <- file.path(Sys.getenv("HOME"), "Library", "LaunchAgents")
+
+LEDGER_PATH <- Sys.getenv(
+  "LAUNCHD_LEDGER",
+  file.path(Sys.getenv("HOME"), ".claude", "logs", "launchd_runs.duckdb")
+)
+
+CLOUD_REPOS_RAW <- Sys.getenv("CLOUD_REPOS", "JohnGavin/llm,JohnGavin/llmtelemetry")
+CLOUD_REPOS     <- trimws(strsplit(CLOUD_REPOS_RAW, ",")[[1]])
+
+REPORT_WINDOW_DAYS <- 7L
+
+# ── Section 1: plist inventory ─────────────────────────────────────────────────
+
+#' Parse a single LaunchAgents plist into a tidy list.
+#' Returns NULL if the file cannot be parsed.
+parse_plist <- function(path) {
+  tmp <- tempfile(fileext = ".json")
+  on.exit(unlink(tmp))
+  ret <- system2("/usr/bin/plutil", c("-convert", "json", "-o", tmp, path),
+                 stdout = FALSE, stderr = FALSE)
+  if (ret != 0L) return(NULL)
+  tryCatch(
+    jsonlite::fromJSON(tmp, simplifyVector = TRUE),
+    error = function(e) NULL
+  )
+}
+
+#' Extract canonical schedule info from a parsed plist.
+#' Returns a named list: type, display, raw (for cadence math).
+extract_schedule <- function(pl) {
+  sci <- pl[["StartCalendarInterval"]]
+  si  <- pl[["StartInterval"]]
+  ral <- isTRUE(pl[["RunAtLoad"]])
+
+  if (!is.null(sci)) {
+    # May be a single dict (list) or list of dicts (array)
+    if (is.data.frame(sci)) {
+      # Multiple calendar intervals — take first for display
+      rows <- sci
+      times <- apply(rows, 1, function(r) {
+        h <- if (!is.na(r[["Hour"]])) as.integer(r[["Hour"]]) else NA_integer_
+        m <- if (!is.na(r[["Minute"]])) as.integer(r[["Minute"]]) else 0L
+        sprintf("%02d:%02d", h, m)
+      })
+      list(type = "calendar", display = paste(times, collapse = ", "), raw = sci)
+    } else if (is.list(sci) && !is.data.frame(sci)) {
+      h <- sci[["Hour"]]
+      m <- if (!is.null(sci[["Minute"]])) sci[["Minute"]] else 0L
+      wd <- sci[["Weekday"]]
+      display <- if (!is.null(wd)) {
+        wd_names <- c("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
+        sprintf("%s %02d:%02d", wd_names[wd + 1L], as.integer(h), as.integer(m))
+      } else {
+        if (!is.null(h)) sprintf("%02d:%02d", as.integer(h), as.integer(m)) else "run-at-load"
+      }
+      list(type = "calendar", display = display, raw = sci)
+    } else {
+      list(type = "calendar", display = "custom", raw = sci)
+    }
+  } else if (!is.null(si)) {
+    secs <- as.integer(si)
+    display <- if (secs < 120L) {
+      sprintf("every %ds", secs)
+    } else if (secs < 3600L) {
+      sprintf("every %dm", secs %/% 60L)
+    } else {
+      sprintf("every %.1fh", secs / 3600)
+    }
+    list(type = "interval", display = display, raw = list(seconds = secs))
+  } else if (ral) {
+    list(type = "daemon", display = "daemon/run-at-load", raw = NULL)
+  } else {
+    list(type = "unknown", display = "unknown", raw = NULL)
+  }
+}
+
+#' Classify a plist into a priority tier.
+#'
+#' Tier rules (in priority order):
+#'  1. Label contains keywords: roborev-metrics-etl, self-review, duckdb-backup,
+#'     codex-overnight → High (overnight data-integrity chain; fires 02:00–08:00)
+#'  2. Label contains: pulse, project-backlog, chrome-tab, roborev-autoclose,
+#'     roborev-severity, wiki-health, or fires 09:00–21:00 → Medium
+#'  3. Interval ≤ 1800s, daemon, or fires <08:00 and not in High keywords → Low
+classify_tier <- function(label, sched) {
+  high_keywords <- c(
+    "roborev-metrics-etl", "self-review", "unified-duckdb-backup",
+    "codex-overnight-learning", "roborev-metrics"
+  )
+  medium_keywords <- c(
+    "pulse", "project-backlog", "chrome-tab", "roborev-autoclose",
+    "roborev-severity", "wiki-health", "pr-status", "roborev-poll",
+    "knowledge-pulse", "config-pulse"
+  )
+
+  lbl_lower <- tolower(label)
+
+  # High: keyword match
+  if (any(vapply(high_keywords, function(k) grepl(k, lbl_lower, fixed = TRUE), logical(1L)))) {
+    return("High")
+  }
+
+  # Check hour for calendar jobs
+  if (!is.null(sched$raw) && sched$type == "calendar") {
+    raw <- sched$raw
+    # Extract first Hour value — raw may be a list (single interval) or data.frame (multi)
+    hour <- if (is.data.frame(raw)) {
+      raw[["Hour"]][1L]
+    } else if (is.list(raw)) {
+      raw[["Hour"]]
+    } else {
+      NA
+    }
+    # hour may still be a vector (e.g. named list with vector value) — take first scalar
+    if (!is.null(hour) && length(hour) >= 1L) {
+      h_val <- suppressWarnings(as.integer(hour[[1L]]))
+      if (!is.na(h_val)) {
+        if (h_val < 8L) return("High")
+        if (h_val >= 8L && h_val <= 21L) {
+          if (any(vapply(medium_keywords, function(k) grepl(k, lbl_lower, fixed = TRUE), logical(1L)))) {
+            return("Medium")
+          }
+          return("Medium")
+        }
+      }
+    }
+  }
+
+  if (any(vapply(medium_keywords, function(k) grepl(k, lbl_lower, fixed = TRUE), logical(1L)))) {
+    return("Medium")
+  }
+
+  if (sched$type == "interval") {
+    secs <- sched$raw[["seconds"]]
+    if (!is.null(secs) && secs <= 1800L) return("Low")
+    return("Medium")
+  }
+
+  "Low"
+}
+
+#' Enumerate all owned LaunchAgents plists, returning a data.frame.
+collect_inventory <- function(launch_dir = LAUNCH_AGENTS_DIR) {
+  plists <- list.files(
+    launch_dir,
+    pattern = "^(com\\.claude\\.|com\\.johngavin\\.|com\\.roborev\\.|com\\.llmtelemetry\\.)",
+    full.names = TRUE
+  )
+  # Exclude backups
+  plists <- plists[!grepl("\\.bak-", plists)]
+
+  rows <- lapply(plists, function(path) {
+    pl <- parse_plist(path)
+    if (is.null(pl)) return(NULL)
+
+    label    <- pl[["Label"]] %||% basename(path)
+    sched    <- extract_schedule(pl)
+    tier     <- classify_tier(label, sched)
+    prog_raw <- pl[["ProgramArguments"]]
+    program  <- if (is.null(prog_raw)) pl[["Program"]] %||% "(none)"
+                else paste(prog_raw, collapse = " ")
+    timeout  <- pl[["TimeOut"]]
+    std_out  <- pl[["StandardOutPath"]]
+    std_err  <- pl[["StandardErrorPath"]]
+
+    # Derive script path for GitHub URL (heuristic: last element that ends in .sh or .R or .py)
+    script_path <- NA_character_
+    if (!is.null(prog_raw) && length(prog_raw) > 0L) {
+      for (arg in rev(prog_raw)) {
+        if (grepl("\\.(sh|R|py)$", arg)) { script_path <- arg; break }
+      }
+    }
+
+    list(
+      label       = label,
+      tier        = tier,
+      schedule    = sched$display,
+      program     = program,
+      script_path = script_path,
+      timeout_s   = if (!is.null(timeout)) as.integer(timeout) else NA_integer_,
+      std_out     = std_out %||% NA_character_,
+      std_err     = std_err %||% NA_character_,
+      plist_path  = path
+    )
+  })
+
+  rows <- Filter(Negate(is.null), rows)
+  if (length(rows) == 0L) {
+    return(data.frame(
+      label = character(), tier = character(), schedule = character(),
+      program = character(), script_path = character(),
+      timeout_s = integer(), std_out = character(),
+      std_err = character(), plist_path = character(),
+      stringsAsFactors = FALSE
+    ))
+  }
+
+  do.call(rbind, lapply(rows, as.data.frame, stringsAsFactors = FALSE))
+}
+
+# ── Section 2: run metrics from ledger ─────────────────────────────────────────
+
+#' Read per-job run metrics from the DuckDB ledger.
+#' Returns a data.frame with one row per label, or a special "empty" data.frame.
+read_run_metrics <- function(ledger = LEDGER_PATH, window_days = REPORT_WINDOW_DAYS) {
+  if (!has_duckdb) {
+    message("launchd_health_report.R: duckdb not available — section 2 skipped")
+    return(NULL)
+  }
+  if (!file.exists(ledger)) {
+    message(sprintf("launchd_health_report.R: ledger not found at %s — first run", ledger))
+    return(data.frame(empty = TRUE, stringsAsFactors = FALSE))
+  }
+
+  con <- duckdb::dbConnect(duckdb::duckdb(), dbdir = ledger, read_only = TRUE)
+  on.exit(duckdb::dbDisconnect(con, shutdown = FALSE))
+
+  tables <- DBI::dbListTables(con)
+  if (!"runs" %in% tables) {
+    message("launchd_health_report.R: 'runs' table not found in ledger — first run")
+    return(data.frame(empty = TRUE, stringsAsFactors = FALSE))
+  }
+
+  cutoff <- format(Sys.time() - window_days * 86400, "%Y-%m-%d %H:%M:%S")
+
+  query <- sprintf(
+    "SELECT
+       label,
+       COUNT(*) AS run_count,
+       SUM(CASE WHEN exit_code != 0 THEN 1 ELSE 0 END) AS failures,
+       ROUND(100.0 * SUM(CASE WHEN exit_code != 0 THEN 1 ELSE 0 END) / COUNT(*), 1) AS failure_pct,
+       ROUND(MEDIAN(EPOCH(finished_at) - EPOCH(started_at)), 1) AS median_duration_s,
+       ROUND(MAX(EPOCH(finished_at) - EPOCH(started_at)), 1)    AS max_duration_s,
+       ROUND(MEDIAN(peak_rss_mb), 1) AS median_rss_mb,
+       ROUND(MAX(peak_rss_mb), 1)    AS max_rss_mb,
+       MAX(exit_code)                AS last_exit_code,
+       MAX(finished_at)              AS last_run
+     FROM runs
+     WHERE started_at >= TIMESTAMPTZ '%s'
+     GROUP BY label
+     ORDER BY label",
+    cutoff
+  )
+
+  tryCatch(
+    DBI::dbGetQuery(con, query),
+    error = function(e) {
+      message("launchd_health_report.R: ledger query error — ", conditionMessage(e))
+      data.frame(empty = TRUE, stringsAsFactors = FALSE)
+    }
+  )
+}
+
+# ── Section 3: auto-generated suggestions ─────────────────────────────────────
+
+#' Compute peak-contention: jobs firing at the same clock minute.
+#' Returns a data.frame with columns: time_slot, count, labels.
+detect_contention <- function(inventory, threshold = 3L) {
+  # Only calendar-type rows with numeric Hour
+  cal_rows <- inventory[grepl("^\\d{2}:\\d{2}", inventory$schedule), ]
+  if (nrow(cal_rows) == 0L) return(data.frame(
+    time_slot = character(), count = integer(), labels = character(),
+    stringsAsFactors = FALSE
+  ))
+
+  # Extract first HH:MM token
+  slots <- regmatches(cal_rows$schedule, regexpr("^\\d{2}:\\d{2}", cal_rows$schedule))
+  tbl <- table(slots)
+  hot <- names(tbl)[tbl >= threshold]
+
+  rows <- lapply(hot, function(slot) {
+    idx <- which(startsWith(cal_rows$schedule, slot))
+    list(
+      time_slot = slot,
+      count     = length(idx),
+      labels    = paste(cal_rows$label[idx], collapse = ", ")
+    )
+  })
+
+  if (length(rows) == 0L) return(data.frame(
+    time_slot = character(), count = integer(), labels = character(),
+    stringsAsFactors = FALSE
+  ))
+  do.call(rbind, lapply(rows, as.data.frame, stringsAsFactors = FALSE))
+}
+
+#' Build suggestion bullets from inventory + metrics.
+build_suggestions <- function(inventory, metrics) {
+  suggestions <- character(0L)
+
+  # Peak contention
+  contention <- detect_contention(inventory, threshold = 3L)
+  if (nrow(contention) > 0L) {
+    for (i in seq_len(nrow(contention))) {
+      r <- contention[i, ]
+      suggestions <- c(suggestions, sprintf(
+        "**Peak contention** at %s: %d jobs fire simultaneously (%s). Consider staggering by 2–5 minutes.",
+        r$time_slot, r$count, r$labels
+      ))
+    }
+  }
+
+  # High failure rate
+  if (!is.null(metrics) && nrow(metrics) > 0L && !"empty" %in% names(metrics)) {
+    fail_jobs <- metrics[!is.na(metrics$failure_pct) & metrics$failure_pct > 10, ]
+    if (nrow(fail_jobs) > 0L) {
+      for (i in seq_len(nrow(fail_jobs))) {
+        r <- fail_jobs[i, ]
+        suggestions <- c(suggestions, sprintf(
+          "**High failure rate** for `%s`: %.0f%% failures (%d/%d runs), last exit %s.",
+          r$label, r$failure_pct, r$failures, r$run_count,
+          if (!is.na(r$last_exit_code)) as.character(r$last_exit_code) else "?"
+        ))
+      }
+    }
+  }
+
+  if (length(suggestions) == 0L) {
+    suggestions <- "_No issues detected. All systems nominal._"
+  }
+
+  suggestions
+}
+
+# ── Section 4: cloud crons ─────────────────────────────────────────────────────
+
+#' Enumerate GitHub Actions workflows for a repo.
+#'
+#' Primary: reads local filesystem (more robust in Nix shells where gh may not be in PATH).
+#' Fallback: calls gh API if local clone not found.
+enumerate_workflows <- function(repo) {
+  repo_name  <- sub(".*/", "", repo)
+  local_root <- file.path(Sys.getenv("HOME"), "docs_gh", repo_name)
+  wf_dir     <- file.path(local_root, ".github", "workflows")
+
+  if (dir.exists(wf_dir)) {
+    yml_files <- list.files(wf_dir, pattern = "\\.(yml|yaml)$", full.names = FALSE)
+    lapply(yml_files, function(f) {
+      list(
+        name     = sub("\\.(yml|yaml)$", "", f),
+        path     = file.path(".github", "workflows", f),
+        html_url = sprintf(
+          "https://github.com/%s/blob/main/.github/workflows/%s", repo, f
+        )
+      )
+    })
+  } else {
+    # Fallback: gh API (try common locations for gh binary)
+    gh_bin <- Sys.which("gh")
+    if (!nzchar(gh_bin)) {
+      gh_candidates <- c(
+        "/nix/var/nix/profiles/default/bin/gh",
+        "/usr/local/bin/gh",
+        "/opt/homebrew/bin/gh"
+      )
+      gh_bin <- gh_candidates[file.exists(gh_candidates)][1L]
+    }
+    if (is.na(gh_bin) || !nzchar(gh_bin)) return(list())
+
+    api_path <- sprintf("/repos/%s/actions/workflows", repo)
+    result <- tryCatch(
+      system2(gh_bin,
+              c("api", api_path, "--jq",
+                ".workflows[] | {name: .name, path: .path, html_url: .html_url}"),
+              stdout = TRUE, stderr = FALSE),
+      error = function(e) character(0L)
+    )
+    if (length(result) == 0L) return(list())
+    parsed <- lapply(result, function(line) {
+      tryCatch(jsonlite::fromJSON(line), error = function(e) NULL)
+    })
+    Filter(Negate(is.null), parsed)
+  }
+}
+
+#' Read a workflow YAML from disk (if local clone exists) or skip.
+#' Returns named list: has_schedule, crons, dispatch_only.
+parse_workflow_triggers <- function(repo, workflow_path) {
+  # Derive local path heuristic
+  repo_name <- sub(".*/", "", repo)
+  local_root <- file.path(Sys.getenv("HOME"), "docs_gh", repo_name)
+  local_file <- file.path(local_root, workflow_path)
+
+  if (!file.exists(local_file)) return(list(has_schedule = NA, crons = NA, dispatch_only = NA))
+
+  content <- readLines(local_file, warn = FALSE)
+  has_schedule  <- any(grepl("schedule:", content))
+  dispatch_only <- any(grepl("workflow_dispatch:", content)) && !has_schedule
+
+  cron_lines <- content[grepl("cron:", content)]
+  crons <- if (length(cron_lines) > 0L) {
+    # Strip everything up to and including "cron:" + optional quote chars
+    cleaned <- trimws(sub(".*cron:[[:space:]]*['\"]?", "", cron_lines))
+    # Strip trailing quote, whitespace, or comment
+    cleaned <- sub("['\"].*$", "", cleaned)
+    cleaned <- trimws(cleaned)
+    paste(cleaned[nzchar(cleaned)], collapse = "; ")
+  } else {
+    NA_character_
+  }
+
+  list(has_schedule = has_schedule, crons = crons, dispatch_only = dispatch_only)
+}
+
+collect_cloud_crons <- function(repos = CLOUD_REPOS) {
+  rows <- list()
+  for (repo in repos) {
+    wfs <- enumerate_workflows(repo)
+    for (wf in wfs) {
+      triggers <- parse_workflow_triggers(repo, wf[["path"]])
+      if (is.na(triggers$has_schedule) && is.na(triggers$dispatch_only)) next
+      if (!isTRUE(triggers$has_schedule) && !isTRUE(triggers$dispatch_only)) next
+
+      rows <- c(rows, list(list(
+        repo           = repo,
+        name           = wf[["name"]],
+        path           = wf[["path"]],
+        html_url       = wf[["html_url"]],
+        has_schedule   = isTRUE(triggers$has_schedule),
+        cron           = if (!is.null(triggers$crons)) triggers$crons else NA_character_,
+        dispatch_only  = isTRUE(triggers$dispatch_only)
+      )))
+    }
+  }
+
+  if (length(rows) == 0L) return(data.frame(
+    repo = character(), name = character(), path = character(),
+    html_url = character(), has_schedule = logical(),
+    cron = character(), dispatch_only = logical(),
+    stringsAsFactors = FALSE
+  ))
+  do.call(rbind, lapply(rows, as.data.frame, stringsAsFactors = FALSE))
+}
+
+# ── Markdown rendering ─────────────────────────────────────────────────────────
+
+`%||%` <- function(a, b) if (!is.null(a)) a else b
+
+fmt_val <- function(x) if (is.null(x) || (length(x) == 1L && is.na(x))) "—" else as.character(x)
+
+render_inventory_table <- function(inventory) {
+  tiers <- c("High", "Medium", "Low")
+  tier_emoji <- c(High = "\U1F534", Medium = "\U1F7E0", Low = "\U1F7E2")
+
+  lines <- character(0L)
+  for (tier in tiers) {
+    sub <- inventory[inventory$tier == tier, ]
+    if (nrow(sub) == 0L) next
+
+    lines <- c(lines, sprintf("\n### %s %s Tier", tier_emoji[tier], tier), "")
+    lines <- c(lines,
+      "| Label | Schedule | Program | Timeout |",
+      "|-------|----------|---------|---------|"
+    )
+    for (i in seq_len(nrow(sub))) {
+      r <- sub[i, ]
+      prog_short <- if (nchar(r$program) > 80) paste0(substr(r$program, 1L, 77L), "...") else r$program
+      timeout_s <- if (!is.na(r$timeout_s)) sprintf("%ds", r$timeout_s) else "—"
+      lines <- c(lines, sprintf("| `%s` | %s | `%s` | %s |",
+        r$label, r$schedule, prog_short, timeout_s
+      ))
+    }
+  }
+  paste(lines, collapse = "\n")
+}
+
+render_metrics_table <- function(metrics) {
+  if (is.null(metrics)) {
+    return("\n> _duckdb not available — section 2 skipped._\n")
+  }
+  if ("empty" %in% names(metrics)) {
+    return(paste0(
+      "\n> **No run data yet.** The ledger (`~/.claude/logs/launchd_runs.duckdb`) ",
+      "has not been populated yet.\n> Wrap plist commands with `bin/launchd_run_record.sh` ",
+      "to start collecting metrics. Data will appear here after the first runs.\n"
+    ))
+  }
+  if (nrow(metrics) == 0L) {
+    return("\n> _No runs recorded in the past 7 days._\n")
+  }
+
+  lines <- c(
+    "",
+    "| Label | Runs | Failures | Fail% | Median Duration (s) | Max Duration (s) | Median RSS (MB) | Max RSS (MB) | Last Exit | Last Run |",
+    "|-------|------|----------|-------|---------------------|------------------|-----------------|--------------|-----------|----------|"
+  )
+  for (i in seq_len(nrow(metrics))) {
+    r <- metrics[i, ]
+    lines <- c(lines, sprintf(
+      "| `%s` | %s | %s | %s | %s | %s | %s | %s | %s | %s |",
+      r$label,
+      fmt_val(r$run_count),
+      fmt_val(r$failures),
+      if (!is.na(r$failure_pct)) sprintf("%.1f%%", r$failure_pct) else "—",
+      fmt_val(r$median_duration_s),
+      fmt_val(r$max_duration_s),
+      fmt_val(r$median_rss_mb),
+      fmt_val(r$max_rss_mb),
+      fmt_val(r$last_exit_code),
+      fmt_val(r$last_run)
+    ))
+  }
+  paste(lines, collapse = "\n")
+}
+
+render_suggestions <- function(suggestions) {
+  paste(paste0("- ", suggestions), collapse = "\n")
+}
+
+render_cloud_crons_table <- function(cloud) {
+  if (nrow(cloud) == 0L) {
+    return("\n> _No scheduled/dispatch-only workflows found in configured repos._\n")
+  }
+
+  lines <- c(
+    "",
+    "| Repo | Workflow | Cron | Type | Link |",
+    "|------|----------|------|------|------|"
+  )
+  for (i in seq_len(nrow(cloud))) {
+    r <- cloud[i, ]
+    type_label <- if (isTRUE(r$dispatch_only)) "dispatch-only" else "scheduled"
+    cron_display <- if (!is.na(r$cron) && nzchar(r$cron)) r$cron else "—"
+    link <- if (!is.null(r$html_url) && !is.na(r$html_url)) {
+      sprintf("[workflow](%s)", r$html_url)
+    } else {
+      r$path
+    }
+    lines <- c(lines, sprintf(
+      "| `%s` | %s | `%s` | %s | %s |",
+      r$repo, r$name, cron_display, type_label, link
+    ))
+  }
+  paste(lines, collapse = "\n")
+}
+
+# ── Main (skipped when sourced with option launchd_health_source_only=TRUE) ────
+
+if (isTRUE(getOption("launchd_health_source_only"))) {
+  # sourced for testing — definitions loaded, main body skipped
+  invisible(NULL)
+} else {
+
+message("launchd_health_report.R: collecting inventory from ", LAUNCH_AGENTS_DIR)
+inventory <- collect_inventory(LAUNCH_AGENTS_DIR)
+message(sprintf("  found %d owned plists", nrow(inventory)))
+
+message("launchd_health_report.R: reading run metrics from ", LEDGER_PATH)
+metrics <- read_run_metrics(LEDGER_PATH, REPORT_WINDOW_DAYS)
+
+message("launchd_health_report.R: building suggestions")
+suggestions <- build_suggestions(inventory, metrics)
+
+message("launchd_health_report.R: enumerating cloud crons")
+cloud_crons <- collect_cloud_crons(CLOUD_REPOS)
+
+# ── Assemble report ────────────────────────────────────────────────────────────
+
+now_utc <- format(Sys.time(), "%Y-%m-%d %H:%M UTC", tz = "UTC")
+
+report_md <- paste0(
+  "# Weekly Scheduled-Task Health Report\n\n",
+  "_Generated: ", now_utc, "_\n\n",
+  "---\n\n",
+  "## 1. Inventory — Priority × Time-of-Day\n",
+  render_inventory_table(inventory),
+  "\n\n---\n\n",
+  "## 2. Per-Job Run Metrics (Rolling ", REPORT_WINDOW_DAYS, " Days)\n",
+  render_metrics_table(metrics),
+  "\n\n---\n\n",
+  "## 3. Auto-Generated Improvement Suggestions\n\n",
+  render_suggestions(suggestions),
+  "\n\n---\n\n",
+  "## 4. Related Cloud Crons (GitHub Actions)\n",
+  render_cloud_crons_table(cloud_crons),
+  "\n"
+)
+
+# ── Write output ───────────────────────────────────────────────────────────────
+
+if (out_path == "/dev/stdout") {
+  cat(report_md)
+} else {
+  dir.create(dirname(out_path), recursive = TRUE, showWarnings = FALSE)
+  writeLines(report_md, out_path)
+  message(sprintf("launchd_health_report.R: report written to %s", out_path))
+}
+
+} # end if (!isTRUE(getOption("launchd_health_source_only")))

--- a/.claude/scripts/send_launchd_health_email.R
+++ b/.claude/scripts/send_launchd_health_email.R
@@ -1,0 +1,300 @@
+#!/usr/bin/env Rscript
+# send_launchd_health_email.R — Send weekly launchd health report via Gmail.
+#
+# Runs launchd_health_report.R to generate a Markdown report, converts it to
+# HTML sections, and sends via blastula (same pattern as send_roborev_email.R).
+#
+# Required env vars:
+#   GMAIL_USERNAME       Gmail sender address
+#   GMAIL_APP_PASSWORD   Gmail app password
+#   REPORT_RECIPIENT     Recipient (defaults to GMAIL_USERNAME)
+#
+# Optional env vars:
+#   EMAIL_DRY_RUN        Set to "1" to print body to stdout without sending
+#   LAUNCHD_LEDGER       Override DuckDB ledger path
+#   CLOUD_REPOS          Override cloud repos (comma-separated)
+#
+# Tracked in llm#300.
+
+suppressPackageStartupMessages({
+  library(blastula)
+})
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+SCRIPTS_DIR <- Sys.getenv(
+  "LAUNCHD_SCRIPTS_DIR",
+  file.path(Sys.getenv("HOME"), "docs_gh", "llm", ".claude", "scripts")
+)
+
+dry_run <- identical(Sys.getenv("EMAIL_DRY_RUN"), "1")
+
+# ── Run aggregator to get report markdown ─────────────────────────────────────
+
+md_tmp <- tempfile(fileext = ".md")
+on.exit(unlink(md_tmp), add = TRUE)
+
+aggregator <- file.path(SCRIPTS_DIR, "launchd_health_report.R")
+if (!file.exists(aggregator)) {
+  stop(sprintf(
+    "send_launchd_health_email.R: aggregator not found at %s\n  Set LAUNCHD_SCRIPTS_DIR env var.",
+    aggregator
+  ))
+}
+
+env_extra <- character(0L)
+ldger <- Sys.getenv("LAUNCHD_LEDGER", "")
+if (nzchar(ldger)) env_extra <- c(env_extra, sprintf("LAUNCHD_LEDGER=%s", ldger))
+repos <- Sys.getenv("CLOUD_REPOS", "")
+if (nzchar(repos)) env_extra <- c(env_extra, sprintf("CLOUD_REPOS=%s", repos))
+
+env_str <- if (length(env_extra) > 0L) paste(env_extra, collapse = " ") else ""
+
+message("send_launchd_health_email.R: running aggregator")
+ret <- system2(
+  "Rscript",
+  c(aggregator, "--out", md_tmp),
+  env = if (nzchar(env_str)) env_extra else character(0L),
+  stdout = FALSE,
+  stderr = ""
+)
+if (ret != 0L) {
+  stop("send_launchd_health_email.R: aggregator failed with exit code ", ret)
+}
+
+if (!file.exists(md_tmp)) {
+  stop("send_launchd_health_email.R: aggregator produced no output file")
+}
+
+report_md <- paste(readLines(md_tmp, warn = FALSE), collapse = "\n")
+
+# ── Colour palette (matches llmtelemetry convention) ──────────────────────────
+
+dark_bg       <- "#1a1a2e"
+dark_card     <- "#16213e"
+dark_row_alt  <- "#0f3460"
+dark_text     <- "#e8e8e8"
+dark_muted    <- "#a0a0a0"
+dark_border   <- "#2a2a4a"
+accent_green  <- "#00d26a"
+accent_blue   <- "#4fc3f7"
+accent_orange <- "#ff9800"
+accent_purple <- "#bb86fc"
+accent_red    <- "#f08080"
+
+# ── Parse report sections ──────────────────────────────────────────────────────
+
+# Split on "---" HR dividers to get section blocks
+sections <- strsplit(report_md, "\n---\n")[[1L]]
+
+s1 <- if (length(sections) >= 1L) sections[1L] else "(no data)"
+s2 <- if (length(sections) >= 2L) sections[2L] else "(no data)"
+s3 <- if (length(sections) >= 3L) sections[3L] else "(no data)"
+s4 <- if (length(sections) >= 4L) sections[4L] else "(no data)"
+
+# ── Convert markdown tables to simple HTML tables ─────────────────────────────
+
+#' Convert a markdown table block to an HTML table.
+md_table_to_html <- function(md_text, header_bg = dark_row_alt, header_color = "#ffffff",
+                              row_bg1 = dark_card, row_bg2 = dark_row_alt) {
+  lines <- strsplit(md_text, "\n")[[1L]]
+  tbl_lines <- lines[grepl("^\\|", lines)]
+  if (length(tbl_lines) < 2L) return(paste0("<pre>", md_text, "</pre>"))
+
+  # First line = header; second = separator; rest = data
+  header_line <- tbl_lines[1L]
+  data_lines  <- if (length(tbl_lines) > 2L) tbl_lines[-(1L:2L)] else character(0L)
+
+  parse_row <- function(line) {
+    cells <- strsplit(line, "\\|")[[1L]]
+    cells <- trimws(cells[nzchar(trimws(cells))])
+    cells
+  }
+
+  header_cells <- parse_row(header_line)
+  th_html <- paste(sprintf(
+    '<th style="padding:6px 8px; border:1px solid %s; color:%s; text-align:left;">%s</th>',
+    dark_border, header_color, header_cells
+  ), collapse = "")
+
+  rows_html <- character(length(data_lines))
+  for (i in seq_along(data_lines)) {
+    cells <- parse_row(data_lines[i])
+    bg <- if (i %% 2L == 0L) row_bg2 else row_bg1
+    td_html <- paste(sprintf(
+      '<td style="padding:5px 8px; border:1px solid %s; color:%s;">%s</td>',
+      dark_border, dark_text, cells
+    ), collapse = "")
+    rows_html[i] <- sprintf('<tr style="background-color:%s;">%s</tr>', bg, td_html)
+  }
+
+  sprintf(
+    '<table style="border-collapse:collapse; width:100%%; font-size:12px;">
+  <tr style="background-color:%s;">%s</tr>
+  %s
+</table>',
+    header_bg, th_html, paste(rows_html, collapse = "\n  ")
+  )
+}
+
+#' Convert inline markdown code `foo` to <code>foo</code>
+md_inline_code <- function(s) {
+  gsub("`([^`]+)`", "<code>\\1</code>", s)
+}
+
+#' Convert **bold** to <strong>bold</strong>
+md_bold <- function(s) {
+  gsub("\\*\\*([^*]+)\\*\\*", "<strong>\\1</strong>", s)
+}
+
+md_to_simple_html <- function(s) {
+  s <- md_inline_code(s)
+  s <- md_bold(s)
+  s
+}
+
+# Section 1 tables
+s1_tables <- md_table_to_html(s1, header_bg = dark_row_alt)
+# Section 2 check for placeholder text vs table
+has_s2_table <- grepl("^\\|", trimws(s2))
+s2_html <- if (has_s2_table) {
+  md_table_to_html(s2)
+} else {
+  sprintf('<p style="color:%s; font-style:italic;">%s</p>',
+          dark_muted, md_to_simple_html(gsub("\n", " ", trimws(s2))))
+}
+# Section 3 bullets
+s3_bullets <- strsplit(trimws(s3), "\n")[[1L]]
+s3_bullets <- s3_bullets[nzchar(s3_bullets)]
+s3_html <- paste(sprintf(
+  '<li style="color:%s; margin-bottom:6px;">%s</li>',
+  dark_text,
+  vapply(gsub("^[-*] ", "", s3_bullets), md_to_simple_html, character(1L))
+), collapse = "\n")
+# Section 4
+s4_html <- if (grepl("^\\|", trimws(sub("^[^|]*", "", s4)))) {
+  md_table_to_html(s4, header_bg = "#2d1b6e")
+} else {
+  sprintf('<p style="color:%s; font-style:italic;">%s</p>',
+          dark_muted, md_to_simple_html(gsub("\n", " ", trimws(s4))))
+}
+
+# ── Build full HTML body ───────────────────────────────────────────────────────
+
+report_date  <- format(Sys.Date(), "%Y-%m-%d")
+generated_at <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+
+# QA markers for tests
+qa_markers <- sprintf(
+  '<!-- QA:section1=inventory --><!-- QA:section2=run_metrics --><!-- QA:section3=suggestions --><!-- QA:section4=cloud_crons --><!-- QA:report_date=%s -->',
+  report_date
+)
+
+email_body <- sprintf(
+  '<div style="background-color:%s; color:%s; padding:20px;
+               font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">
+<h2 style="color:%s; margin-bottom:4px;">Weekly Scheduled-Task Health Report — %s</h2>
+<p style="color:%s; font-size:11px; margin-top:0;">Generated: %s</p>
+
+<h3 style="color:%s; margin-top:20px; border-bottom:1px solid %s; padding-bottom:4px;">
+  &#x1F534; Section 1 — Inventory (Priority &times; Time-of-Day)
+</h3>
+%s
+
+<h3 style="color:%s; margin-top:24px; border-bottom:1px solid %s; padding-bottom:4px;">
+  &#x1F4CA; Section 2 — Per-Job Run Metrics (7-Day)
+</h3>
+%s
+
+<h3 style="color:%s; margin-top:24px; border-bottom:1px solid %s; padding-bottom:4px;">
+  &#x26A0; Section 3 — Auto-Generated Improvement Suggestions
+</h3>
+<ul style="margin:0; padding-left:20px;">
+%s
+</ul>
+
+<h3 style="color:%s; margin-top:24px; border-bottom:1px solid %s; padding-bottom:4px;">
+  &#x2601; Section 4 — Related Cloud Crons (GitHub Actions)
+</h3>
+%s
+
+<p style="color:%s; font-size:10px; margin-top:24px;">
+  Tracked in <a href="https://github.com/JohnGavin/llm/issues/300" style="color:%s;">llm#300</a>.
+  Ledger: ~/.claude/logs/launchd_runs.duckdb
+</p>
+%s
+</div>',
+  dark_bg, dark_text,
+  accent_orange, report_date,
+  dark_muted, generated_at,
+  accent_orange, dark_border,
+  s1_tables,
+  accent_blue, dark_border,
+  s2_html,
+  accent_red, dark_border,
+  s3_html,
+  accent_purple, dark_border,
+  s4_html,
+  dark_muted, accent_blue,
+  qa_markers
+)
+
+# ── Dry-run mode ───────────────────────────────────────────────────────────────
+
+if (dry_run) {
+  message("send_launchd_health_email.R: EMAIL_DRY_RUN=1 — printing body to stdout")
+  cat(email_body, "\n")
+  message("send_launchd_health_email.R: dry-run complete (not sent)")
+  quit(status = 0L)
+}
+
+# ── Credentials ────────────────────────────────────────────────────────────────
+
+gmail_user <- Sys.getenv("GMAIL_USERNAME", "")
+gmail_pass <- Sys.getenv("GMAIL_APP_PASSWORD", "")
+
+if (!nzchar(gmail_user) || !nzchar(gmail_pass)) {
+  message("send_launchd_health_email.R: GMAIL_USERNAME or GMAIL_APP_PASSWORD not set")
+  cat("\n--- Email body (credentials missing, not sent) ---\n")
+  cat(email_body, "\n")
+  quit(status = 1L)
+}
+
+report_to <- Sys.getenv("REPORT_RECIPIENT", "")
+if (!nzchar(report_to)) report_to <- gmail_user
+
+# ── Compose and send ───────────────────────────────────────────────────────────
+
+london_time <- format(Sys.time(), tz = "Europe/London", "%Y-%m-%d %H:%M")
+
+email <- compose_email(
+  body   = md(email_body),
+  footer = md(sprintf(
+    "<span style='color:%s;'>Sent: %s (London)</span>",
+    dark_muted, london_time
+  ))
+)
+
+smtp_creds <- creds_envvar(
+  user        = gmail_user,
+  pass_envvar = "GMAIL_APP_PASSWORD",
+  host        = "smtp.gmail.com",
+  port        = 465,
+  use_ssl     = TRUE
+)
+
+tryCatch({
+  smtp_send(
+    email       = email,
+    to          = report_to,
+    from        = gmail_user,
+    subject     = sprintf("Weekly Scheduled-Task Health Report — %s", report_date),
+    credentials = smtp_creds
+  )
+  message(sprintf("send_launchd_health_email.R: email sent to %s", report_to))
+}, error = function(e) {
+  message("send_launchd_health_email.R: SMTP send failed — ", conditionMessage(e))
+  cat("\n--- Email body (SMTP failed) ---\n")
+  cat(email_body, "\n")
+  quit(status = 1L)
+})

--- a/bin/launchd_health_weekly_cron.sh
+++ b/bin/launchd_health_weekly_cron.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# launchd_health_weekly_cron.sh — Cron wrapper for the weekly health email.
+#
+# Steps:
+#   1. Generate the markdown report via launchd_health_report.R
+#   2. Send the email via send_launchd_health_email.R
+#   3. Log the run
+#
+# Invoked by: com.claude.launchd-health-weekly.plist (Sunday 09:00)
+#
+# Environment variables (set in ~/.claude/.env or plist EnvironmentVariables):
+#   GMAIL_USERNAME        Gmail sender
+#   GMAIL_APP_PASSWORD    Gmail app password
+#   REPORT_RECIPIENT      Override recipient
+#   EMAIL_DRY_RUN         Set to 1 to print body without sending
+#   LAUNCHD_LEDGER        Override DuckDB ledger path
+#   CLOUD_REPOS           Override repos for cloud-cron enumeration
+#
+# Tracked in llm#300.
+
+set -euo pipefail
+
+# ── Paths ──────────────────────────────────────────────────────────────────────
+
+REPO_ROOT="${REPO_ROOT:-$HOME/docs_gh/llm}"
+SCRIPTS_DIR="$REPO_ROOT/.claude/scripts"
+LOG_DIR="${LOG_DIR:-$HOME/.claude/logs}"
+LOG_FILE="$LOG_DIR/launchd_health_weekly.log"
+REPORT_OUT="$LOG_DIR/launchd_health_report_$(date +%Y-%m-%d).md"
+
+# Bring Nix-shell R into PATH if needed
+if [[ -f "$REPO_ROOT/default.nix" ]]; then
+  NIX_R="$(/usr/bin/env nix-shell "$REPO_ROOT/default.nix" --run "which Rscript" 2>/dev/null || true)"
+  if [[ -n "$NIX_R" ]]; then
+    export PATH="$(dirname "$NIX_R"):$PATH"
+  fi
+fi
+
+RSCRIPT="${RSCRIPT:-Rscript}"
+
+# ── Logging ────────────────────────────────────────────────────────────────────
+
+mkdir -p "$LOG_DIR"
+
+log() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') launchd_health_weekly_cron $*" >> "$LOG_FILE"
+}
+
+log "START"
+
+# ── Source credentials if available ───────────────────────────────────────────
+
+ENV_FILE="$HOME/.claude/.env"
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  log "sourced credentials from $ENV_FILE"
+fi
+
+# ── Step 1: Generate markdown report ─────────────────────────────────────────
+
+log "running aggregator → $REPORT_OUT"
+"$RSCRIPT" "$SCRIPTS_DIR/launchd_health_report.R" --out "$REPORT_OUT" 2>>"$LOG_FILE"
+log "aggregator done ($(wc -l < "$REPORT_OUT") lines)"
+
+# ── Step 2: Send email ─────────────────────────────────────────────────────────
+
+export LAUNCHD_SCRIPTS_DIR="$SCRIPTS_DIR"
+log "sending email"
+"$RSCRIPT" "$SCRIPTS_DIR/send_launchd_health_email.R" 2>>"$LOG_FILE"
+log "email send complete"
+
+# ── Step 3: Prune old reports (keep 30 days) ──────────────────────────────────
+
+find "$LOG_DIR" -name "launchd_health_report_*.md" -mtime +30 -delete 2>/dev/null || true
+log "pruned old reports"
+
+log "DONE"

--- a/bin/launchd_run_record.sh
+++ b/bin/launchd_run_record.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# launchd_run_record.sh — Wrapper that records launchd job run metrics to DuckDB.
+#
+# Usage:
+#   launchd_run_record.sh <label> -- <cmd> [args...]
+#
+# Records: label, started_at, finished_at, exit_code, peak_rss_mb into
+# ~/.claude/logs/launchd_runs.duckdb (schema created on first run).
+#
+# Example plist ProgramArguments adoption:
+#   <array>
+#     <string>/bin/bash</string>
+#     <string>/path/to/bin/launchd_run_record.sh</string>
+#     <string>com.claude.my-job</string>
+#     <string>--</string>
+#     <string>/bin/bash</string>
+#     <string>/path/to/my_script.sh</string>
+#   </array>
+#
+# Tracked in llm#300.
+
+set -euo pipefail
+
+# ── Arg parsing ────────────────────────────────────────────────────────────────
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: launchd_run_record.sh <label> -- <cmd> [args...]" >&2
+  exit 1
+fi
+
+LABEL="$1"
+shift
+if [[ "$1" != "--" ]]; then
+  echo "launchd_run_record.sh: expected '--' separator after label" >&2
+  exit 1
+fi
+shift   # consume "--"
+
+CMD=("$@")
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+LEDGER="${LAUNCHD_LEDGER:-$HOME/.claude/logs/launchd_runs.duckdb}"
+LOG_DIR="$(dirname "$LEDGER")"
+TIMELOG="$(mktemp /tmp/launchd_time.XXXXXX)"
+DUCKDB_BIN="${DUCKDB_BIN:-duckdb}"
+
+# ── Ensure ledger + schema exist ───────────────────────────────────────────────
+
+mkdir -p "$LOG_DIR"
+
+ensure_schema() {
+  # Idempotent: CREATE TABLE IF NOT EXISTS
+  "$DUCKDB_BIN" "$LEDGER" <<'SQL' 2>/dev/null || true
+CREATE TABLE IF NOT EXISTS runs (
+  label        VARCHAR NOT NULL,
+  started_at   TIMESTAMPTZ NOT NULL,
+  finished_at  TIMESTAMPTZ NOT NULL,
+  exit_code    INTEGER NOT NULL,
+  peak_rss_mb  DOUBLE,
+  host         VARCHAR
+);
+SQL
+}
+
+if command -v "$DUCKDB_BIN" &>/dev/null; then
+  ensure_schema
+else
+  echo "launchd_run_record.sh: duckdb not found in PATH — metrics not recorded" >&2
+  # Still run the command (wrapper must never block the real job)
+  exec "${CMD[@]}"
+fi
+
+# ── Run the command under /usr/bin/time ───────────────────────────────────────
+
+STARTED_AT="$(date -u '+%Y-%m-%d %H:%M:%S')"
+EXIT_CODE=0
+
+# /usr/bin/time -l on macOS emits "N maximum resident set size" in bytes
+if /usr/bin/time -l "${CMD[@]}" 2>"$TIMELOG"; then
+  EXIT_CODE=0
+else
+  EXIT_CODE=$?
+fi
+
+FINISHED_AT="$(date -u '+%Y-%m-%d %H:%M:%S')"
+
+# ── Parse peak RSS from time output ──────────────────────────────────────────
+
+PEAK_RSS_MB="NULL"
+if [[ -f "$TIMELOG" ]]; then
+  # macOS /usr/bin/time -l output: "        N  maximum resident set size"
+  rss_bytes=$(grep -i "maximum resident set size" "$TIMELOG" | awk '{print $1}' | head -1)
+  if [[ -n "$rss_bytes" && "$rss_bytes" =~ ^[0-9]+$ ]]; then
+    # Convert bytes → MB
+    PEAK_RSS_MB=$(awk "BEGIN {printf \"%.2f\", $rss_bytes / 1048576}")
+  fi
+fi
+rm -f "$TIMELOG"
+
+# ── Append row to ledger ───────────────────────────────────────────────────────
+
+HOST="$(hostname -s 2>/dev/null || echo 'unknown')"
+
+"$DUCKDB_BIN" "$LEDGER" <<SQL 2>/dev/null || true
+INSERT INTO runs (label, started_at, finished_at, exit_code, peak_rss_mb, host)
+VALUES (
+  '$(echo "$LABEL" | sed "s/'/''/g")',
+  TIMESTAMPTZ '${STARTED_AT}+00:00',
+  TIMESTAMPTZ '${FINISHED_AT}+00:00',
+  ${EXIT_CODE},
+  ${PEAK_RSS_MB},
+  '$(echo "$HOST" | sed "s/'/''/g")'
+);
+SQL
+
+exit "$EXIT_CODE"

--- a/bin/launchd_run_record_install.sh
+++ b/bin/launchd_run_record_install.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# launchd_run_record_install.sh — Show suggested wrapper adoptions for owned plists.
+#
+# For each ~/Library/LaunchAgents/com.claude.*.plist, prints the suggested
+# ProgramArguments change to wrap the command with launchd_run_record.sh.
+#
+# This script is READ-ONLY (it never edits plists automatically).
+# Review the suggestions and apply manually.
+#
+# Tracked in llm#300.
+
+set -euo pipefail
+
+PLIST_DIR="${PLIST_DIR:-$HOME/Library/LaunchAgents}"
+WRAPPER="${WRAPPER:-$HOME/docs_gh/llm/bin/launchd_run_record.sh}"
+PLUTIL="${PLUTIL:-/usr/bin/plutil}"
+
+echo "# Suggested ProgramArguments wrapper adoptions"
+echo "# Script: launchd_run_record_install.sh"
+echo "# Review carefully before applying. DO NOT apply automatically."
+echo ""
+
+for plist in "$PLIST_DIR"/com.claude.*.plist; do
+  [[ -f "$plist" ]] || continue
+  [[ "$plist" == *.bak-* ]] && continue
+
+  label=$(basename "$plist" .plist)
+  tmpjson=$(mktemp /tmp/plist_install.XXXXXX.json)
+  "$PLUTIL" -convert json -o "$tmpjson" "$plist" 2>/dev/null || { rm -f "$tmpjson"; continue; }
+
+  # Extract current ProgramArguments
+  prog_args=$(python3 -c "
+import json, sys
+with open('$tmpjson') as f:
+    d = json.load(f)
+args = d.get('ProgramArguments', [])
+for a in args:
+    print(a)
+" 2>/dev/null)
+
+  rm -f "$tmpjson"
+
+  # Check if already wrapped
+  if echo "$prog_args" | grep -q "launchd_run_record"; then
+    echo "## $label  ← already wrapped"
+    echo ""
+    continue
+  fi
+
+  echo "## $label"
+  echo "Current ProgramArguments:"
+  echo "$prog_args" | sed 's/^/  /'
+  echo ""
+  echo "Suggested replacement:"
+  echo "  /bin/bash"
+  echo "  $WRAPPER"
+  echo "  $label"
+  echo "  --"
+  echo "$prog_args" | sed 's/^/  /'
+  echo ""
+  echo "Plist key block:"
+  echo "  <key>ProgramArguments</key>"
+  echo "  <array>"
+  echo "    <string>/bin/bash</string>"
+  echo "    <string>$WRAPPER</string>"
+  echo "    <string>$label</string>"
+  echo "    <string>--</string>"
+  while IFS= read -r arg; do
+    echo "    <string>$arg</string>"
+  done <<< "$prog_args"
+  echo "  </array>"
+  echo ""
+done
+
+echo "# Review complete. Apply changes manually with a text editor or plutil."
+echo "# Then: launchctl unload <plist> && launchctl load <plist>"

--- a/tests/fixtures/launchd/com.claude.contention-test.plist
+++ b/tests/fixtures/launchd/com.claude.contention-test.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.contention-test</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/contention_test.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/tests/fixtures/launchd/com.claude.contention-test2.plist
+++ b/tests/fixtures/launchd/com.claude.contention-test2.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.contention-test2</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/contention_test2.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/tests/fixtures/launchd/com.claude.high-tier-job.plist
+++ b/tests/fixtures/launchd/com.claude.high-tier-job.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.high-tier-job</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/high_tier_job.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>TimeOut</key>
+    <integer>120</integer>
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/high_tier_job.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/high_tier_job.err</string>
+</dict>
+</plist>

--- a/tests/fixtures/launchd/com.claude.medium-tier-job.plist
+++ b/tests/fixtures/launchd/com.claude.medium-tier-job.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.medium-tier-job</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/medium_tier_job.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/medium_tier_job.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/medium_tier_job.err</string>
+</dict>
+</plist>

--- a/tests/fixtures/launchd/com.johngavin.low-tier-daemon.plist
+++ b/tests/fixtures/launchd/com.johngavin.low-tier-daemon.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.johngavin.low-tier-daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/low_tier_daemon.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/low_tier_daemon.out</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/low_tier_daemon.err</string>
+</dict>
+</plist>

--- a/tests/fixtures/launchd/dispatch-only-workflow.yml
+++ b/tests/fixtures/launchd/dispatch-only-workflow.yml
@@ -1,0 +1,20 @@
+name: Self-Review Verify Email
+
+on:
+  workflow_dispatch:
+    inputs:
+      result:
+        description: "PASS or FAIL"
+        required: true
+      count:
+        description: "row count"
+        required: false
+        default: "?"
+
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Send email
+        run: echo "Sending email for ${{ inputs.result }}"

--- a/tests/testthat/test-launchd-health-report.R
+++ b/tests/testthat/test-launchd-health-report.R
@@ -1,0 +1,216 @@
+# test-launchd-health-report.R — Tests for launchd health report components.
+#
+# Tests:
+#   1. Tier classification for all 3 tiers
+#   2. Peak-contention detection
+#   3. Cloud-cron workflow YAML parsing (dispatch-only fixture)
+#   4. "Ledger empty" path produces placeholder text
+#   5. Email dry-run produces all 4 section QA markers
+#
+# Tracked in llm#300.
+
+library(testthat)
+
+# ── Source the aggregator functions ───────────────────────────────────────────
+
+# We source directly to get the helper functions in scope
+scripts_dir <- normalizePath(
+  file.path(testthat::test_path(), "..", "..", ".claude", "scripts"),
+  mustWork = FALSE
+)
+aggregator_path <- file.path(scripts_dir, "launchd_health_report.R")
+
+# Only run if aggregator exists (worktree check)
+skip_if(!file.exists(aggregator_path),
+        "launchd_health_report.R not found — skipping launchd tests")
+
+# Source with launchd_health_source_only=TRUE to load helper functions without
+# running the main body (which would collect from real LaunchAgents and exit).
+old_opt <- getOption("launchd_health_source_only")
+options(launchd_health_source_only = TRUE)
+.agg_env <- new.env(parent = baseenv())
+suppressMessages(
+  source(aggregator_path, local = .agg_env)
+)
+options(launchd_health_source_only = old_opt)
+
+# Pull the key functions
+parse_plist        <- get("parse_plist",        envir = .agg_env)
+extract_schedule   <- get("extract_schedule",   envir = .agg_env)
+classify_tier      <- get("classify_tier",      envir = .agg_env)
+detect_contention  <- get("detect_contention",  envir = .agg_env)
+collect_inventory  <- get("collect_inventory",  envir = .agg_env)
+read_run_metrics   <- get("read_run_metrics",   envir = .agg_env)
+parse_workflow_triggers <- get("parse_workflow_triggers", envir = .agg_env)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+fixtures_dir <- normalizePath(
+  file.path(testthat::test_path(), "..", "fixtures", "launchd"),
+  mustWork = FALSE
+)
+
+skip_if(!dir.exists(fixtures_dir), "fixtures/launchd not found — skipping")
+
+# ── Test 1: Tier classification ───────────────────────────────────────────────
+
+test_that("High-tier plist is classified correctly", {
+  pl <- parse_plist(file.path(fixtures_dir, "com.claude.high-tier-job.plist"))
+  skip_if(is.null(pl), "plutil not available")
+  sched <- extract_schedule(pl)
+  tier  <- classify_tier(pl[["Label"]], sched)
+  # 02:00 calendar job → High
+  expect_equal(tier, "High")
+})
+
+test_that("Medium-tier plist is classified correctly", {
+  pl <- parse_plist(file.path(fixtures_dir, "com.claude.medium-tier-job.plist"))
+  skip_if(is.null(pl), "plutil not available")
+  sched <- extract_schedule(pl)
+  tier  <- classify_tier(pl[["Label"]], sched)
+  # 09:00 calendar job → Medium
+  expect_equal(tier, "Medium")
+})
+
+test_that("Low/continuous-tier plist (interval) is classified correctly", {
+  pl <- parse_plist(file.path(fixtures_dir, "com.johngavin.low-tier-daemon.plist"))
+  skip_if(is.null(pl), "plutil not available")
+  sched <- extract_schedule(pl)
+  tier  <- classify_tier(pl[["Label"]], sched)
+  # 300s interval + RunAtLoad → Low
+  expect_equal(tier, "Low")
+})
+
+# ── Test 2: Peak contention detection ─────────────────────────────────────────
+
+test_that("detect_contention finds 3+ jobs at the same minute", {
+  # Three fixtures fire at 09:00: medium-tier-job, chrome-tab-backup (in real data),
+  # and our contention-test fixture.
+  inv <- collect_inventory(fixtures_dir)
+  skip_if(is.null(inv) || nrow(inv) == 0L, "inventory empty")
+
+  # Count 09:00 jobs in the fixture set
+  at_nine <- sum(startsWith(inv$schedule, "09:00"))
+  if (at_nine < 3L) skip(sprintf("only %d jobs at 09:00 in fixtures (need 3)", at_nine))
+
+  contention <- detect_contention(inv, threshold = 3L)
+  expect_true(nrow(contention) >= 1L)
+  expect_true(any(contention$time_slot == "09:00"))
+  expect_true(any(contention$count >= 3L))
+})
+
+test_that("detect_contention returns empty df when no contention", {
+  inv_empty <- data.frame(
+    label    = c("com.claude.job-a", "com.claude.job-b"),
+    tier     = c("High", "Medium"),
+    schedule = c("02:00", "09:00"),
+    stringsAsFactors = FALSE
+  )
+  result <- detect_contention(inv_empty, threshold = 3L)
+  expect_equal(nrow(result), 0L)
+})
+
+# ── Test 3: Cloud cron YAML parsing (dispatch-only fixture) ───────────────────
+
+test_that("dispatch-only workflow YAML is parsed as dispatch_only=TRUE", {
+  # Temporarily place fixture in a structure that parse_workflow_triggers can find
+  tmpdir <- file.path(tempdir(), "docs_gh", "llm-test", ".github", "workflows")
+  dir.create(tmpdir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(file.path(tempdir(), "docs_gh"), recursive = TRUE), add = TRUE)
+
+  fixture_src <- file.path(fixtures_dir, "dispatch-only-workflow.yml")
+  skip_if(!file.exists(fixture_src), "dispatch-only-workflow.yml fixture missing")
+  file.copy(fixture_src, file.path(tmpdir, "dispatch-only-workflow.yml"), overwrite = TRUE)
+
+  # Temporarily override HOME-based path resolution via withr
+  old_home <- Sys.getenv("HOME")
+  on.exit(Sys.setenv(HOME = old_home), add = TRUE)
+  Sys.setenv(HOME = tempdir())
+
+  triggers <- parse_workflow_triggers(
+    "docs_gh/llm-test",
+    ".github/workflows/dispatch-only-workflow.yml"
+  )
+  expect_true(isTRUE(triggers$dispatch_only))
+  expect_false(isTRUE(triggers$has_schedule))
+})
+
+test_that("scheduled workflow YAML is parsed as has_schedule=TRUE", {
+  tmpdir <- file.path(tempdir(), "docs_gh", "llmtelemetry-test", ".github", "workflows")
+  dir.create(tmpdir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(file.path(tempdir(), "docs_gh"), recursive = TRUE), add = TRUE)
+
+  writeLines(
+    c("name: Daily Test", "on:", "  schedule:", "    - cron: '0 8 * * *'", "jobs:", "  run:", "    runs-on: ubuntu-latest"),
+    file.path(tmpdir, "daily-test.yaml")
+  )
+
+  old_home <- Sys.getenv("HOME")
+  on.exit(Sys.setenv(HOME = old_home), add = TRUE)
+  Sys.setenv(HOME = tempdir())
+
+  triggers <- parse_workflow_triggers(
+    "docs_gh/llmtelemetry-test",
+    ".github/workflows/daily-test.yaml"
+  )
+  expect_true(isTRUE(triggers$has_schedule))
+  expect_false(isTRUE(triggers$dispatch_only))
+  expect_true(grepl("0 8", triggers$crons))
+})
+
+# ── Test 4: Ledger empty path ─────────────────────────────────────────────────
+
+test_that("read_run_metrics returns empty-marker df when ledger does not exist", {
+  result <- suppressMessages(
+    read_run_metrics(ledger = "/tmp/this_ledger_does_not_exist.duckdb")
+  )
+  # Should be a data.frame with an 'empty' column
+  expect_true(is.data.frame(result))
+  expect_true("empty" %in% names(result))
+})
+
+test_that("render_metrics_table emits placeholder when ledger is empty", {
+  render_fn <- get("render_metrics_table", envir = .agg_env)
+  empty_df <- data.frame(empty = TRUE, stringsAsFactors = FALSE)
+  output <- render_fn(empty_df)
+  expect_true(grepl("No run data yet", output))
+  expect_true(grepl("launchd_run_record", output))
+})
+
+# ── Test 5: Email dry-run has all 4 section QA markers ────────────────────────
+
+test_that("email dry-run output contains all 4 section QA markers", {
+  # Run the sender in dry-run mode, capturing stdout
+  sender_path <- file.path(scripts_dir, "send_launchd_health_email.R")
+  skip_if(!file.exists(sender_path), "send_launchd_health_email.R not found")
+  skip_if(!file.exists(aggregator_path), "launchd_health_report.R not found")
+
+  tmp_out <- tempfile(fileext = ".html")
+  on.exit(unlink(tmp_out), add = TRUE)
+
+  ret <- system2(
+    "Rscript",
+    c(sender_path),
+    env   = c(
+      "EMAIL_DRY_RUN=1",
+      sprintf("LAUNCHD_SCRIPTS_DIR=%s", scripts_dir),
+      # Point at a non-existent ledger so it gracefully gives placeholder
+      "LAUNCHD_LEDGER=/tmp/test_ledger_nonexistent.duckdb",
+      "CLOUD_REPOS=JohnGavin/llm,JohnGavin/llmtelemetry"
+    ),
+    stdout = tmp_out,
+    stderr = FALSE,
+    wait   = TRUE,
+    timeout = 120L
+  )
+
+  skip_if(ret != 0L, "dry-run returned non-zero — environment likely missing blastula/Rscript")
+  skip_if(!file.exists(tmp_out), "dry-run produced no output file")
+
+  content <- paste(readLines(tmp_out, warn = FALSE), collapse = " ")
+
+  expect_true(grepl("QA:section1=inventory", content),   label = "QA marker: section1")
+  expect_true(grepl("QA:section2=run_metrics", content), label = "QA marker: section2")
+  expect_true(grepl("QA:section3=suggestions", content), label = "QA marker: section3")
+  expect_true(grepl("QA:section4=cloud_crons", content), label = "QA marker: section4")
+})


### PR DESCRIPTION
## Summary

Closes #300. Implements the weekly scheduled-task health email (all 4 sections + ledger seed) under **Scope A**.

### Scope decision: Scope A (recommended)

Section 2 (per-job run metrics) is included with a graceful first-run placeholder. The `launchd_runs.duckdb` ledger starts empty and populates once plist commands are wrapped with `bin/launchd_run_record.sh`. Sections 1, 3, and 4 are fully live on day 1.

## Files

| File | Purpose |
|------|---------|
| `.claude/scripts/launchd_health_report.R` | Aggregator — sections 1-4, `--out PATH` / `--dry-run` |
| `.claude/scripts/send_launchd_health_email.R` | Blastula email sender, `EMAIL_DRY_RUN=1`, QA markers |
| `bin/launchd_run_record.sh` | Per-run wrapper: `<label> -- <cmd>`, captures peak RSS via `/usr/bin/time -l`, writes to `~/.claude/logs/launchd_runs.duckdb` |
| `bin/launchd_run_record_install.sh` | Read-only migration helper — prints suggested plist wrapping per `com.claude.*.plist`; never auto-edits |
| `bin/launchd_health_weekly_cron.sh` | Cron wrapper: generate → send → prune old reports |
| `.claude/launchd/com.claude.launchd-health-weekly.plist` | Sunday 09:00 launchd trigger (`plutil -lint` OK) |
| `tests/testthat/test-launchd-health-report.R` | 16 passing tests |
| `tests/fixtures/launchd/*.plist` / `*.yml` | 5 plist fixtures + dispatch-only YAML |

## Ledger growth plan

- Day 1: ledger empty; section 2 shows placeholder "No run data yet — wrap commands with `bin/launchd_run_record.sh`"
- After wrapping 1+ plists: first rows appear; section 2 shows real metrics
- Week 2+: duration trend (7d vs prior 7d) available; week-over-week >50% growth flagged
- Recommended migration order: 🔴 High tier first (self-review-stage1, unified-duckdb-backup, roborev-metrics-etl)
- Migration is optional and per-plist; run `bin/launchd_run_record_install.sh` to see suggested changes

## Smoke output (real LaunchAgents, 2026-05-29)

**Section 1 — Inventory (24 owned plists):**
- 🔴 High: 5 rows (roborev-metrics-etl 02:00, self-review-stage1 02:30, unified-duckdb-backup 03:00, codex-overnight-learning 06:10, self-review-verify 08:00)
- 🟠 Medium: 13 rows (config-pulse, knowledge-pulse, pr-status-pulse, roborev-* jobs, wiki-health-pulse, ccusage/codexbar/llmtelemetry refresh)
- 🟢 Low: 7 rows (roborev-agent-health 30m, signal-* 5m/10m, daemons: agentsview, signal-cli, jaeger, auto-refine)

**Section 2 — Run metrics:** `> No run data yet. Ledger populates over the next week.`

**Section 3 — Suggestions:** `Peak contention at 09:00: 4 jobs fire simultaneously (config-pulse, roborev-poll-merges, roborev-project-backlog, chrome-tab-backup). Consider staggering by 2–5 minutes.`

**Section 4 — Cloud crons (6 rows):**
- JohnGavin/llmtelemetry daily-report `0 8 * * *` scheduled
- JohnGavin/llmtelemetry hf-archive `30 7 * * *` scheduled
- JohnGavin/llmtelemetry self-review-email dispatch-only
- JohnGavin/llm quarto-publish dispatch-only
- JohnGavin/llm wiki-sync-check dispatch-only
- JohnGavin/llmtelemetry deploy-dashboard dispatch-only

## Tests

`[ FAIL 0 | WARN 0 | SKIP 1 | PASS 16 ]` for the new test file.
Full suite: `[ FAIL 2 | SKIP 11 | PASS 270 ]` — the 2 failures are pre-existing snapshot divergences in `test-cmonitor-integration.R` (unrelated to this PR); the skip is blastula not available in the Nix shell.

## Activation (after merge)

```bash
# Install the weekly plist
cp .claude/launchd/com.claude.launchd-health-weekly.plist ~/Library/LaunchAgents/
launchctl load ~/Library/LaunchAgents/com.claude.launchd-health-weekly.plist

# Test immediately (dry run)
EMAIL_DRY_RUN=1 Rscript .claude/scripts/send_launchd_health_email.R

# Optional: wrap a High-tier plist to start collecting metrics
# Review suggestions first:
bin/launchd_run_record_install.sh
# Then apply manually to one plist and reload it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)