### PR TITLE
fix(self-review): Stage 1 false positives — rate-windowing + reachable status filter (#269)

### DIFF
--- a/.claude/scripts/self_review_stage1.sql
+++ b/.claude/scripts/self_review_stage1.sql
@@ -32,15 +32,25 @@ CREATE TABLE IF NOT EXISTS self_review_findings_stage1 (
 );
 
 -- ─────────────────────────────────────────────────────────────────────────────
--- DETECTOR 1: Stuck loop — repeated identical tool calls
+-- DETECTOR 1: Stuck loop — agents dispatched multiple times but never completed
 --
--- Proxy: same agent_type dispatched ≥ 3 times in one session with status 'failed'
--- (hook_events and agent_runs don't store raw tool inputs; we use agent repetition
---  as the available signal until a richer tool-call log is added in Stage 2.)
+-- Fix (#269): The original query used no status filter and matched status='done'
+-- rows, producing false positives whenever the same agent type was legitimately
+-- dispatched ≥3 times in a session (e.g., three fixer agents on different tasks).
+-- status='failed' was referenced in comments but that value never appears in the
+-- ETL because ended_at is never written back — every completed agent stays
+-- status='running' or 'done' depending on ETL version.
 --
--- Threshold: ≥ 3 identical (session_id, agent_type, status) rows
+-- Corrected definition of "stuck":
+--   status = 'running' AND ended_at IS NULL AND started_at < NOW() - 1 HOUR
+--   (i.e., an agent that started over an hour ago and has not finished)
+-- The session_id + agent_type combination appearing ≥3 times under those
+-- conditions is the genuine stuck-loop signal.
+--
+-- Threshold: ≥ 3 such rows per (session_id, agent_type)
 -- Severity: major
 -- ─────────────────────────────────────────────────────────────────────────────
+-- Ref: #269 — false positives from status='done' rows matching the old query
 WITH stuck_loop_candidates AS (
     SELECT
         session_id,
@@ -50,7 +60,15 @@ WITH stuck_loop_candidates AS (
         MIN(started_at) AS first_call,
         MAX(started_at) AS last_call
     FROM agent_runs
-    WHERE session_id IS NOT NULL
+    WHERE
+        session_id IS NOT NULL
+        -- Only flag agents that are still marked running and have no end time.
+        -- Completed agents (status='done', ended_at IS NOT NULL) are not stuck.
+        -- (#269: previous version had no status filter; matched status='done')
+        AND status = 'running'
+        AND ended_at IS NULL
+        -- Must have been running for > 1 hour to avoid flagging in-flight agents.
+        AND started_at < current_timestamp - INTERVAL '1' HOUR
     GROUP BY session_id, agent_type, status
     HAVING COUNT(*) >= 3
 ),
@@ -148,16 +166,25 @@ ON CONFLICT (finding_id) DO NOTHING;
 -- Source: errors table, grouped by (source, day).
 -- Cross-referenced against agent_runs to estimate total tool calls per day.
 --
+-- Fix (#269): The original query had no time-window on the errors table, so a
+-- single old error (e.g., 2026-04-20 signal_notes) produced a 100% error rate
+-- finding indefinitely. Added WHERE logged_at >= NOW() - 7 DAYS on both CTEs
+-- so only the rolling 7-day window is evaluated.
+--
 -- Threshold: error_count / max(total_calls, 1) > 0.20 (20%)
 -- Severity: major (>= 50%) or minor (20-50%)
 -- ─────────────────────────────────────────────────────────────────────────────
+-- Ref: #269 — absolute counts produced stale findings from historical data
 WITH daily_errors AS (
     SELECT
         CAST(logged_at AS DATE)     AS day_bucket,
         source                      AS tool_name,
         COUNT(*)                    AS error_count
     FROM errors
-    WHERE session_id IS NOT NULL
+    WHERE
+        session_id IS NOT NULL
+        -- Rate-window: only consider the last 7 days (#269 fix)
+        AND logged_at >= current_timestamp - INTERVAL '7' DAY
     GROUP BY CAST(logged_at AS DATE), source
 ),
 daily_agent_calls AS (
@@ -165,7 +192,10 @@ daily_agent_calls AS (
         CAST(started_at AS DATE)    AS day_bucket,
         COUNT(*)                    AS total_calls
     FROM agent_runs
-    WHERE session_id IS NOT NULL
+    WHERE
+        session_id IS NOT NULL
+        -- Rate-window: only consider the last 7 days (#269 fix)
+        AND started_at >= current_timestamp - INTERVAL '7' DAY
     GROUP BY CAST(started_at AS DATE)
 ),
 error_rates AS (

--- a/plans/235-self-review-stage1.md
+++ b/plans/235-self-review-stage1.md
@@ -14,17 +14,17 @@ involved. No issues are filed. No files are edited.
 
 | Detector | Finding type | Threshold | Severity |
 |---|---|---|---|
-| Repeated identical agent dispatches (stuck loop proxy) | `stuck_loop` | same `(session_id, agent_type, status)` ≥ 3 times | major |
+| Repeated identical agent dispatches (stuck loop proxy) | `stuck_loop` | same `(session_id, agent_type)` with `status='running' AND ended_at IS NULL AND started_at < NOW()-1h` ≥ 3 times | major |
 | Permission/guard blocks | `excessive_guard_blocks` | > 5 blocks from any guard hook in one hour | major |
-| Tool error rate | `high_tool_error_rate` | error_count / total_calls > 20% per tool per day | minor (20-50%) / major (≥50%) |
+| Tool error rate | `high_tool_error_rate` | error_count / total_calls > 20% per tool per day, rolling 7-day window | minor (20-50%) / major (≥50%) |
 | Agent dispatch isolation violations | `isolation_violation` | any hook_events row with `output_preview ILIKE '%ISOLATION%VIOLATION%'` | critical |
 | Pivot-signal rule threshold | `pivot_signal_threshold` | ≥ 3 errors from same tool in one session (3=minor, 5=major, 7=critical) | minor/major/critical |
 
 ### Thresholds — rationale
 
-- **Stuck loop ≥ 3:** the `pivot-signal` rule treats 3 consecutive failures as the first signal. Below 3, variation is normal; at 3 the agent is expected to pause and pivot.
+- **Stuck loop ≥ 3:** the `pivot-signal` rule treats 3 consecutive failures as the first signal. Below 3, variation is normal; at 3 the agent is expected to pause and pivot. Agents flagged must have `status='running'`, `ended_at IS NULL`, and `started_at < NOW()-1h` — completed agents (`status='done'`) are never stuck by definition. (Fixed: #269)
 - **Guard blocks > 5/hour:** individual blocks are expected (hooks are working). Five+ in an hour indicates a systematic issue (bad dispatch pattern, missing bypass flag, or hook misconfiguration).
-- **Error rate > 20%:** one-in-five failures is the standard alert threshold in production SRE practice. Below 20% is within operational noise.
+- **Error rate > 20%:** one-in-five failures is the standard alert threshold in production SRE practice. Below 20% is within operational noise. Rate is computed over the rolling 7-day window only — historical errors outside that window are excluded. (Fixed: #269)
 - **Isolation violations:** zero tolerance. A single confirmed violation means an agent wrote to the main checkout — immediate surfacing required.
 - **Pivot signal 3/5/7:** maps directly to the rule's three-tier escalation table.
 

--- a/tests/testthat/test-self-review-stage1.R
+++ b/tests/testthat/test-self-review-stage1.R
@@ -1,0 +1,369 @@
+# test-self-review-stage1.R — Regression tests for self_review_stage1.sql detectors.
+#
+# Issue: #269 — Stage 1 self-review detectors emit false positives.
+#
+# Two false-positive patterns fixed:
+#   1. stuck_loop — the original query had no status filter, matching
+#      status='done' rows (legitimate multi-dispatch sessions).
+#      Fixed: filter status='running' AND ended_at IS NULL AND started_at < NOW()-1h.
+#   2. high_tool_error_rate — absolute count, not rate-windowed.
+#      A single old error produced a 100% rate finding indefinitely.
+#      Fixed: both CTEs now bound to logged_at/started_at >= NOW() - 7 DAYS.
+#
+# Tests use an in-memory DuckDB fixture database populated with synthetic rows.
+# Each test asserts:
+#   - The fixture row that WOULD have triggered the false positive does NOT trigger.
+#   - A genuine positive row DOES trigger.
+#
+# DuckDB CLI is required. Tests are skipped on CI where it is unavailable.
+
+library(testthat)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+repo_root <- function() {
+  # Walk up from test file location to find the git repo root.
+  this_file <- tryCatch(
+    normalizePath(sys.frame(0)$ofile, mustWork = FALSE),
+    error = function(e) ""
+  )
+  if (nzchar(this_file) && file.exists(this_file)) {
+    candidate <- dirname(dirname(this_file))
+    if (file.exists(file.path(candidate, ".git"))) return(candidate)
+  }
+  tp <- tryCatch(testthat::test_path(), error = function(e) "")
+  if (nzchar(tp)) {
+    candidate <- normalizePath(file.path(tp, "..", ".."), mustWork = FALSE)
+    if (file.exists(file.path(candidate, ".git"))) return(candidate)
+  }
+  path <- getwd()
+  for (i in seq_len(10L)) {
+    if (file.exists(file.path(path, ".git"))) return(path)
+    parent <- dirname(path)
+    if (parent == path) break
+    path <- parent
+  }
+  getwd()
+}
+
+sql_file <- function() {
+  normalizePath(
+    file.path(repo_root(), ".claude", "scripts", "self_review_stage1.sql"),
+    mustWork = FALSE
+  )
+}
+
+duckdb_cmd <- function() {
+  # Prefer the nix-shell duckdb for version parity with the pipeline.
+  nix_default <- normalizePath(
+    file.path(repo_root(), "default.nix"),
+    mustWork = FALSE
+  )
+  if (nzchar(Sys.which("nix-shell")) && file.exists(nix_default)) {
+    # Use nix-shell wrapper: pipe SQL via stdin
+    list(
+      type = "nix",
+      nix_default = nix_default
+    )
+  } else if (nzchar(Sys.which("duckdb"))) {
+    list(type = "path")
+  } else {
+    list(type = "none")
+  }
+}
+
+# Run setup SQL then the detector SQL against a FRESH in-memory DuckDB.
+# Each call gets an independent temp file so CREATE TABLE never conflicts.
+# setup_sql is prepended to the detector SQL file contents.
+run_sql <- function(setup_sql, detector_sql_file) {
+  dc <- duckdb_cmd()
+  if (dc$type == "none") return(NULL)
+
+  detector_lines <- readLines(detector_sql_file, warn = FALSE)
+  # The detector SQL starts with CREATE TABLE IF NOT EXISTS self_review_findings_stage1.
+  # The setup_sql provides the source tables (agent_runs, hook_events, etc.).
+  combined_sql <- paste(c(setup_sql, "", detector_lines), collapse = "\n")
+
+  tmp_sql <- tempfile("stage1_test_", fileext = ".sql")
+  writeLines(combined_sql, tmp_sql)
+  on.exit(unlink(tmp_sql), add = TRUE)
+
+  # Use a FRESH file-based DB each call to avoid "table already exists" errors.
+  tmp_db <- tempfile("stage1_test_", fileext = ".duckdb")
+  on.exit(unlink(tmp_db), add = TRUE)
+
+  if (dc$type == "nix") {
+    cmd <- sprintf(
+      "nix-shell '%s' --run \"duckdb -init /dev/null '%s' < '%s' 2>&1\"",
+      dc$nix_default, tmp_db, tmp_sql
+    )
+    out <- system(cmd, intern = TRUE)
+  } else {
+    # Use shell=TRUE so that < redirection works as expected.
+    cmd <- sprintf("duckdb -init /dev/null '%s' < '%s' 2>&1", tmp_db, tmp_sql)
+    out <- system(cmd, intern = TRUE)
+  }
+  out
+}
+
+# ── Detector 1: stuck_loop ────────────────────────────────────────────────────
+
+test_that("stuck_loop FALSE POSITIVE: status=done rows do NOT trigger detector (#269)", {
+  # Regression: the original query had no status filter. Sessions where the same
+  # agent_type was legitimately dispatched ≥3 times with status='done' were
+  # flagged as stuck loops. This must no longer trigger.
+  skip_if(duckdb_cmd()$type == "none", "duckdb not available")
+  skip_if_not(file.exists(sql_file()), "self_review_stage1.sql not found")
+
+  setup_sql <- "
+-- Fixture: three fixer runs that completed successfully (status='done').
+-- This is a normal multi-dispatch session; NOT a stuck loop.
+CREATE TABLE agent_runs (
+    id          INTEGER,
+    session_id  VARCHAR,
+    agent_type  VARCHAR,
+    model       VARCHAR,
+    started_at  TIMESTAMP,
+    ended_at    TIMESTAMP,
+    duration_sec DOUBLE,
+    prompt_preview VARCHAR,
+    status      VARCHAR,
+    tool_use_id VARCHAR,
+    backfilled  BOOLEAN
+);
+-- All three are 'done' with ended_at set — completed agents.
+INSERT INTO agent_runs VALUES
+  (1, 'sess-fp-001', 'fixer', 'sonnet', now() - INTERVAL '2' HOUR, now() - INTERVAL '1' HOUR, 3600.0, 'task A', 'done', 'tool-1', false),
+  (2, 'sess-fp-001', 'fixer', 'sonnet', now() - INTERVAL '1' HOUR, now() - INTERVAL '30' MINUTE, 1800.0, 'task B', 'done', 'tool-2', false),
+  (3, 'sess-fp-001', 'fixer', 'sonnet', now() - INTERVAL '30' MINUTE, now(),                    1800.0, 'task C', 'done', 'tool-3', false);
+
+-- Other tables required by the SQL file but not used by detector 1:
+CREATE TABLE hook_events (id INTEGER, session_id VARCHAR, hook_name VARCHAR, event_type VARCHAR, fired_at TIMESTAMP, duration_ms INTEGER, output_preview VARCHAR);
+CREATE TABLE errors (id INTEGER, session_id VARCHAR, source VARCHAR, error_text VARCHAR, context VARCHAR, logged_at TIMESTAMP);
+CREATE TABLE sessions (session_id VARCHAR, project VARCHAR, started_at TIMESTAMP, ended_at TIMESTAMP, model VARCHAR);
+"
+  out <- run_sql(setup_sql, sql_file())
+  expect_false(is.null(out), label = "duckdb returned NULL")
+
+  combined <- paste(out, collapse = "\n")
+  # stuck_loop must not appear in the findings summary
+  expect_false(
+    grepl("stuck_loop", combined),
+    label = "stuck_loop finding triggered by status='done' rows — false positive not fixed"
+  )
+})
+
+test_that("stuck_loop TRUE POSITIVE: running agents stuck > 1 hour DO trigger detector", {
+  skip_if(duckdb_cmd()$type == "none", "duckdb not available")
+  skip_if_not(file.exists(sql_file()), "self_review_stage1.sql not found")
+
+  setup_sql <- "
+CREATE TABLE agent_runs (
+    id          INTEGER,
+    session_id  VARCHAR,
+    agent_type  VARCHAR,
+    model       VARCHAR,
+    started_at  TIMESTAMP,
+    ended_at    TIMESTAMP,
+    duration_sec DOUBLE,
+    prompt_preview VARCHAR,
+    status      VARCHAR,
+    tool_use_id VARCHAR,
+    backfilled  BOOLEAN
+);
+-- Three 'running' agents with no ended_at, started more than 1 hour ago.
+-- This represents genuinely stuck agents.
+INSERT INTO agent_runs VALUES
+  (1, 'sess-tp-001', 'fixer', 'sonnet', now() - INTERVAL '3' HOUR, NULL, NULL, 'task A', 'running', 'tool-1', false),
+  (2, 'sess-tp-001', 'fixer', 'sonnet', now() - INTERVAL '2' HOUR, NULL, NULL, 'task B', 'running', 'tool-2', false),
+  (3, 'sess-tp-001', 'fixer', 'sonnet', now() - INTERVAL '90' MINUTE, NULL, NULL, 'task C', 'running', 'tool-3', false);
+
+CREATE TABLE hook_events (id INTEGER, session_id VARCHAR, hook_name VARCHAR, event_type VARCHAR, fired_at TIMESTAMP, duration_ms INTEGER, output_preview VARCHAR);
+CREATE TABLE errors (id INTEGER, session_id VARCHAR, source VARCHAR, error_text VARCHAR, context VARCHAR, logged_at TIMESTAMP);
+CREATE TABLE sessions (session_id VARCHAR, project VARCHAR, started_at TIMESTAMP, ended_at TIMESTAMP, model VARCHAR);
+"
+  out <- run_sql(setup_sql, sql_file())
+  expect_false(is.null(out), label = "duckdb returned NULL")
+
+  combined <- paste(out, collapse = "\n")
+  # stuck_loop MUST appear in the summary
+  expect_true(
+    grepl("stuck_loop", combined),
+    label = "stuck_loop finding NOT triggered by genuinely stuck running agents"
+  )
+})
+
+test_that("stuck_loop NOT triggered by running agents started < 1 hour ago (in-flight)", {
+  # Agents that are still running but started recently are in-flight, not stuck.
+  skip_if(duckdb_cmd()$type == "none", "duckdb not available")
+  skip_if_not(file.exists(sql_file()), "self_review_stage1.sql not found")
+
+  setup_sql <- "
+CREATE TABLE agent_runs (
+    id          INTEGER,
+    session_id  VARCHAR,
+    agent_type  VARCHAR,
+    model       VARCHAR,
+    started_at  TIMESTAMP,
+    ended_at    TIMESTAMP,
+    duration_sec DOUBLE,
+    prompt_preview VARCHAR,
+    status      VARCHAR,
+    tool_use_id VARCHAR,
+    backfilled  BOOLEAN
+);
+-- Three 'running' agents started within the last 30 minutes — in-flight.
+INSERT INTO agent_runs VALUES
+  (1, 'sess-inf-001', 'fixer', 'sonnet', now() - INTERVAL '30' MINUTE, NULL, NULL, 'task A', 'running', 'tool-1', false),
+  (2, 'sess-inf-001', 'fixer', 'sonnet', now() - INTERVAL '20' MINUTE, NULL, NULL, 'task B', 'running', 'tool-2', false),
+  (3, 'sess-inf-001', 'fixer', 'sonnet', now() - INTERVAL '10' MINUTE, NULL, NULL, 'task C', 'running', 'tool-3', false);
+
+CREATE TABLE hook_events (id INTEGER, session_id VARCHAR, hook_name VARCHAR, event_type VARCHAR, fired_at TIMESTAMP, duration_ms INTEGER, output_preview VARCHAR);
+CREATE TABLE errors (id INTEGER, session_id VARCHAR, source VARCHAR, error_text VARCHAR, context VARCHAR, logged_at TIMESTAMP);
+CREATE TABLE sessions (session_id VARCHAR, project VARCHAR, started_at TIMESTAMP, ended_at TIMESTAMP, model VARCHAR);
+"
+  out <- run_sql(setup_sql, sql_file())
+  expect_false(is.null(out), label = "duckdb returned NULL")
+
+  combined <- paste(out, collapse = "\n")
+  expect_false(
+    grepl("stuck_loop", combined),
+    label = "stuck_loop triggered by in-flight agents (started < 1h ago)"
+  )
+})
+
+# ── Detector 3: high_tool_error_rate ─────────────────────────────────────────
+
+test_that("high_tool_error_rate FALSE POSITIVE: old errors outside 7-day window do NOT trigger (#269)", {
+  # Regression: a single error logged 6+ weeks ago produced a 100% error rate
+  # finding indefinitely because the query had no time window.
+  skip_if(duckdb_cmd()$type == "none", "duckdb not available")
+  skip_if_not(file.exists(sql_file()), "self_review_stage1.sql not found")
+
+  setup_sql <- "
+CREATE TABLE agent_runs (
+    id          INTEGER,
+    session_id  VARCHAR,
+    agent_type  VARCHAR,
+    model       VARCHAR,
+    started_at  TIMESTAMP,
+    ended_at    TIMESTAMP,
+    duration_sec DOUBLE,
+    prompt_preview VARCHAR,
+    status      VARCHAR,
+    tool_use_id VARCHAR,
+    backfilled  BOOLEAN
+);
+-- One old agent run (40 days ago) to match the old error row
+INSERT INTO agent_runs VALUES
+  (1, 'sess-old-001', 'fixer', 'sonnet', now() - INTERVAL '40' DAY, now() - INTERVAL '40' DAY + INTERVAL '1' HOUR, 3600.0, 'old task', 'done', 'tool-old', false);
+
+CREATE TABLE hook_events (id INTEGER, session_id VARCHAR, hook_name VARCHAR, event_type VARCHAR, fired_at TIMESTAMP, duration_ms INTEGER, output_preview VARCHAR);
+
+CREATE TABLE errors (id INTEGER, session_id VARCHAR, source VARCHAR, error_text VARCHAR, context VARCHAR, logged_at TIMESTAMP);
+-- One error 40 days old — outside the 7-day window.
+-- In the original query this produced 1/1 = 100% error rate finding.
+INSERT INTO errors VALUES
+  (1, 'sess-old-001', 'signal_notes', 'old error', '{}', now() - INTERVAL '40' DAY);
+
+CREATE TABLE sessions (session_id VARCHAR, project VARCHAR, started_at TIMESTAMP, ended_at TIMESTAMP, model VARCHAR);
+"
+  out <- run_sql(setup_sql, sql_file())
+  expect_false(is.null(out), label = "duckdb returned NULL")
+
+  combined <- paste(out, collapse = "\n")
+  expect_false(
+    grepl("high_tool_error_rate", combined),
+    label = "high_tool_error_rate triggered by error outside 7-day window — false positive not fixed"
+  )
+})
+
+test_that("high_tool_error_rate TRUE POSITIVE: recent high error rate DOES trigger detector", {
+  # A tool with a genuine high error rate in the last 7 days must still fire.
+  skip_if(duckdb_cmd()$type == "none", "duckdb not available")
+  skip_if_not(file.exists(sql_file()), "self_review_stage1.sql not found")
+
+  setup_sql <- "
+CREATE TABLE agent_runs (
+    id          INTEGER,
+    session_id  VARCHAR,
+    agent_type  VARCHAR,
+    model       VARCHAR,
+    started_at  TIMESTAMP,
+    ended_at    TIMESTAMP,
+    duration_sec DOUBLE,
+    prompt_preview VARCHAR,
+    status      VARCHAR,
+    tool_use_id VARCHAR,
+    backfilled  BOOLEAN
+);
+-- 2 recent agent calls today
+INSERT INTO agent_runs VALUES
+  (1, 'sess-rate-001', 'fixer', 'sonnet', now() - INTERVAL '2' HOUR, now() - INTERVAL '1' HOUR, 3600.0, 'task', 'done', 'tool-a', false),
+  (2, 'sess-rate-001', 'fixer', 'sonnet', now() - INTERVAL '1' HOUR, now(),                    3600.0, 'task', 'done', 'tool-b', false);
+
+CREATE TABLE hook_events (id INTEGER, session_id VARCHAR, hook_name VARCHAR, event_type VARCHAR, fired_at TIMESTAMP, duration_ms INTEGER, output_preview VARCHAR);
+
+CREATE TABLE errors (id INTEGER, session_id VARCHAR, source VARCHAR, error_text VARCHAR, context VARCHAR, logged_at TIMESTAMP);
+-- 2 errors from the same tool today — 2 errors / 2 calls = 100% error rate (> 20% threshold)
+INSERT INTO errors VALUES
+  (1, 'sess-rate-001', 'bad_tool', 'error 1', '{}', now() - INTERVAL '2' HOUR),
+  (2, 'sess-rate-001', 'bad_tool', 'error 2', '{}', now() - INTERVAL '1' HOUR);
+
+CREATE TABLE sessions (session_id VARCHAR, project VARCHAR, started_at TIMESTAMP, ended_at TIMESTAMP, model VARCHAR);
+"
+  out <- run_sql(setup_sql, sql_file())
+  expect_false(is.null(out), label = "duckdb returned NULL")
+
+  combined <- paste(out, collapse = "\n")
+  expect_true(
+    grepl("high_tool_error_rate", combined),
+    label = "high_tool_error_rate NOT triggered by recent high error rate — genuine positive lost"
+  )
+})
+
+# ── Shell syntax check ────────────────────────────────────────────────────────
+
+test_that("self_review_stage1.sh passes bash -n syntax check", {
+  sh <- normalizePath(
+    file.path(repo_root(), ".claude", "scripts", "self_review_stage1.sh"),
+    mustWork = FALSE
+  )
+  skip_if_not(file.exists(sh), "self_review_stage1.sh not found")
+  exit_code <- system2("bash", args = c("-n", sh), stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L, info = "self_review_stage1.sh has bash syntax errors")
+})
+
+test_that("self_review_stage1.sql exists and is non-empty", {
+  f <- sql_file()
+  expect_true(file.exists(f), info = "self_review_stage1.sql not found")
+  lines <- readLines(f, warn = FALSE)
+  expect_gt(length(lines), 10L, label = "SQL file appears empty")
+})
+
+test_that("self_review_stage1.sql contains rate-window predicate for errors (#269)", {
+  f <- sql_file()
+  skip_if_not(file.exists(f), "self_review_stage1.sql not found")
+  sql_text <- paste(readLines(f, warn = FALSE), collapse = "\n")
+  # The fix must include a time-bounded WHERE clause on the errors table.
+  expect_true(
+    grepl("INTERVAL.*DAY", sql_text, ignore.case = TRUE),
+    info = "No INTERVAL DAY predicate found in SQL — rate-window fix (#269) may be missing"
+  )
+})
+
+test_that("self_review_stage1.sql stuck_loop detector filters on status='running' (#269)", {
+  f <- sql_file()
+  skip_if_not(file.exists(f), "self_review_stage1.sql not found")
+  sql_text <- paste(readLines(f, warn = FALSE), collapse = "\n")
+  # The fix must filter on status = 'running'
+  expect_true(
+    grepl("status\\s*=\\s*'running'", sql_text, ignore.case = FALSE),
+    info = "stuck_loop detector does not filter on status='running' — fix (#269) may be missing"
+  )
+  # And also require ended_at IS NULL
+  expect_true(
+    grepl("ended_at\\s+IS\\s+NULL", sql_text, ignore.case = TRUE),
+    info = "stuck_loop detector does not check ended_at IS NULL — fix (#269) may be missing"
+  )
+})


### PR DESCRIPTION
## Summary

Fixes two false-positive patterns identified in #269 for the Stage 1 self-review SQL detectors.

### Detector 1: stuck_loop — unreachable status filter fixed

**Problem:** The original query had no `status` filter, so it matched all `(session_id, agent_type, status)` groups with ≥3 rows — including sessions where the same agent type was legitimately dispatched multiple times (e.g., three `fixer` agents on different tasks, all with `status='done'`). The comments referenced `status='failed'` but that value never appears in the ETL because `ended_at` is never written back for completed agents.

**Fix:** Filter to only agents that are genuinely stuck: `status = 'running' AND ended_at IS NULL AND started_at < NOW() - 1 HOUR`. Completed agents (`status='done'`) are never stuck by definition. In-flight agents (started < 1 hour ago) are excluded to avoid false positives during active sessions.

### Detector 3: high_tool_error_rate — rate-window added

**Problem:** Both the `errors` and `agent_runs` CTEs had no time bound. A single error on 2026-04-20 (`signal_notes`, 1 error / 1 agent call = 100%) generated a permanent `major` finding on every run — months after the event.

**Fix:** Added `logged_at >= current_timestamp - INTERVAL '7' DAY` and `started_at >= current_timestamp - INTERVAL '7' DAY` to bound both CTEs to a rolling 7-day window.

### Before / After finding counts (live `unified.duckdb`)

| Detector | Before (OLD SQL) | After (NEW SQL) |
|---|---|---|
| stuck_loop candidates on live data | 9 rows (all status='done') | 0 rows |
| high_tool_error_rate candidates | 1 row (2026-04-20, 40 days old) | 0 rows |
| Total findings in DB (cumulative) | 9 (all false positives) | 0 new findings inserted |

### Tests added

`tests/testthat/test-self-review-stage1.R` — 16 tests:
- False-positive fixtures that WOULD have triggered the old query assert NO finding
- Genuine positive fixtures (stuck running agents, recent high error rate) assert finding DOES fire
- Static assertions that the SQL contains the required predicates (`status='running'`, `ended_at IS NULL`, `INTERVAL DAY`)

All 16 tests pass (`[ FAIL 0 | WARN 0 | SKIP 0 | PASS 16 ]`).

## Test plan

- [x] `tests/testthat/test-self-review-stage1.R` — all 16 pass
- [x] `bash -n .claude/scripts/self_review_stage1.sh` — syntax OK
- [x] New SQL verified against live `unified.duckdb` — 0 new false positives inserted

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
