### PR TITLE
chore(scripts): --body-file convention (#200)

### DIFF
--- a/.claude/rules/_companions/auto-delegation-dispatch-details.md
+++ b/.claude/rules/_companions/auto-delegation-dispatch-details.md
@@ -206,6 +206,64 @@ Evidence: PR #243 (llmtelemetry roborev dashboard) shipped via this pattern in
 
 ---
 
+## `gh` CLI — Always Use `--body-file` (#200)
+
+**CRITICAL:** Never use `--body "$(cat ...)"` or `--body "$var"` with multiline content
+in any `gh` CLI call. Use `--body-file <path>` instead.
+
+### Why
+
+`--body "$(cat /tmp/file.md)"` is a command substitution. Claude Code's static
+analyser cannot see inside `$(...)`, so every such call triggers an approval prompt
+("Contains shell syntax that cannot be statically analysed"). With `--body-file`,
+the path is visible in the command and the allowlist works correctly — zero prompts.
+
+The same applies to `--body "$multiline_var"` when the variable contains markdown
+with pipes, backticks, or tables (heredoc-body failures, see llm#200).
+
+### Supported commands
+
+`--body-file` exists on all these subcommands:
+
+```
+gh pr create  --body-file <path>
+gh pr edit    --body-file <path>
+gh pr comment --body-file <path>
+gh issue create  --body-file <path>
+gh issue edit    --body-file <path>
+gh issue comment --body-file <path>
+gh release create --notes-file <path>
+```
+
+### Required pattern (agents AND scripts)
+
+```bash
+# WRONG — triggers approval prompt
+gh pr create --title "..." --body "$(cat /tmp/body.md)"
+gh issue comment 42 --body "$multiline_var"
+
+# RIGHT — statically analysable, zero prompts
+_body=$(mktemp /tmp/gh_body_XXXXXX.md)
+printf '%s' "$body_content" > "$_body"
+gh pr create --title "..." --body-file "$_body"
+rm -f "$_body"
+```
+
+Cleanup is mandatory. Use `rm -f` immediately after the `gh` call, or register a
+`trap 'rm -f "$_body"' EXIT` at the top of the function.
+
+**Exception:** `git commit -m "$(cat <<'EOF' ... EOF)"` patterns are NOT affected —
+these are git, not gh CLI, and do not trigger the same approval path. Leave those
+as-is. Document the exception with a comment when the two patterns appear near each
+other.
+
+### Reference
+
+- llm#200 — origin issue with full options analysis
+- `bash-safety` rule — compound commands; `$(...)` is a related surface
+
+---
+
 ## Right vs Wrong
 
 ```

--- a/.claude/scripts/roborev_handoff.sh
+++ b/.claude/scripts/roborev_handoff.sh
@@ -453,15 +453,19 @@ while IFS= read -r repo_json; do
             if [ -n "$existing" ]; then
               log "skip: $repo_name job=$job_id issue already exists (#$existing)"
             else
-              issue_body=$(printf '## roborev review — commit `%s`\n\n%s\n\n---\n_roborev job: %s_\n' \
-                "$commit_short" "$output" "$job_id")
+              # Use --body-file to avoid command-substitution approval prompts (#200)
+              _body_file_1a=$(mktemp /tmp/roborev_handoff_1a_XXXXXX.md)
+              printf '## roborev review — commit `%s`\n\n%s\n\n---\n_roborev job: %s_\n' \
+                "$commit_short" "$output" "$job_id" > "$_body_file_1a"
               issue_url=$(
                 "$GH" issue create \
                   --repo "$owner_repo" \
                   --title "roborev review for $commit_short" \
                   --label "roborev-handoff" \
-                  --body "$issue_body" 2>/dev/null
-              ) && {
+                  --body-file "$_body_file_1a" 2>/dev/null
+              )
+              rm -f "$_body_file_1a"
+              [ -n "$issue_url" ] && {
                 log "1a: created issue $issue_url job=$job_id repo=$repo_name"
                 "$ROBOREV" close "$job_id" >/dev/null 2>&1 \
                   && log "1a: closed job=$job_id" \
@@ -504,7 +508,13 @@ while IFS= read -r repo_json; do
                 log "skip: $repo_name job=$job_id already in digest #$digest_num"
               else
                 new_body="${existing_body}${append_block}"
-                "$GH" issue edit "$digest_num" --repo "$owner_repo" --body "$new_body" >/dev/null 2>&1 && {
+                # Use --body-file to avoid command-substitution approval prompts (#200)
+                _body_file_1b=$(mktemp /tmp/roborev_handoff_1b_XXXXXX.md)
+                printf '%s' "$new_body" > "$_body_file_1b"
+                "$GH" issue edit "$digest_num" --repo "$owner_repo" --body-file "$_body_file_1b" >/dev/null 2>&1
+                _gh_rc=$?
+                rm -f "$_body_file_1b"
+                [ "$_gh_rc" -eq 0 ] && {
                   log "1b: appended to digest #$digest_num job=$job_id repo=$repo_name"
                   "$ROBOREV" close "$job_id" >/dev/null 2>&1 \
                     && log "1b: closed job=$job_id" \
@@ -515,13 +525,18 @@ while IFS= read -r repo_json; do
               fi
             else
               # Create new digest issue for this week
+              # Use --body-file to avoid command-substitution approval prompts (#200)
+              _body_file_1b_new=$(mktemp /tmp/roborev_handoff_1bnew_XXXXXX.md)
+              printf '%s' "$append_block" > "$_body_file_1b_new"
               issue_url=$(
                 "$GH" issue create \
                   --repo "$owner_repo" \
                   --title "$digest_title" \
                   --label "roborev-digest" \
-                  --body "$append_block" 2>/dev/null
-              ) && {
+                  --body-file "$_body_file_1b_new" 2>/dev/null
+              )
+              rm -f "$_body_file_1b_new"
+              [ -n "$issue_url" ] && {
                 log "1b: created digest $issue_url job=$job_id repo=$repo_name"
                 "$ROBOREV" close "$job_id" >/dev/null 2>&1 \
                   && log "1b: closed job=$job_id" \


### PR DESCRIPTION
## Summary

- Replaces all three `--body "$var"` calls in `.claude/scripts/roborev_handoff.sh` with `--body-file <tmp>` + `rm -f` cleanup, eliminating command-substitution approval prompts per #200
- Adds a `gh CLI — Always Use --body-file (#200)` section to `.claude/rules/_companions/auto-delegation-dispatch-details.md` documenting the convention, supported gh subcommands, required temp-file pattern, and the git-commit exception

## Files changed (2)

| File | Change |
|------|--------|
| `.claude/scripts/roborev_handoff.sh` | 3 `--body "$var"` → `--body-file <mktemp> + rm -f` |
| `.claude/rules/_companions/auto-delegation-dispatch-details.md` | New section: `gh CLI — Always Use --body-file (#200)` |

## Test plan

- [x] `bash -n .claude/scripts/roborev_handoff.sh` passes (no syntax errors)
- [x] `grep -- '--body ' .claude/scripts/roborev_handoff.sh` returns 0 matches
- [x] `grep 'body-file' .claude/scripts/roborev_handoff.sh` shows all 3 occurrences converted

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
