### PR TITLE
docs(rule): hf upload for CI (#299)

### DIFF
--- a/.claude/rules/huggingface-upload.md
+++ b/.claude/rules/huggingface-upload.md
@@ -7,22 +7,116 @@ paths: ["**/*.parquet", "**/huggingface*", "**/hf_*"]
 ## When This Applies
 Any project that hosts Parquet data on HuggingFace Datasets.
 
-## CRITICAL: Use Git Clone + Push, Not REST API
+## Method Decision Table
 
-The HuggingFace REST API upload endpoints are undocumented and unreliable:
-- `POST /api/upload` → 404
-- `POST /api/datasets/{repo}/upload/main` → 404
-- `PUT /api/datasets/{repo}/upload/main/file` → 404
-- `POST /api/datasets/{repo}/commit/main` → schema errors
+| Context | Method | Why |
+|---------|--------|-----|
+| **CI / GitHub Actions / automation** | `hf upload` CLI | Works with `HF_TOKEN` env var; no credential-helper setup needed |
+| **Local interactive** | `git clone` + `git-lfs push` | Familiar git workflow after one-time `hf auth login` |
+| **REST API** | **Forbidden** | Endpoints undocumented and unreliable (see below) |
 
-**The only reliable method is git clone + git-lfs push:**
+## CI / Automation Path — `hf upload` (preferred for CI)
+
+### Why `git+lfs` fails in CI
+
+`git+lfs` push over HTTPS requires a credential helper to supply the token.
+In CI, the token is available as an environment variable but git's LFS smart-HTTP
+protocol falls back to HTTP Basic auth, producing:
+
+```
+remote: Password authentication in git is no longer supported.
+You must use a user access token with the appropriate scope.
+```
+
+This error fires regardless of whether the git username is the token itself or
+the account name, because HuggingFace's LFS endpoint rejects HTTP Basic auth
+altogether. The `hf` CLI bypasses this by posting via the HuggingFace Hub REST
+client which authenticates with Bearer tokens natively.
+
+### CLI binary: `hf` (not `huggingface-cli`)
+
+`huggingface-cli` is a deprecated no-op as of recent `huggingface_hub` releases
+("no longer works. Use `hf`"). Always use the `hf` binary.
+
+```bash
+# Verify you have the right binary
+hf --version          # huggingface_hub x.y.z
+hf auth whoami        # prints your username when HF_TOKEN is set
+```
+
+### Command form
+
+```bash
+hf upload <repo_id> <local_path> <path_in_repo> \
+  --repo-type dataset \
+  --commit-message "Update equity_daily: N tickers, M rows"
+```
+
+- `<repo_id>` — `owner/repo-name` (no `https://`, no `datasets/` prefix)
+- `<local_path>` — local file or directory to upload
+- `<path_in_repo>` — destination path inside the repo (`.` for repo root)
+- `--repo-type` — `dataset`, `model`, or `space` (default: `model`)
+
+### R integration: `shQuote()` is mandatory
+
+`system2()` does not shell-quote arguments. Any argument containing spaces
+(e.g. a commit message) MUST be wrapped in `shQuote()`:
+
+```r
+system2("hf", args = c(
+  "upload",
+  shQuote(repo_id),
+  shQuote(local_path),
+  ".",
+  "--repo-type", "dataset",
+  "--commit-message", shQuote(commit_msg)
+))
+```
+
+Omitting `shQuote()` produces: `Got unexpected extra arguments (...)`.
+
+### Token requirements
+
+The token MUST be a valid **classic Write token** (fine-grained tokens may lack
+write scope for datasets). Verify before storing:
+
+```bash
+HF_TOKEN='hf_xxx' hf auth whoami   # must print your username, not an error
+```
+
+Strip whitespace defensively when reading from secrets:
+
+```bash
+HF_TOKEN="$(echo "$HF_TOKEN" | tr -d '[:space:]')"
+```
+
+### GitHub Actions step (5-line example)
+
+```yaml
+- name: Upload dataset to HuggingFace
+  env:
+    HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  run: |
+    pip install --quiet --upgrade huggingface_hub
+    hf upload owner/my-dataset data/dist/equity_daily.parquet equity_daily.parquet \
+      --repo-type dataset \
+      --commit-message "CI update $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+Store the token as a GitHub Actions secret named `HF_TOKEN`. Never hardcode
+it in the workflow YAML.
+
+## Local Interactive Path — `git clone` + `git-lfs push` (interactive only)
+
+**This path requires `hf auth login` to have been run once. It does NOT work
+in CI without a configured credential helper. For CI, use `hf upload` above.**
 
 ```bash
 # Use a unique variable name to avoid shadowing system $TMPDIR
 HF_WORKDIR=$(mktemp -d)
 
 # Clone using git credential helper (avoids embedding token in URL or env).
-# One-time setup: huggingface-cli login
+# One-time setup: hf auth login
 # This stores the token in ~/.cache/huggingface/token and configures git to
 # use it via the credential helper — never exposes it in ps output or history.
 GIT_ASKPASS=echo git clone "https://huggingface.co/datasets/owner/repo" "$HF_WORKDIR/repo"
@@ -54,9 +148,20 @@ rm -rf "$HF_WORKDIR"
 - Logged by some git versions
 - Persisted in `.git/config` remote URL
 
+## Why REST API Is Forbidden
+
+The HuggingFace REST API upload endpoints are undocumented and unreliable:
+- `POST /api/upload` → 404
+- `POST /api/datasets/{repo}/upload/main` → 404
+- `PUT /api/datasets/{repo}/upload/main/file` → 404
+- `POST /api/datasets/{repo}/commit/main` → schema errors
+
+Use `hf upload` (CI) or `git+lfs` (local interactive) only.
+
 ## Token Location
 
-`~/.cache/huggingface/token` — set via `huggingface-cli login` or manually.
+Interactive: `~/.cache/huggingface/token` — set via `hf auth login`.
+CI: `HF_TOKEN` environment variable (GitHub Actions secret).
 
 ## Auth Verification
 


### PR DESCRIPTION
## Summary

- Adds a "CI / automation path" section to `.claude/rules/huggingface-upload.md` documenting `hf upload` for GitHub Actions (closes #299)
- Explains exactly why `git+lfs` fails in CI: HuggingFace LFS smart-HTTP endpoint rejects HTTP Basic auth; error is `Password authentication in git is no longer supported`
- Marks the existing `git clone` + `git-lfs push` path as **interactive only**
- Adds a method decision table so the right path is chosen at a glance

### New CI path documented

```yaml
- name: Upload dataset to HuggingFace
  env:
    HF_TOKEN: ${{ secrets.HF_TOKEN }}
  run: |
    pip install --quiet --upgrade huggingface_hub
    hf upload owner/my-dataset data/dist/equity_daily.parquet equity_daily.parquet \
      --repo-type dataset \
      --commit-message "CI update $(date -u +%Y-%m-%dT%H:%M:%SZ)"
```

### Why git+lfs fails in CI

The git LFS smart-HTTP protocol falls back to HTTP Basic auth when the
credential helper is absent (as in CI). HuggingFace disabled Basic auth:

```
remote: Password authentication in git is no longer supported.
You must use a user access token with the appropriate scope.
```

The `hf` CLI uses Bearer auth natively from `HF_TOKEN` and bypasses this.

### Other gotchas documented (from issue body)

- `huggingface-cli` is a deprecated no-op — always use the `hf` binary
- `system2()` in R does not shell-quote — `shQuote()` is mandatory for any arg with spaces
- Token must be a classic Write token; strip whitespace before `gh secret set`

## Test plan

- [x] YAML example validated with Python `yaml.safe_load` — parses correctly
- [x] File is 203 lines (no runaway growth)
- [x] `git diff` confirms only `.claude/rules/huggingface-upload.md` changed

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
