### PR TITLE
feat(config-digest): daily config-change digest email (#297)

### DIFF
--- a/.claude/launchd/com.claude.config-digest-email.plist
+++ b/.claude/launchd/com.claude.config-digest-email.plist
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.claude.config-digest-email.plist
+     Daily config-change digest: git log → markdown → email.
+     Runs at 08:00 local time (same slot as the roborev daily email).
+
+     Install:
+       cp .claude/launchd/com.claude.config-digest-email.plist \
+          ~/Library/LaunchAgents/com.claude.config-digest-email.plist
+       launchctl load -w ~/Library/LaunchAgents/com.claude.config-digest-email.plist
+
+     Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.claude.config-digest-email.plist
+       rm ~/Library/LaunchAgents/com.claude.config-digest-email.plist
+
+     Manual dry-run:
+       EMAIL_DRY_RUN=1 bash ~/docs_gh/llm/bin/config_digest_cron.sh
+
+     Credentials: ~/.claude/env/roborev_email.env (shared with roborev email job)
+       GMAIL_USERNAME=you@gmail.com
+       GMAIL_APP_PASSWORD=<16-char app password>
+       REPORT_RECIPIENT=you@gmail.com
+
+     Tracked in llm#297.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.config-digest-email</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/config_digest_cron.sh</string>
+    </array>
+
+    <!-- Daily at 08:05 local time (5 min after roborev daily email slot) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>5</integer>
+    </dict>
+
+    <!-- Do NOT run immediately on launchctl load -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- PATH must include nix stable profile so nix-shell resolves -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+        <key>NIX_SSL_CERT_FILE</key>
+        <string>/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/config_digest_email_launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/config_digest_email_launchd.log</string>
+
+    <!-- Retry once after 60 s if job exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+</dict>
+</plist>

--- a/.claude/scripts/config_change_digest.R
+++ b/.claude/scripts/config_change_digest.R
@@ -1,0 +1,461 @@
+#!/usr/bin/env Rscript
+# config_change_digest.R — Aggregate git changes to meta-config categories into a
+# structured markdown digest.
+#
+# Usage:
+#   Rscript .claude/scripts/config_change_digest.R \
+#     [--since YYYY-MM-DDTHH:MM:SS] [--out PATH] [--dry-run]
+#
+# Defaults:
+#   --since   24 hours ago (ISO8601)
+#   --out     /tmp/config_change_digest_<date>.md
+#   --dry-run print digest to stdout only
+#
+# Category paths (relative to repo root):
+#   Skills    .claude/skills/**
+#   Agents    .claude/agents/**
+#   Rules     .claude/rules/**
+#   Memory    .claude/memory/**
+#   Hooks     .claude/hooks/**
+#   Scripts   .claude/scripts/**
+#   Templates .claude/templates/**
+#   Commands  .claude/commands/**
+#
+# Output: a structured markdown file consumed by send_config_digest_email.R.
+#
+# Tracked in llm#297.
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+args <- commandArgs(trailingOnly = TRUE)
+
+parse_args <- function(args) {
+  out <- list(
+    since   = format(Sys.time() - 86400, "%Y-%m-%dT%H:%M:%S"),
+    out     = file.path(tempdir(), sprintf("config_change_digest_%s.md", format(Sys.Date()))),
+    dry_run = FALSE
+  )
+  i <- 1L
+  while (i <= length(args)) {
+    if (args[i] == "--since" && i + 1L <= length(args)) {
+      out$since <- args[i + 1L]; i <- i + 2L
+    } else if (args[i] == "--out" && i + 1L <= length(args)) {
+      out$out <- args[i + 1L]; i <- i + 2L
+    } else if (args[i] == "--dry-run") {
+      out$dry_run <- TRUE; i <- i + 1L
+    } else {
+      i <- i + 1L
+    }
+  }
+  out
+}
+
+cfg <- parse_args(args)
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+
+find_repo_root <- function() {
+  # Env override: allows tests to point at a synthetic fixture repo.
+  env_root <- Sys.getenv("LLM_REPO_ROOT", unset = "")
+  if (nzchar(env_root) && file.exists(file.path(env_root, ".git"))) {
+    return(normalizePath(env_root))
+  }
+  # Walk up from script location or working directory
+  start <- tryCatch(
+    dirname(normalizePath(sys.frame(0)$ofile, mustWork = FALSE)),
+    error = function(e) getwd()
+  )
+  path <- start
+  for (i in seq_len(10L)) {
+    if (file.exists(file.path(path, ".git"))) return(path)
+    parent <- dirname(path)
+    if (parent == path) break
+    path <- parent
+  }
+  # Final fallback: cwd
+  getwd()
+}
+
+REPO_ROOT <- find_repo_root()
+
+# ── Category definitions ──────────────────────────────────────────────────────
+
+CATEGORIES <- list(
+  list(name = "Skills",    path = ".claude/skills",    exclude = c(".system", "generated")),
+  list(name = "Agents",    path = ".claude/agents",    exclude = character(0)),
+  list(name = "Rules",     path = ".claude/rules",     exclude = character(0)),
+  list(name = "Memory",    path = ".claude/memory",    exclude = character(0)),
+  list(name = "Hooks",     path = ".claude/hooks",     exclude = character(0)),
+  list(name = "Scripts",   path = ".claude/scripts",   exclude = character(0)),
+  list(name = "Templates", path = ".claude/templates", exclude = character(0)),
+  list(name = "Commands",  path = ".claude/commands",  exclude = character(0))
+)
+
+# ── Git helpers ───────────────────────────────────────────────────────────────
+
+run_git <- function(...) {
+  result <- system2("git", args = c("-C", REPO_ROOT, ...),
+                    stdout = TRUE, stderr = FALSE)
+  result
+}
+
+git_log_numstat <- function(since, path_prefix) {
+  # Returns character vector of lines from git log --numstat.
+  # Use --pretty=tformat: to avoid system2 shell-interpolation of % tokens.
+  # Separator is UNIT SEPARATOR (ASCII 31) converted to | in post-process.
+  fmt <- paste0("COMMIT:", "%H", "\x1f", "%s", "\x1f", "%ae", "\x1f", "%ad")
+  run_git("log", "--numstat",
+          paste0("--pretty=tformat:", fmt),
+          "--date=iso-strict",
+          paste0("--since=", since),
+          "--", path_prefix)
+}
+
+git_log_commits <- function(since) {
+  # Returns all commits in window: hash\x1fsubject
+  fmt <- paste0("%H", "\x1f", "%s")
+  lines <- run_git("log",
+                   paste0("--pretty=tformat:", fmt),
+                   "--no-merges",
+                   paste0("--since=", since))
+  lines
+}
+
+parse_conv_scope <- function(subject) {
+  # Extract scope from conventional commit: "type(scope): msg" -> "scope"
+  m <- regmatches(subject, regexpr("\\(([^)]+)\\)", subject))
+  if (length(m) == 0L || !nzchar(m)) return(NA_character_)
+  gsub("[()]", "", m)
+}
+
+parse_conv_type <- function(subject) {
+  m <- regmatches(subject, regexpr("^([a-z]+)(?:\\([^)]*\\))?:", subject, perl = TRUE))
+  if (length(m) == 0L || !nzchar(m)) return(NA_character_)
+  gsub(":.*$", "", gsub("\\([^)]*\\)", "", m))
+}
+
+# ── Per-category stats ────────────────────────────────────────────────────────
+
+compute_category_stats <- function(cat_def, since) {
+  path  <- cat_def$path
+  excl  <- cat_def$exclude
+
+  lines <- git_log_numstat(since, path)
+  if (length(lines) == 0L) {
+    return(list(
+      name = cat_def$name, path = path,
+      n_commits = 0L, n_added = 0L, n_deleted = 0L,
+      files_changed = character(0), commits = list()
+    ))
+  }
+
+  # Parse numstat output
+  # Format alternates: COMMIT:<hash>|<subject>|<author>|<date>
+  #                    <added>\t<deleted>\t<file>
+  current_commit <- NULL
+  commits <- list()
+  files_changed <- character(0)
+  total_added <- 0L
+  total_deleted <- 0L
+
+  for (line in lines) {
+    if (startsWith(line, "COMMIT:")) {
+      parts <- strsplit(sub("^COMMIT:", "", line), "\x1f", fixed = TRUE)[[1]]
+      current_commit <- list(
+        hash    = if (length(parts) >= 1L) parts[[1L]] else "",
+        subject = if (length(parts) >= 2L) parts[[2L]] else "",
+        author  = if (length(parts) >= 3L) parts[[3L]] else "",
+        date    = if (length(parts) >= 4L) parts[[4L]] else ""
+      )
+      commits[[length(commits) + 1L]] <- current_commit
+    } else if (grepl("^\t", line) || grepl("^[0-9-]", line)) {
+      # numstat line: added\tdeleted\tfile
+      parts <- strsplit(trimws(line), "\t")[[1]]
+      if (length(parts) < 3L) next
+      # Filter excluded subdirectories
+      file_path <- parts[[3L]]
+      if (length(excl) > 0L) {
+        skip <- any(sapply(excl, function(ex) grepl(ex, file_path, fixed = TRUE)))
+        if (skip) next
+      }
+      added   <- suppressWarnings(as.integer(parts[[1L]]))
+      deleted <- suppressWarnings(as.integer(parts[[2L]]))
+      if (!is.na(added))   total_added   <- total_added   + added
+      if (!is.na(deleted)) total_deleted <- total_deleted + deleted
+      files_changed <- unique(c(files_changed, file_path))
+    }
+  }
+
+  list(
+    name          = cat_def$name,
+    path          = path,
+    n_commits     = length(commits),
+    n_added       = total_added,
+    n_deleted     = total_deleted,
+    files_changed = files_changed,
+    commits       = commits
+  )
+}
+
+# ── Theme clustering ──────────────────────────────────────────────────────────
+
+cluster_themes <- function(commit_lines, top_n = 5L) {
+  # commit_lines: "hash|subject" format from git_log_commits()
+  if (length(commit_lines) == 0L) return(list())
+
+  parsed <- lapply(commit_lines, function(l) {
+    parts   <- strsplit(l, "\x1f", fixed = TRUE)[[1L]]
+    hash    <- if (length(parts) >= 1L) parts[[1L]] else ""
+    subject <- if (length(parts) >= 2L) paste(parts[-1L], collapse = " ") else ""
+    scope   <- parse_conv_scope(subject)
+    type    <- parse_conv_type(subject)
+    list(hash = hash, subject = subject, scope = scope, type = type)
+  })
+
+  # Group by scope (fall back to type if no scope)
+  theme_key <- function(p) {
+    if (!is.na(p$scope) && nzchar(p$scope)) return(p$scope)
+    if (!is.na(p$type)  && nzchar(p$type))  return(p$type)
+    "other"
+  }
+
+  themes <- list()
+  for (p in parsed) {
+    k <- theme_key(p)
+    if (is.null(themes[[k]])) themes[[k]] <- list(commits = list(), n = 0L)
+    themes[[k]]$commits <- c(themes[[k]]$commits, list(p))
+    themes[[k]]$n       <- themes[[k]]$n + 1L
+  }
+
+  # Sort by count descending; return top N
+  counts <- sapply(themes, function(t) t$n)
+  themes_sorted <- themes[order(counts, decreasing = TRUE)]
+  head(themes_sorted, top_n)
+}
+
+# ── Lessons-learnt extraction ─────────────────────────────────────────────────
+
+extract_lessons <- function(since, changelog_path = NULL) {
+  lessons <- list()
+
+  # 1. fix:/revert: commits
+  fix_fmt     <- paste0("%H", "\x1f", "%s")
+  fix_commits <- run_git("log",
+    paste0("--pretty=tformat:", fix_fmt),
+    "--no-merges",
+    paste0("--since=", since))
+
+  for (line in fix_commits) {
+    parts   <- strsplit(line, "\x1f", fixed = TRUE)[[1L]]
+    subject <- if (length(parts) >= 2L) paste(parts[-1L], collapse = " ") else ""
+    type    <- parse_conv_type(subject)
+    if (!is.na(type) && type %in% c("fix", "revert")) {
+      short_hash <- if (length(parts) >= 1L) substr(parts[[1L]], 1L, 7L) else ""
+      lessons[[length(lessons) + 1L]] <- list(
+        type    = type,
+        subject = subject,
+        hash    = short_hash,
+        source  = "commit"
+      )
+    }
+  }
+
+  # 2. CHANGELOG.md "Failed approaches" section within window
+  if (is.null(changelog_path)) {
+    changelog_path <- file.path(REPO_ROOT, "CHANGELOG.md")
+  }
+  if (file.exists(changelog_path)) {
+    cl_lines <- readLines(changelog_path, warn = FALSE)
+    # Find sections matching the since window: look for ## <date> headings
+    since_date <- tryCatch(
+      as.Date(substr(since, 1L, 10L)),
+      error = function(e) Sys.Date() - 1L
+    )
+    in_window_section  <- FALSE
+    in_failed_section  <- FALSE
+    failed_bullets     <- character(0)
+
+    for (l in cl_lines) {
+      # Check for date heading
+      if (grepl("^## \\d{4}-\\d{2}-\\d{2}", l)) {
+        date_str <- regmatches(l, regexpr("\\d{4}-\\d{2}-\\d{2}", l))
+        if (length(date_str) > 0L) {
+          section_date <- tryCatch(as.Date(date_str), error = function(e) NA)
+          if (!is.na(section_date) && section_date >= since_date) {
+            in_window_section <- TRUE
+          } else {
+            in_window_section <- FALSE
+          }
+        }
+        in_failed_section <- FALSE
+      } else if (in_window_section && grepl("^###.*[Ff]ailed", l)) {
+        in_failed_section <- TRUE
+      } else if (in_window_section && grepl("^###", l)) {
+        in_failed_section <- FALSE
+      } else if (in_failed_section && grepl("^-", l)) {
+        failed_bullets <- c(failed_bullets, trimws(sub("^-+\\s*", "", l)))
+      }
+    }
+
+    if (length(failed_bullets) > 0L) {
+      for (b in head(failed_bullets, 5L)) {
+        lessons[[length(lessons) + 1L]] <- list(
+          type    = "changelog-failed",
+          subject = b,
+          hash    = "",
+          source  = "CHANGELOG"
+        )
+      }
+    }
+  }
+
+  lessons
+}
+
+# ── Markdown rendering ────────────────────────────────────────────────────────
+
+render_markdown <- function(cat_stats, themes, lessons, since, generated_at) {
+  lines <- character(0)
+  emit  <- function(...) lines <<- c(lines, sprintf(...))
+
+  emit("# Config-Change Digest — %s", format(as.Date(substr(since, 1L, 10L)) + 1L))
+  emit("")
+  emit("**Window:** since `%s` | **Generated:** `%s` UTC", since, generated_at)
+  emit("")
+  emit("---")
+  emit("")
+
+  # ── Section 1: Category summary table ──────────────────────────────────────
+  emit("## Changes by Category")
+  emit("")
+  emit("| Category | Files changed | Lines added | Lines deleted |")
+  emit("|----------|:-------------:|:-----------:|:-------------:|")
+
+  total_files   <- 0L
+  total_added   <- 0L
+  total_deleted <- 0L
+
+  for (s in cat_stats) {
+    n_files <- length(s$files_changed)
+    total_files   <- total_files   + n_files
+    total_added   <- total_added   + s$n_added
+    total_deleted <- total_deleted + s$n_deleted
+    if (n_files == 0L && s$n_added == 0L && s$n_deleted == 0L) next
+    emit("| %s | %d | +%d | -%d |",
+         s$name, n_files, s$n_added, s$n_deleted)
+  }
+
+  emit("| **Total** | **%d** | **+%d** | **-%d** |",
+       total_files, total_added, total_deleted)
+  emit("")
+
+  # ── Section 2: Themes today ────────────────────────────────────────────────
+  emit("## Themes Today")
+  emit("")
+
+  if (length(themes) == 0L) {
+    emit("_No commits in window._")
+  } else {
+    for (theme_name in names(themes)) {
+      t <- themes[[theme_name]]
+      emit("### `%s` (%d commit%s)", theme_name, t$n, if (t$n == 1L) "" else "s")
+      emit("")
+      for (c in head(t$commits, 3L)) {
+        short_hash <- substr(c$hash, 1L, 7L)
+        emit("- `%s` %s", short_hash, c$subject)
+      }
+      if (t$n > 3L) emit("- _(+%d more)_", t$n - 3L)
+      emit("")
+    }
+  }
+
+  emit("---")
+  emit("")
+
+  # ── Section 3: Lessons learnt ──────────────────────────────────────────────
+  emit("## Lessons Learnt")
+  emit("")
+
+  fix_lessons <- Filter(function(l) l$source == "commit", lessons)
+  cl_lessons  <- Filter(function(l) l$source == "CHANGELOG", lessons)
+
+  if (length(fix_lessons) == 0L && length(cl_lessons) == 0L) {
+    emit("_No fix/revert commits or CHANGELOG failed-approach entries in window._")
+  } else {
+    if (length(fix_lessons) > 0L) {
+      emit("### From fix/revert commits")
+      emit("")
+      for (l in fix_lessons) {
+        emit("- **[%s]** `%s` %s", toupper(l$type), l$hash, l$subject)
+      }
+      emit("")
+    }
+    if (length(cl_lessons) > 0L) {
+      emit("### From CHANGELOG (failed approaches)")
+      emit("")
+      for (l in cl_lessons) {
+        emit("- %s", l$subject)
+      }
+      emit("")
+    }
+  }
+
+  emit("---")
+  emit("")
+  emit("<!-- QA:config_digest_generated=%s -->"  , generated_at)
+  emit("<!-- QA:config_digest_since=%s -->"       , since)
+  emit("<!-- QA:config_digest_total_files=%d -->" , total_files)
+  emit("<!-- QA:config_digest_total_added=%d -->" , total_added)
+  emit("<!-- QA:config_digest_total_deleted=%d -->", total_deleted)
+  emit("<!-- QA:config_digest_n_themes=%d -->"    , length(themes))
+  emit("<!-- QA:config_digest_n_lessons=%d -->"   , length(lessons))
+
+  paste(lines, collapse = "\n")
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+main <- function() {
+  since        <- cfg$since
+  out_path     <- cfg$out
+  dry_run      <- cfg$dry_run
+  generated_at <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+
+  message(sprintf("config_change_digest.R: repo=%s since=%s", REPO_ROOT, since))
+
+  # Per-category stats
+  cat_stats <- lapply(CATEGORIES, compute_category_stats, since = since)
+
+  # Theme clustering (all commits in window, not scoped to category)
+  commit_lines <- git_log_commits(since)
+  themes <- cluster_themes(commit_lines, top_n = 5L)
+
+  # Lessons learnt
+  lessons <- extract_lessons(since)
+
+  # Render
+  digest <- render_markdown(cat_stats, themes, lessons, since, generated_at)
+
+  # Summary to stderr for callers
+  total_files   <- sum(sapply(cat_stats, function(s) length(s$files_changed)))
+  total_added   <- sum(sapply(cat_stats, function(s) s$n_added))
+  total_deleted <- sum(sapply(cat_stats, function(s) s$n_deleted))
+  message(sprintf(
+    "config_change_digest.R: %d files changed | +%d/-%d lines | %d themes | %d lessons",
+    total_files, total_added, total_deleted, length(themes), length(lessons)
+  ))
+
+  if (dry_run) {
+    message("config_change_digest.R: --dry-run — printing to stdout")
+    cat(digest, "\n")
+    message("config_change_digest.R: dry-run complete")
+    return(invisible(NULL))
+  }
+
+  dir.create(dirname(out_path), showWarnings = FALSE, recursive = TRUE)
+  writeLines(digest, out_path)
+  message(sprintf("config_change_digest.R: written to %s", out_path))
+  invisible(out_path)
+}
+
+main()

--- a/.claude/scripts/send_config_digest_email.R
+++ b/.claude/scripts/send_config_digest_email.R
@@ -1,0 +1,399 @@
+#!/usr/bin/env Rscript
+# send_config_digest_email.R — Send daily config-change digest email via Gmail.
+#
+# Reads the markdown digest produced by config_change_digest.R (or generates it
+# on the fly if CONFIG_DIGEST_PATH is not set) and sends an HTML email via blastula.
+#
+# Required env vars:
+#   GMAIL_USERNAME       Gmail address (sender + credential lookup)
+#   GMAIL_APP_PASSWORD   Gmail app password
+#   REPORT_RECIPIENT     Recipient address (falls back to GMAIL_USERNAME)
+#
+# Optional env vars:
+#   CONFIG_DIGEST_PATH   Pre-computed markdown digest (skips aggregator call)
+#   CONFIG_DIGEST_SINCE  ISO8601 --since arg passed to aggregator (default: 24h ago)
+#   EMAIL_DRY_RUN        Set to "1" to print body to stdout without sending
+#   LLM_REPO_ROOT        Repo root (auto-detected if absent)
+#
+# Usage:
+#   Rscript .claude/scripts/send_config_digest_email.R
+#   EMAIL_DRY_RUN=1 Rscript .claude/scripts/send_config_digest_email.R
+#
+# Called from bin/config_digest_cron.sh (Path b) or standalone.
+# Tracked in llm#297.
+
+suppressPackageStartupMessages({
+  library(blastula)
+})
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+dry_run <- identical(Sys.getenv("EMAIL_DRY_RUN"), "1")
+
+config_digest_path  <- Sys.getenv("CONFIG_DIGEST_PATH", "")
+config_digest_since <- Sys.getenv(
+  "CONFIG_DIGEST_SINCE",
+  format(Sys.time() - 86400, "%Y-%m-%dT%H:%M:%S")
+)
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+
+find_repo_root <- function() {
+  env_root <- Sys.getenv("LLM_REPO_ROOT", "")
+  if (nzchar(env_root) && dir.exists(env_root)) return(env_root)
+  # Walk up from script location
+  start <- tryCatch(
+    dirname(normalizePath(sys.frame(0)$ofile, mustWork = FALSE)),
+    error = function(e) getwd()
+  )
+  path <- start
+  for (i in seq_len(12L)) {
+    if (file.exists(file.path(path, ".git"))) return(path)
+    parent <- dirname(path)
+    if (parent == path) break
+    path <- parent
+  }
+  getwd()
+}
+
+REPO_ROOT <- find_repo_root()
+
+# ── Generate digest if not pre-computed ───────────────────────────────────────
+
+if (!nzchar(config_digest_path) || !file.exists(config_digest_path)) {
+  aggregator <- file.path(REPO_ROOT, ".claude", "scripts", "config_change_digest.R")
+  if (!file.exists(aggregator)) {
+    message("send_config_digest_email.R: aggregator not found at ", aggregator)
+    quit(status = 1L)
+  }
+  config_digest_path <- file.path(
+    tempdir(),
+    sprintf("config_digest_%s.md", format(Sys.Date()))
+  )
+  message(sprintf(
+    "send_config_digest_email.R: generating digest (since=%s) ...",
+    config_digest_since
+  ))
+  ret <- system2("Rscript", args = c(
+    aggregator,
+    "--since", config_digest_since,
+    "--out",   config_digest_path
+  ), stdout = FALSE, stderr = TRUE)
+  if (!file.exists(config_digest_path)) {
+    message("send_config_digest_email.R: aggregator did not produce output at ",
+            config_digest_path)
+    quit(status = 1L)
+  }
+}
+
+message(sprintf("send_config_digest_email.R: reading digest %s", config_digest_path))
+digest_md <- paste(readLines(config_digest_path, warn = FALSE), collapse = "\n")
+
+# ── Extract QA markers from digest ────────────────────────────────────────────
+
+qa_val <- function(key, text) {
+  m <- regmatches(text,
+    regexpr(sprintf("<!-- QA:%s=([^-]+) -->", key), text, perl = TRUE))
+  if (length(m) == 0L || !nzchar(m)) return(NA_character_)
+  sub(sprintf("<!-- QA:%s=", key), "", sub(" -->$", "", m))
+}
+
+generated_at  <- qa_val("config_digest_generated", digest_md)
+since_label   <- qa_val("config_digest_since",     digest_md)
+total_files   <- qa_val("config_digest_total_files",   digest_md)
+total_added   <- qa_val("config_digest_total_added",   digest_md)
+total_deleted <- qa_val("config_digest_total_deleted", digest_md)
+n_themes      <- qa_val("config_digest_n_themes",  digest_md)
+n_lessons     <- qa_val("config_digest_n_lessons", digest_md)
+
+if (is.na(generated_at)) generated_at <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+if (is.na(since_label))  since_label  <- config_digest_since
+
+report_date <- format(Sys.Date())
+
+# ── Colour palette (dark-mode safe; matches llmtelemetry convention) ──────────
+
+dark_bg       <- "#1a1a2e"
+dark_card     <- "#16213e"
+dark_row_alt  <- "#0f3460"
+dark_text     <- "#e8e8e8"
+dark_muted    <- "#a0a0a0"
+dark_border   <- "#2a2a4a"
+accent_green  <- "#00d26a"
+accent_blue   <- "#4fc3f7"
+accent_orange <- "#ff9800"
+accent_purple <- "#bb86fc"
+
+# ── Build email sections from markdown ────────────────────────────────────────
+
+# Strip QA comment lines from rendered prose
+clean_md <- gsub("<!-- QA:[^>]+ -->", "", digest_md)
+
+# Convert markdown headings and bullets to basic HTML
+md_to_html <- function(txt) {
+  lines <- strsplit(txt, "\n", fixed = TRUE)[[1L]]
+  out   <- character(length(lines))
+  for (i in seq_along(lines)) {
+    l <- lines[i]
+    if (grepl("^## ", l)) {
+      out[i] <- sprintf(
+        '<h2 style="color:%s; margin-top:20px; margin-bottom:6px;">%s</h2>',
+        accent_orange, htmlify(sub("^## ", "", l))
+      )
+    } else if (grepl("^### ", l)) {
+      out[i] <- sprintf(
+        '<h3 style="color:%s; margin-top:14px; margin-bottom:4px;">%s</h3>',
+        accent_blue, htmlify(sub("^### ", "", l))
+      )
+    } else if (grepl("^\\|", l) && grepl("\\|", l)) {
+      # Table row — pass through
+      out[i] <- render_table_row(l)
+    } else if (grepl("^- ", l)) {
+      out[i] <- sprintf(
+        '<li style="color:%s; margin-bottom:3px;">%s</li>',
+        dark_text, inline_code_html(htmlify(sub("^- +", "", l)))
+      )
+    } else if (grepl("^---$", l)) {
+      out[i] <- sprintf('<hr style="border-color:%s; margin:12px 0;">', dark_border)
+    } else if (nzchar(trimws(l))) {
+      out[i] <- sprintf('<p style="color:%s; margin:4px 0;">%s</p>',
+                        dark_text, inline_code_html(htmlify(l)))
+    } else {
+      out[i] <- ""
+    }
+  }
+  paste(out, collapse = "\n")
+}
+
+htmlify <- function(txt) {
+  # Minimal HTML escaping
+  txt <- gsub("&", "&amp;", txt, fixed = TRUE)
+  txt <- gsub("<", "&lt;",  txt, fixed = TRUE)
+  txt <- gsub(">", "&gt;",  txt, fixed = TRUE)
+  txt
+}
+
+inline_code_html <- function(txt) {
+  # Replace `code` spans with styled <code> elements
+  gsub("`([^`]+)`",
+       sprintf('<code style="background:%s; color:%s; padding:1px 3px; border-radius:3px;">\\1</code>',
+               dark_row_alt, accent_green),
+       txt, perl = TRUE)
+}
+
+# Table state tracking
+in_table      <- FALSE
+table_header  <- TRUE
+table_html    <- character(0)
+
+render_table_row <- function(l) {
+  # Skip divider rows like |---|---|
+  if (grepl("^\\|[-: |]+\\|$", l)) return("")
+  cells <- strsplit(trimws(l), "\\s*\\|\\s*")[[1L]]
+  cells <- cells[nzchar(cells)]
+  if (length(cells) == 0L) return("")
+  if (cells[1L] == "Category" || cells[1L] == "Metric") {
+    # Header row
+    paste0(
+      sprintf('<tr style="background:%s;">', dark_row_alt),
+      paste(sprintf(
+        '<th style="padding:5px 8px; border:1px solid %s; color:white; text-align:left;">%s</th>',
+        dark_border, htmlify(cells)
+      ), collapse = ""),
+      "</tr>"
+    )
+  } else {
+    paste0(
+      sprintf('<tr style="background:%s;">', dark_card),
+      paste(sprintf(
+        '<td style="padding:4px 8px; border:1px solid %s; color:%s;">%s</td>',
+        dark_border, dark_text, inline_code_html(htmlify(cells))
+      ), collapse = ""),
+      "</tr>"
+    )
+  }
+}
+
+# ── Wrap table rows ────────────────────────────────────────────────────────────
+
+wrap_tables <- function(html_lines) {
+  # Group consecutive <tr> elements into <table>
+  result    <- character(0)
+  in_t      <- FALSE
+  buf       <- character(0)
+
+  for (l in strsplit(html_lines, "\n", fixed = TRUE)[[1L]]) {
+    if (grepl("^<tr ", l) || grepl("^<th ", l)) {
+      if (!in_t) {
+        result <- c(result, sprintf(
+          '<table style="border-collapse:collapse; width:100%%; font-size:12px; margin:8px 0;">'
+        ))
+        in_t <- TRUE
+      }
+      result <- c(result, l)
+    } else {
+      if (in_t) {
+        result <- c(result, "</table>")
+        in_t   <- FALSE
+      }
+      result <- c(result, l)
+    }
+  }
+  if (in_t) result <- c(result, "</table>")
+  paste(result, collapse = "\n")
+}
+
+# ── Headline summary table (two-column Metric | Value) ─────────────────────────
+
+headline_rows <- list(
+  c("Files changed",   if (!is.na(total_files))   total_files   else "—"),
+  c("Lines added",     if (!is.na(total_added))    paste0("+", total_added) else "—"),
+  c("Lines deleted",   if (!is.na(total_deleted))  paste0("-", total_deleted) else "—"),
+  c("Themes clustered",if (!is.na(n_themes))       n_themes      else "—"),
+  c("Lessons found",   if (!is.na(n_lessons))      n_lessons     else "—")
+)
+
+headline_html <- sprintf(
+  '<h3 style="color:%s; margin-top:20px;">At a Glance (last 24h)</h3>
+<table style="border-collapse:collapse; width:100%%; font-size:12px;">
+  <tr style="background-color:%s;">
+    <th style="padding:6px 8px; border:1px solid %s; color:white; text-align:left;">Metric</th>
+    <th style="padding:6px 8px; border:1px solid %s; color:white; text-align:right;">Value</th>
+  </tr>',
+  accent_orange, dark_row_alt, dark_border, dark_border
+)
+
+for (i in seq_along(headline_rows)) {
+  bg <- if (i %% 2L == 0L) dark_row_alt else dark_card
+  headline_html <- paste0(headline_html, sprintf(
+    '<tr style="background-color:%s;">
+      <td style="padding:5px 8px; border:1px solid %s; color:%s;">%s</td>
+      <td style="padding:5px 8px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+    </tr>',
+    bg,
+    dark_border, dark_text,   headline_rows[[i]][1L],
+    dark_border, accent_green, headline_rows[[i]][2L]
+  ))
+}
+headline_html <- paste0(headline_html, "</table>")
+
+# ── Digest body (converted markdown) ──────────────────────────────────────────
+
+digest_html_raw <- md_to_html(clean_md)
+digest_html     <- wrap_tables(digest_html_raw)
+
+# ── GH commit link ─────────────────────────────────────────────────────────────
+
+gh_commits_url <- sprintf(
+  "https://github.com/JohnGavin/llm/commits/main?since=%s",
+  URLencode(since_label, reserved = TRUE)
+)
+
+commits_link_html <- sprintf(
+  '<div style="margin:12px 0;">
+  <a href="%s"
+     style="display:inline-block; padding:8px 16px; background-color:%s;
+            color:#1a1a2e; text-decoration:none; border-radius:4px;
+            font-weight:bold; font-size:12px;">
+    View Commits on GitHub
+  </a>
+</div>',
+  gh_commits_url, accent_blue
+)
+
+# ── QA markers ────────────────────────────────────────────────────────────────
+
+qa_markers <- sprintf(
+  '<!-- QA:email_report_date=%s --><!-- QA:email_total_files=%s --><!-- QA:email_n_themes=%s --><!-- QA:email_n_lessons=%s --><!-- QA:config_digest_section=present -->',
+  report_date,
+  if (!is.na(total_files)) total_files else "0",
+  if (!is.na(n_themes))    n_themes    else "0",
+  if (!is.na(n_lessons))   n_lessons   else "0"
+)
+
+# ── Assemble full body ─────────────────────────────────────────────────────────
+
+email_body <- sprintf(
+  '<div style="background-color:%s; color:%s; padding:20px;
+               font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">
+<h2 style="color:%s; margin-bottom:4px;">Config-Change Digest — %s</h2>
+<p style="color:%s; font-size:11px; margin-top:0;">
+  Generated: %s UTC &nbsp;|&nbsp; Window: since %s
+</p>
+%s
+%s
+%s
+<p style="color:%s; font-size:10px; margin-top:20px;">
+  Digest file: %s
+</p>
+%s
+</div>',
+  dark_bg, dark_text,
+  accent_orange, report_date,
+  dark_muted, generated_at, since_label,
+  commits_link_html,
+  headline_html,
+  digest_html,
+  dark_muted, config_digest_path,
+  qa_markers
+)
+
+# ── Dry-run ────────────────────────────────────────────────────────────────────
+
+if (dry_run) {
+  message("send_config_digest_email.R: EMAIL_DRY_RUN=1 — printing body to stdout")
+  cat(email_body, "\n")
+  message("send_config_digest_email.R: dry-run complete (not sent)")
+  quit(status = 0L)
+}
+
+# ── Credentials ────────────────────────────────────────────────────────────────
+
+gmail_user <- Sys.getenv("GMAIL_USERNAME", "")
+gmail_pass <- Sys.getenv("GMAIL_APP_PASSWORD", "")
+
+if (!nzchar(gmail_user) || !nzchar(gmail_pass)) {
+  message("send_config_digest_email.R: GMAIL_USERNAME or GMAIL_APP_PASSWORD not set")
+  cat("\n--- Email body (credentials missing, not sent) ---\n")
+  cat(email_body, "\n")
+  quit(status = 1L)
+}
+
+report_to <- Sys.getenv("REPORT_RECIPIENT", "")
+if (!nzchar(report_to)) report_to <- gmail_user
+
+# ── Compose and send ───────────────────────────────────────────────────────────
+
+london_time <- format(Sys.time(), tz = "Europe/London", "%Y-%m-%d %H:%M")
+
+email <- compose_email(
+  body   = md(email_body),
+  footer = md(sprintf(
+    "<span style='color:%s;'>Sent: %s (London)</span>",
+    dark_muted, london_time
+  ))
+)
+
+smtp_creds <- creds_envvar(
+  user        = gmail_user,
+  pass_envvar = "GMAIL_APP_PASSWORD",
+  host        = "smtp.gmail.com",
+  port        = 465L,
+  use_ssl     = TRUE
+)
+
+tryCatch({
+  smtp_send(
+    email       = email,
+    to          = report_to,
+    from        = gmail_user,
+    subject     = sprintf("Config-Change Digest — %s", report_date),
+    credentials = smtp_creds
+  )
+  message(sprintf("send_config_digest_email.R: email sent to %s", report_to))
+}, error = function(e) {
+  message("send_config_digest_email.R: SMTP send failed — ", conditionMessage(e))
+  cat("\n--- Email body (SMTP failed) ---\n")
+  cat(email_body, "\n")
+  quit(status = 1L)
+})

--- a/bin/config_digest_cron.sh
+++ b/bin/config_digest_cron.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# config_digest_cron.sh — Wrapper for daily config-change digest email.
+#
+# Steps:
+#   1. Generate markdown digest:
+#      Rscript .claude/scripts/config_change_digest.R --since <24h-ago>
+#   2. Send digest email:
+#      Rscript .claude/scripts/send_config_digest_email.R
+#
+# All R calls wrapped in nix-shell per nix-agent-shell-protocol rule.
+# Dry-run mode (EMAIL_DRY_RUN=1) passes through to child scripts.
+#
+# Env vars sourced from ~/.claude/env/roborev_email.env if it exists:
+#   GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT
+#
+# Log: ~/.claude/logs/config_digest_email.log
+#
+# Install plist:
+#   cp .claude/launchd/com.claude.config-digest-email.plist \
+#      ~/Library/LaunchAgents/com.claude.config-digest-email.plist
+#   launchctl load -w ~/Library/LaunchAgents/com.claude.config-digest-email.plist
+#
+# Manual run (dry):
+#   EMAIL_DRY_RUN=1 bash bin/config_digest_cron.sh
+#
+# Tracked in llm#297.
+
+set -uo pipefail
+
+# ── PATH (launchd runs with a bare PATH) ──────────────────────────────────────
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# ── Recursion guard ───────────────────────────────────────────────────────────
+: "${CONFIG_DIGEST_DEPTH:=0}"
+if (( CONFIG_DIGEST_DEPTH > 0 )); then
+  echo "[config_digest_cron] ERROR: recursion detected (depth=${CONFIG_DIGEST_DEPTH}). Abort." >&2
+  exit 1
+fi
+export CONFIG_DIGEST_DEPTH=$(( CONFIG_DIGEST_DEPTH + 1 ))
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LLM_NIX="${REPO_ROOT}/default.nix"
+LOG_FILE="${HOME}/.claude/logs/config_digest_email.log"
+ENV_FILE="${HOME}/.claude/env/roborev_email.env"
+LOCK_FILE="/tmp/config_digest_cron.lock"
+DIGEST_PATH="${HOME}/.claude/logs/config_digest_$(date +%Y-%m-%d).md"
+
+EMAIL_DRY_RUN="${EMAIL_DRY_RUN:-0}"
+export EMAIL_DRY_RUN LLM_REPO_ROOT="${REPO_ROOT}"
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+mkdir -p "$(dirname "${LOG_FILE}")"
+
+log() {
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  printf '%s: %s\n' "${ts}" "$1" | tee -a "${LOG_FILE}"
+}
+
+log "=== config_digest_cron.sh starting (EMAIL_DRY_RUN=${EMAIL_DRY_RUN}) ==="
+
+# ── Lock ──────────────────────────────────────────────────────────────────────
+if [ -f "${LOCK_FILE}" ]; then
+  existing_pid="$(cat "${LOCK_FILE}" 2>/dev/null || true)"
+  if [ -n "${existing_pid}" ] && kill -0 "${existing_pid}" 2>/dev/null; then
+    log "SKIP: another instance running (PID ${existing_pid})"
+    exit 0
+  fi
+fi
+printf '%d' "$$" > "${LOCK_FILE}"
+trap 'rm -f "${LOCK_FILE}"' EXIT
+
+# ── Load credentials ──────────────────────────────────────────────────────────
+if [ -f "${ENV_FILE}" ]; then
+  log "Loading env from ${ENV_FILE}"
+  set -a
+  while IFS='=' read -r key val; do
+    [[ "${key}" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${key}" ]] && continue
+    export "${key}=${val}"
+  done < "${ENV_FILE}"
+  set +a
+else
+  log "INFO: ${ENV_FILE} not found — relying on existing environment"
+fi
+
+# ── Check nix ────────────────────────────────────────────────────────────────
+if [ ! -f "${LLM_NIX}" ]; then
+  log "ERROR: nix file not found at ${LLM_NIX}"
+  exit 1
+fi
+if ! command -v nix-shell > /dev/null 2>&1; then
+  log "ERROR: nix-shell not on PATH (${PATH})"
+  exit 1
+fi
+
+# ── Step 1: Generate digest ───────────────────────────────────────────────────
+log "Step 1: generating config-change digest..."
+
+AGGREGATOR="${REPO_ROOT}/.claude/scripts/config_change_digest.R"
+if [ ! -f "${AGGREGATOR}" ]; then
+  log "ERROR: config_change_digest.R not found at ${AGGREGATOR}"
+  exit 1
+fi
+
+SINCE="$(date -v -24H '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || date -d '24 hours ago' '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || echo '')"
+if [ -z "${SINCE}" ]; then
+  # Fallback: yesterday noon
+  SINCE="$(date '+%Y-%m-%d')T00:00:00"
+fi
+log "  since=${SINCE}"
+
+nix-shell "${LLM_NIX}" --run \
+  "Rscript '${AGGREGATOR}' --since '${SINCE}' --out '${DIGEST_PATH}'" \
+  >> "${LOG_FILE}" 2>&1
+STEP1_EXIT=$?
+
+if [ "${STEP1_EXIT}" -ne 0 ]; then
+  log "WARNING: config_change_digest.R exited ${STEP1_EXIT} — continuing"
+fi
+log "Step 1 done (exit=${STEP1_EXIT})"
+
+# ── Step 2: Send email ────────────────────────────────────────────────────────
+log "Step 2: sending config digest email..."
+EMAIL_SCRIPT="${REPO_ROOT}/.claude/scripts/send_config_digest_email.R"
+
+if [ ! -f "${EMAIL_SCRIPT}" ]; then
+  log "ERROR: send_config_digest_email.R not found at ${EMAIL_SCRIPT}"
+  exit 1
+fi
+
+nix-shell "${LLM_NIX}" --run \
+  "CONFIG_DIGEST_PATH='${DIGEST_PATH}' CONFIG_DIGEST_SINCE='${SINCE}' Rscript '${EMAIL_SCRIPT}'" \
+  >> "${LOG_FILE}" 2>&1
+STEP2_EXIT=$?
+
+if [ "${STEP2_EXIT}" -ne 0 ]; then
+  log "ERROR: send_config_digest_email.R exited ${STEP2_EXIT}"
+  exit "${STEP2_EXIT}"
+fi
+log "Step 2 done"
+
+log "=== config_digest_cron.sh done ==="

--- a/tests/testthat/test-config-change-digest.R
+++ b/tests/testthat/test-config-change-digest.R
@@ -1,0 +1,504 @@
+# test-config-change-digest.R — Tests for config_change_digest.R and
+# send_config_digest_email.R.
+#
+# Coverage:
+#   - Aggregator: per-category counts/lines from synthetic git fixture
+#   - Aggregator: theme grouping by conventional-commit scope
+#   - Aggregator: lessons-learnt extraction (fix commits + CHANGELOG)
+#   - Aggregator: --dry-run prints to stdout, exits 0
+#   - Email: dry-run (EMAIL_DRY_RUN=1) output contains digest sections and
+#     dashboard-link placeholder
+#   - Shell scripts: bash -n syntax checks
+#   - plist: plutil -lint validation
+#
+# Uses a synthetic git repository fixture — no real llm git history needed.
+# All external processes guarded with skip_if_not / skip_on_ci as needed.
+
+library(testthat)
+
+# ── Paths ────────────────────────────────────────────────────────────────────
+
+repo_root <- function() {
+  # Attempt 1: resolve from the location of this test file (most reliable
+  # when test_file() is called with an absolute path).
+  this_file <- tryCatch(
+    normalizePath(sys.frame(0)$ofile, mustWork = FALSE),
+    error = function(e) ""
+  )
+  if (nzchar(this_file) && file.exists(this_file)) {
+    candidate <- dirname(dirname(this_file))  # up from tests/testthat/
+    if (file.exists(file.path(candidate, ".git"))) return(candidate)
+  }
+
+  # Attempt 2: use testthat::test_path() (works when run via devtools::test())
+  tp <- tryCatch(testthat::test_path(), error = function(e) "")
+  if (nzchar(tp)) {
+    candidate <- normalizePath(file.path(tp, "..", ".."), mustWork = FALSE)
+    if (file.exists(file.path(candidate, ".git"))) return(candidate)
+  }
+
+  # Attempt 3: walk up from cwd
+  path <- getwd()
+  for (i in seq_len(10L)) {
+    if (file.exists(file.path(path, ".git"))) return(path)
+    parent <- dirname(path)
+    if (parent == path) break
+    path <- parent
+  }
+  getwd()
+}
+
+script_path <- function(name) {
+  normalizePath(
+    file.path(repo_root(), ".claude", "scripts", name),
+    mustWork = FALSE
+  )
+}
+
+bin_path <- function(name) {
+  normalizePath(
+    file.path(repo_root(), "bin", name),
+    mustWork = FALSE
+  )
+}
+
+launchd_path <- function(name) {
+  normalizePath(
+    file.path(repo_root(), ".claude", "launchd", name),
+    mustWork = FALSE
+  )
+}
+
+# ── Synthetic git fixture ─────────────────────────────────────────────────────
+
+# Creates a minimal git repo with commits spanning multiple config categories.
+# Returns the path to the temporary repo.
+make_git_fixture <- function() {
+  dir <- tempfile("config_digest_git_fixture_")
+  dir.create(dir, recursive = TRUE)
+
+  # Write a small shell script to create the fixture commits — avoids
+  # system2() shell-quoting issues with parentheses in commit messages.
+  script_path <- file.path(dir, "make_fixture.sh")
+  writeLines(c(
+    "#!/bin/sh",
+    paste0("set -e"),
+    paste0("cd '", dir, "'"),
+    "git init -b main",
+    "git config user.email 'test@example.com'",
+    "git config user.name  'Test User'",
+
+    # Skills
+    paste0("mkdir -p '.claude/skills/r-package-workflow'"),
+    "printf 'line1\\nline2\\nline3\\n' > '.claude/skills/r-package-workflow/SKILL.md'",
+    "git add .",
+    "git commit -m 'feat(r-package-workflow): add step 9'",
+
+    # Rules
+    paste0("mkdir -p '.claude/rules'"),
+    "printf 'line1\\nline2\\nline3\\n' > '.claude/rules/bash-safety.md'",
+    "git add .",
+    "git commit -m 'fix(bash-safety): correct ban documentation'",
+
+    # Hooks
+    paste0("mkdir -p '.claude/hooks'"),
+    "printf 'line1\\nline2\\nline3\\n' > '.claude/hooks/pre_commit_lint.sh'",
+    "git add .",
+    "git commit -m 'feat(hooks): new pre-commit lint hook'",
+
+    # Scripts
+    paste0("mkdir -p '.claude/scripts'"),
+    "printf 'line1\\nline2\\nline3\\n' > '.claude/scripts/burn_rate_check.sh'",
+    "git add .",
+    "git commit -m 'chore(scripts): update burn_rate_check threshold'",
+
+    # Rules second fix
+    "printf 'line1\\nline2\\nline3\\nline4\\n' > '.claude/rules/nix-nested-shell.md'",
+    "git add .",
+    "git commit -m 'fix(nix): correct nested shell isolation docs'",
+
+    # Memory
+    paste0("mkdir -p '.claude/memory'"),
+    "printf 'line1\\nline2\\nline3\\n' > '.claude/memory/MEMORY.md'",
+    "git add .",
+    "git commit -m 'docs(memory): record worktree location convention'"
+  ), script_path)
+
+  system2("bash", args = script_path, stdout = FALSE, stderr = FALSE)
+  dir
+}
+
+# ── Run the aggregator script against a fixture ───────────────────────────────
+
+run_aggregator <- function(since = "2020-01-01T00:00:00", extra_args = character(0),
+                           repo_dir = NULL) {
+  agg <- script_path("config_change_digest.R")
+  skip_if_not(file.exists(agg), "config_change_digest.R not found")
+
+  out_path <- tempfile("digest_", fileext = ".md")
+  on.exit(unlink(out_path), add = TRUE)
+
+  # Build the env override list for withr (named character vector, not KEY=VAL).
+  env_override <- if (!is.null(repo_dir)) c(LLM_REPO_ROOT = repo_dir) else character(0)
+
+  args <- c(agg,
+    "--since", since,
+    "--out",   out_path,
+    extra_args)
+
+  # Use withr::with_envvar to set LLM_REPO_ROOT in the child process without
+  # passing the full Sys.getenv() blob (which includes huge shellHook exports
+  # that break system2 arg handling under Nix).
+  result <- withr::with_envvar(
+    env_override,
+    system2("Rscript", args = args, stdout = TRUE, stderr = TRUE)
+  )
+
+  list(
+    output   = paste(result, collapse = "\n"),
+    md_path  = out_path,
+    md_exists = file.exists(out_path),
+    md_text   = if (file.exists(out_path)) paste(readLines(out_path, warn = FALSE), collapse = "\n") else ""
+  )
+}
+
+# ── Helper: run email script in dry-run mode ──────────────────────────────────
+
+run_email_dry_run <- function(digest_path = NULL, extra_env = character(0)) {
+  email_script <- script_path("send_config_digest_email.R")
+  skip_if_not(file.exists(email_script), "send_config_digest_email.R not found")
+  skip_if_not_installed("blastula")
+
+  # If no pre-made digest, generate a minimal one
+  if (is.null(digest_path)) {
+    digest_path <- tempfile("digest_email_test_", fileext = ".md")
+    writeLines(c(
+      "# Config-Change Digest — 2026-05-29",
+      "",
+      "**Window:** since 2026-05-28T00:00:00 | **Generated:** 2026-05-29T08:00:00Z UTC",
+      "",
+      "## Changes by Category",
+      "",
+      "| Category | Files changed | Lines added | Lines deleted |",
+      "|----------|:---:|:---:|:---:|",
+      "| Rules | 2 | +45 | -3 |",
+      "| Scripts | 1 | +80 | -0 |",
+      "| **Total** | **3** | **+125** | **-3** |",
+      "",
+      "## Themes Today",
+      "",
+      "### `bash-safety` (2 commits)",
+      "",
+      "- `abc1234` fix(bash-safety): correct example",
+      "- `def5678` docs(bash-safety): add rationale",
+      "",
+      "## Lessons Learnt",
+      "",
+      "### From fix/revert commits",
+      "",
+      "- **[FIX]** `abc1234` fix(bash-safety): correct example",
+      "",
+      "---",
+      "",
+      "<!-- QA:config_digest_generated=2026-05-29T08:00:00Z -->",
+      "<!-- QA:config_digest_since=2026-05-28T00:00:00 -->",
+      "<!-- QA:config_digest_total_files=3 -->",
+      "<!-- QA:config_digest_total_added=125 -->",
+      "<!-- QA:config_digest_total_deleted=3 -->",
+      "<!-- QA:config_digest_n_themes=1 -->",
+      "<!-- QA:config_digest_n_lessons=1 -->"
+    ), digest_path)
+  }
+
+  # Build named env override for withr (do NOT pass env= to system2 — the full
+  # Sys.getenv() blob is too large and includes shellHook exports that break
+  # system2 under Nix; withr::with_envvar sets vars in the child process env).
+  env_override <- c(
+    EMAIL_DRY_RUN           = "1",
+    CONFIG_DIGEST_PATH      = digest_path,
+    GMAIL_USERNAME          = "",
+    GMAIL_APP_PASSWORD      = "",
+    REPORT_RECIPIENT        = ""
+  )
+  # Merge caller extras (named character vector, KEY = VALUE form)
+  if (length(extra_env) > 0L) {
+    extra_named <- setNames(
+      sub("^[^=]+=", "", extra_env),
+      sub("=.*$",    "", extra_env)
+    )
+    env_override <- c(env_override, extra_named)
+  }
+
+  result <- withr::with_envvar(
+    env_override,
+    system2("Rscript", args = email_script,
+            stdout = TRUE, stderr = TRUE)
+  )
+  list(
+    output = paste(result, collapse = "\n"),
+    digest_path = digest_path
+  )
+}
+
+# ── Aggregator tests ──────────────────────────────────────────────────────────
+
+test_that("aggregator --dry-run prints to stdout and exits 0", {
+  agg <- script_path("config_change_digest.R")
+  skip_if_not(file.exists(agg), "config_change_digest.R not found")
+
+  out <- system2("Rscript", args = c(agg, "--since", "2020-01-01T00:00:00", "--dry-run"),
+                 stdout = TRUE, stderr = FALSE)
+  combined <- paste(out, collapse = "\n")
+
+  # Must contain the markdown digest header
+  expect_true(grepl("Config-Change Digest", combined),
+              info = "Digest header not found in --dry-run output")
+})
+
+test_that("aggregator produces output file with required sections", {
+  agg <- script_path("config_change_digest.R")
+  skip_if_not(file.exists(agg), "config_change_digest.R not found")
+
+  out_path <- tempfile("digest_sections_", fileext = ".md")
+  on.exit(unlink(out_path), add = TRUE)
+
+  system2("Rscript", args = c(agg,
+    "--since", "2020-01-01T00:00:00",
+    "--out",   out_path),
+    stdout = FALSE, stderr = FALSE)
+
+  skip_if_not(file.exists(out_path), "aggregator did not produce output file")
+  text <- paste(readLines(out_path, warn = FALSE), collapse = "\n")
+
+  expect_true(grepl("Changes by Category", text),
+              info = "Category section missing from digest")
+  expect_true(grepl("Themes Today", text),
+              info = "Themes section missing from digest")
+  expect_true(grepl("Lessons Learnt", text),
+              info = "Lessons section missing from digest")
+})
+
+test_that("aggregator emits QA markers in output file", {
+  agg <- script_path("config_change_digest.R")
+  skip_if_not(file.exists(agg), "config_change_digest.R not found")
+
+  out_path <- tempfile("digest_qa_", fileext = ".md")
+  on.exit(unlink(out_path), add = TRUE)
+
+  system2("Rscript", args = c(agg,
+    "--since", "2020-01-01T00:00:00",
+    "--out",   out_path),
+    stdout = FALSE, stderr = FALSE)
+
+  skip_if_not(file.exists(out_path), "aggregator did not produce output file")
+  text <- paste(readLines(out_path, warn = FALSE), collapse = "\n")
+
+  expect_true(grepl("QA:config_digest_generated=", text),
+              info = "QA:config_digest_generated marker missing")
+  expect_true(grepl("QA:config_digest_total_files=", text),
+              info = "QA:config_digest_total_files marker missing")
+  expect_true(grepl("QA:config_digest_n_themes=", text),
+              info = "QA:config_digest_n_themes marker missing")
+})
+
+test_that("aggregator with synthetic fixture detects category changes", {
+  agg <- script_path("config_change_digest.R")
+  skip_if_not(file.exists(agg), "config_change_digest.R not found")
+  skip_if_not(nzchar(Sys.which("git")), "git not found")
+
+  fixture_dir <- make_git_fixture()
+  on.exit(unlink(fixture_dir, recursive = TRUE), add = TRUE)
+
+  out_path <- tempfile("digest_fixture_", fileext = ".md")
+  on.exit(unlink(out_path), add = TRUE)
+
+  withr::with_envvar(
+    c(LLM_REPO_ROOT = fixture_dir),
+    system2("Rscript", args = c(agg,
+      "--since", "2020-01-01T00:00:00",
+      "--out",   out_path),
+      stdout = FALSE, stderr = FALSE)
+  )
+
+  skip_if_not(file.exists(out_path), "aggregator did not produce output file")
+  text <- paste(readLines(out_path, warn = FALSE), collapse = "\n")
+
+  # The fixture has .claude/skills/, .claude/rules/, .claude/hooks/,
+  # .claude/scripts/, .claude/memory/ changes — at least some must show up.
+  expect_true(grepl("\\| Skills", text) || grepl("\\| Rules", text) ||
+              grepl("\\| Scripts", text) || grepl("\\| Memory", text),
+              info = "No category changes detected from synthetic fixture")
+})
+
+test_that("aggregator with synthetic fixture clusters themes by scope", {
+  agg <- script_path("config_change_digest.R")
+  skip_if_not(file.exists(agg), "config_change_digest.R not found")
+  skip_if_not(nzchar(Sys.which("git")), "git not found")
+
+  fixture_dir <- make_git_fixture()
+  on.exit(unlink(fixture_dir, recursive = TRUE), add = TRUE)
+
+  out_path <- tempfile("digest_themes_", fileext = ".md")
+  on.exit(unlink(out_path), add = TRUE)
+
+  withr::with_envvar(
+    c(LLM_REPO_ROOT = fixture_dir),
+    system2("Rscript", args = c(agg,
+      "--since", "2020-01-01T00:00:00",
+      "--out",   out_path),
+      stdout = FALSE, stderr = FALSE)
+  )
+
+  skip_if_not(file.exists(out_path), "aggregator did not produce output file")
+  text <- paste(readLines(out_path, warn = FALSE), collapse = "\n")
+
+  # The fixture has commits with scopes: r-package-workflow, bash-safety, hooks,
+  # scripts, nix, memory.  Themes section must be non-empty.
+  expect_true(grepl("### `", text),
+              info = "No theme headings found — theme clustering may have failed")
+})
+
+test_that("aggregator with synthetic fixture extracts fix lessons", {
+  agg <- script_path("config_change_digest.R")
+  skip_if_not(file.exists(agg), "config_change_digest.R not found")
+  skip_if_not(nzchar(Sys.which("git")), "git not found")
+
+  fixture_dir <- make_git_fixture()
+  on.exit(unlink(fixture_dir, recursive = TRUE), add = TRUE)
+
+  out_path <- tempfile("digest_lessons_", fileext = ".md")
+  on.exit(unlink(out_path), add = TRUE)
+
+  withr::with_envvar(
+    c(LLM_REPO_ROOT = fixture_dir),
+    system2("Rscript", args = c(agg,
+      "--since", "2020-01-01T00:00:00",
+      "--out",   out_path),
+      stdout = FALSE, stderr = FALSE)
+  )
+
+  skip_if_not(file.exists(out_path), "aggregator did not produce output file")
+  text <- paste(readLines(out_path, warn = FALSE), collapse = "\n")
+
+  # Fixture has 2 fix: commits → lessons section must mention them
+  expect_true(grepl("\\[FIX\\]", text),
+              info = "No [FIX] lessons from fix commits in synthetic fixture")
+})
+
+test_that("aggregator includes CHANGELOG failed-approaches from window", {
+  agg <- script_path("config_change_digest.R")
+  skip_if_not(file.exists(agg), "config_change_digest.R not found")
+  skip_if_not(nzchar(Sys.which("git")), "git not found")
+
+  fixture_dir <- make_git_fixture()
+  on.exit(unlink(fixture_dir, recursive = TRUE), add = TRUE)
+
+  # Write a CHANGELOG with a failed approach in window
+  cl_path <- file.path(fixture_dir, "CHANGELOG.md")
+  writeLines(c(
+    "# Changelog",
+    "",
+    "## 2026-05-29 (test session)",
+    "",
+    "### Failed Approaches",
+    "",
+    "- Used bash glob that did not recurse — switch to find",
+    "- Called btw_tool_run_r which hung the session"
+  ), cl_path)
+
+  out_path <- tempfile("digest_cl_", fileext = ".md")
+  on.exit(unlink(out_path), add = TRUE)
+
+  withr::with_envvar(
+    c(LLM_REPO_ROOT = fixture_dir),
+    system2("Rscript", args = c(agg,
+      "--since", "2026-05-28T00:00:00",
+      "--out",   out_path),
+      stdout = FALSE, stderr = FALSE)
+  )
+
+  skip_if_not(file.exists(out_path), "aggregator did not produce output file")
+  text <- paste(readLines(out_path, warn = FALSE), collapse = "\n")
+
+  expect_true(
+    grepl("bash glob", text) || grepl("CHANGELOG", text),
+    info = "CHANGELOG failed-approach entry not reflected in lessons section"
+  )
+})
+
+# ── Email dry-run tests ───────────────────────────────────────────────────────
+
+test_that("email dry-run output contains digest sections", {
+  res <- run_email_dry_run()
+  out <- res$output
+
+  expect_true(grepl("Config-Change Digest", out),
+              info = "Digest title not found in email dry-run output")
+  expect_true(grepl("Changes by Category", out),
+              info = "Category section not found in email dry-run output")
+  expect_true(grepl("Themes Today", out) || grepl("Theme", out),
+              info = "Themes section not found in email dry-run output")
+  expect_true(grepl("Lessons", out),
+              info = "Lessons section not found in email dry-run output")
+})
+
+test_that("email dry-run output contains GitHub commits link", {
+  res <- run_email_dry_run()
+  out <- res$output
+
+  expect_true(grepl("github.com/JohnGavin/llm/commits", out),
+              info = "GitHub commits link not found in email dry-run output")
+})
+
+test_that("email dry-run output contains QA markers", {
+  res <- run_email_dry_run()
+  out <- res$output
+
+  expect_true(grepl("QA:email_report_date=", out),
+              info = "QA:email_report_date marker missing from dry-run output")
+  expect_true(grepl("QA:config_digest_section=present", out),
+              info = "QA:config_digest_section marker missing from dry-run output")
+})
+
+test_that("email dry-run output is non-empty", {
+  res <- run_email_dry_run()
+  expect_gt(nchar(res$output), 200L)
+})
+
+test_that("email dry-run At a Glance table shows numeric values from digest", {
+  res <- run_email_dry_run()
+  out <- res$output
+
+  # The digest fixture has 3 files / +125 lines
+  expect_true(grepl("125", out) || grepl("\\+", out),
+              info = "Expected numeric values from digest not found in email body")
+})
+
+# ── Shell script syntax checks ────────────────────────────────────────────────
+
+test_that("config_change_digest.R is a well-formed R script (parse check)", {
+  agg <- script_path("config_change_digest.R")
+  skip_if_not(file.exists(agg), "config_change_digest.R not found")
+  expect_silent(parse(file = agg))
+})
+
+test_that("send_config_digest_email.R is a well-formed R script (parse check)", {
+  em <- script_path("send_config_digest_email.R")
+  skip_if_not(file.exists(em), "send_config_digest_email.R not found")
+  expect_silent(parse(file = em))
+})
+
+test_that("config_digest_cron.sh passes bash -n syntax check", {
+  sh <- bin_path("config_digest_cron.sh")
+  skip_if_not(file.exists(sh), "config_digest_cron.sh not found")
+  exit_code <- system2("bash", args = c("-n", sh), stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L, info = "config_digest_cron.sh has bash syntax errors")
+})
+
+test_that("com.claude.config-digest-email.plist is valid XML (plutil)", {
+  pl <- launchd_path("com.claude.config-digest-email.plist")
+  skip_if_not(file.exists(pl), "com.claude.config-digest-email.plist not found")
+  skip_if_not(nzchar(Sys.which("plutil")), "plutil not available")
+  exit_code <- system2("plutil", args = c("-lint", pl), stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L, info = "plist failed plutil -lint validation")
+})


### PR DESCRIPTION
## Summary

- Implements the daily config-change digest email for the `llm` meta-config repo (llm#297), mirroring the roborev daily email pattern (Path b: separate aggregator + email sender + launchd job)
- New `config_change_digest.R` aggregates `git log --numstat` over 8 config categories (Skills, Agents, Rules, Memory, Hooks, Scripts, Templates, Commands), clusters by conventional-commit scope, and extracts lessons from `fix:`/`revert:` commits + CHANGELOG "Failed Approaches" bullets
- 14 passing tests with synthetic git fixture (blastula/plutil skipped outside nix shell)

## Design decisions

**Path b chosen** (separate script + launchd) over Path a (amend self-review) to avoid touching the existing roborev pipeline. New job shares credentials via `~/.claude/env/roborev_email.env`.

**`\x1f` unit separator** as `git --pretty=tformat:` field delimiter — prevents `%s`, `%ae` tokens from being misinterpreted as shell variable expansions when passed through `system2()`.

**`LLM_REPO_ROOT` env override** in `find_repo_root()` — allows tests to point the aggregator at a synthetic git fixture without modifying real history.

## Smoke run (2026-05-27 to 2026-05-29)

```
67 files changed, +3349/-214 lines, 5 themes, 4 lessons
Themes: roborev×5, roborev-etl×2, codex×1, skills×1, isolation×1
```

## Test plan

- [ ] 14 PASS, 0 FAIL, 6 SKIP (blastula/plutil absent from test env — expected)
- [ ] R parse checks pass for all 3 R files
- [ ] `bash -n bin/config_digest_cron.sh` exits 0
- [ ] Activate launchd job: `cp .claude/launchd/com.claude.config-digest-email.plist ~/Library/LaunchAgents/` then `launchctl load -w ~/Library/LaunchAgents/com.claude.config-digest-email.plist`
- [ ] Manual dry-run: `EMAIL_DRY_RUN=1 bash bin/config_digest_cron.sh`

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)