### PR TITLE
feat(roborev): post-merge hook + business-hours poller (#217 Phase 2+3)

### DIFF
--- a/.claude/launchd/com.claude.roborev-poll-merges.plist
+++ b/.claude/launchd/com.claude.roborev-poll-merges.plist
@@ -9,9 +9,12 @@
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_poll_merges.sh</string>
         <string>--apply</string>
     </array>
+    <!-- Business-hours restriction: weekdays 09:00–21:00 only (13 runs/day × 5 days = 65 entries).
+         Reduced from prior 09-22 window to 09-21 per #217 Phase 2.
+         Phase 4 (full removal) deferred pending 7-day soak after post-merge hook rollout. -->
     <key>StartCalendarInterval</key>
     <array>
-        <!-- Monday 09-22 -->
+        <!-- Monday 09-21 -->
         <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>11</integer><key>Minute</key><integer>0</integer></dict>
@@ -25,8 +28,7 @@
         <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>19</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>20</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
-        <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
-        <!-- Tuesday 09-22 -->
+        <!-- Tuesday 09-21 -->
         <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>11</integer><key>Minute</key><integer>0</integer></dict>
@@ -40,8 +42,7 @@
         <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>19</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>20</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
-        <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
-        <!-- Wednesday 09-22 -->
+        <!-- Wednesday 09-21 -->
         <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>11</integer><key>Minute</key><integer>0</integer></dict>
@@ -55,8 +56,7 @@
         <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>19</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>20</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
-        <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
-        <!-- Thursday 09-22 -->
+        <!-- Thursday 09-21 -->
         <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>11</integer><key>Minute</key><integer>0</integer></dict>
@@ -70,8 +70,7 @@
         <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>19</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>20</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
-        <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
-        <!-- Friday 09-22 -->
+        <!-- Friday 09-21 -->
         <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>11</integer><key>Minute</key><integer>0</integer></dict>
@@ -85,8 +84,12 @@
         <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>19</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>20</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
-        <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
     </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/johngavin/.nvm/versions/node/v24.13.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
     <!--
       StandardInPath=/dev/null prevents SIGTTIN/SIGTTOU stopping the process
       (state T) when bash's process substitution < <(...) opens a pipe under

--- a/bin/roborev_install_post_merge_hook.sh
+++ b/bin/roborev_install_post_merge_hook.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# roborev_install_post_merge_hook.sh <repo-path>
+#
+# Installs a post-merge git hook that triggers roborev review on the
+# merged-in commits.  The hook runs `roborev review --since ORIG_HEAD`
+# which reviews all commits between the pre-merge HEAD (exclusive) and
+# the current HEAD (inclusive) — exactly the commits the merge brought in.
+#
+# Idempotent: re-running on a repo that already has our hook refreshes
+# the marker comment but otherwise changes nothing.
+#
+# Safety: refuses to overwrite an UNRECOGNISED existing post-merge hook
+# (one that lacks the installer marker comment).  Prints a warning and
+# exits 0 so the all-repos wrapper can continue.
+#
+# Usage:
+#   bin/roborev_install_post_merge_hook.sh /path/to/repo
+#
+# Part of: llm#217 Phase 3 — post-merge hook installer
+# Installed-by marker (must stay on line ~14 for idempotency detection):
+#   Installed by ~/docs_gh/llm/bin/roborev_install_post_merge_hook.sh
+
+set -uo pipefail
+
+INSTALLER_MARKER="Installed by ~/docs_gh/llm/bin/roborev_install_post_merge_hook.sh"
+
+usage() {
+    echo "Usage: $0 <repo-path>" >&2
+    echo "  repo-path: path to a git working tree" >&2
+    exit 1
+}
+
+# ── Argument validation ──────────────────────────────────────────────────────
+if [[ $# -ne 1 ]]; then
+    usage
+fi
+
+REPO_PATH="$1"
+
+if [[ ! -d "${REPO_PATH}/.git" ]]; then
+    echo "ERROR: not a git repository (no .git/ directory): ${REPO_PATH}" >&2
+    exit 1
+fi
+
+HOOKS_DIR="${REPO_PATH}/.git/hooks"
+HOOK_FILE="${HOOKS_DIR}/post-merge"
+
+# ── Check for unrecognised existing hook ────────────────────────────────────
+if [[ -f "${HOOK_FILE}" ]]; then
+    if grep -qF "${INSTALLER_MARKER}" "${HOOK_FILE}" 2>/dev/null; then
+        : # our hook — safe to overwrite / refresh
+    else
+        echo "SKIP: ${REPO_PATH} — existing post-merge hook not written by this installer." >&2
+        echo "      Inspect ${HOOK_FILE} manually if you want to replace it." >&2
+        exit 0
+    fi
+fi
+
+# ── Write the hook ───────────────────────────────────────────────────────────
+cat > "${HOOK_FILE}" <<'HOOK'
+#!/usr/bin/env bash
+# Installed by ~/docs_gh/llm/bin/roborev_install_post_merge_hook.sh
+# Triggers a roborev review on the commits brought in by the merge.
+# ORIG_HEAD is set automatically by git to the pre-merge HEAD SHA.
+# `roborev review --since ORIG_HEAD` reviews all commits between
+# ORIG_HEAD (exclusive) and HEAD (inclusive) — i.e. exactly the merged commits.
+set -uo pipefail
+if ! command -v roborev > /dev/null 2>&1; then exit 0; fi
+roborev review --since "${1:-ORIG_HEAD}" --quiet > /dev/null 2>&1 || true
+HOOK
+
+chmod +x "${HOOK_FILE}"
+
+echo "OK: installed post-merge hook in ${REPO_PATH}"

--- a/bin/roborev_install_post_merge_hook_all.sh
+++ b/bin/roborev_install_post_merge_hook_all.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# roborev_install_post_merge_hook_all.sh
+#
+# Wrapper: iterates ~/docs_gh/* looking for git repositories and calls
+# roborev_install_post_merge_hook.sh on each one.
+#
+# Summary line printed at the end: installed=N skipped=M failed=K
+#
+# Usage:
+#   bin/roborev_install_post_merge_hook_all.sh
+#
+# Part of: llm#217 Phase 3 — all-repos post-merge hook installer wrapper
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="${SCRIPT_DIR}/roborev_install_post_merge_hook.sh"
+
+if [[ ! -x "${INSTALLER}" ]]; then
+    echo "ERROR: installer not found or not executable: ${INSTALLER}" >&2
+    exit 1
+fi
+
+DOCS_DIR="${HOME}/docs_gh"
+
+if [[ ! -d "${DOCS_DIR}" ]]; then
+    echo "ERROR: ${DOCS_DIR} not found" >&2
+    exit 1
+fi
+
+installed=0
+skipped=0
+failed=0
+
+for candidate in "${DOCS_DIR}"/*/; do
+    # Strip trailing slash for display
+    repo="${candidate%/}"
+    if [[ ! -d "${repo}/.git" ]]; then
+        continue
+    fi
+    output="$("${INSTALLER}" "${repo}" 2>&1)"
+    exit_code=$?
+    if [[ ${exit_code} -ne 0 ]]; then
+        echo "FAILED: ${repo} — ${output}" >&2
+        (( failed += 1 ))
+    elif echo "${output}" | grep -q "^SKIP:"; then
+        echo "${output}"
+        (( skipped += 1 ))
+    else
+        echo "${output}"
+        (( installed += 1 ))
+    fi
+done
+
+echo ""
+echo "Summary: installed=${installed} skipped=${skipped} failed=${failed}"

--- a/tests/test_roborev_post_merge_hook.sh
+++ b/tests/test_roborev_post_merge_hook.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# tests/test_roborev_post_merge_hook.sh
+#
+# Unit tests for bin/roborev_install_post_merge_hook.sh
+#
+# Uses a synthetic temp git-repo fixture.
+# Exits 0 if all tests pass, 1 on any failure.
+#
+# Part of: llm#217 Phase 3 — post-merge hook installer tests
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="${SCRIPT_DIR}/../bin/roborev_install_post_merge_hook.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT="$(mktemp -d)"
+
+# Cleanup on exit
+cleanup() { rm -rf "${TMPDIR_ROOT}"; }
+trap cleanup EXIT
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+pass() { echo "PASS: $1"; (( PASS += 1 )); }
+fail() { echo "FAIL: $1"; (( FAIL += 1 )); }
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "${expected}" == "${actual}" ]]; then
+        pass "${desc}"
+    else
+        fail "${desc} — expected='${expected}' actual='${actual}'"
+    fi
+}
+
+assert_true() {
+    local desc="$1"
+    if eval "$2"; then
+        pass "${desc}"
+    else
+        fail "${desc}"
+    fi
+}
+
+assert_false() {
+    local desc="$1"
+    if ! eval "$2"; then
+        pass "${desc}"
+    else
+        fail "${desc}"
+    fi
+}
+
+make_git_repo() {
+    local dir
+    dir="$(mktemp -d "${TMPDIR_ROOT}/repo_XXXX")"
+    git -C "${dir}" init -q
+    git -C "${dir}" config user.email "test@test.local"
+    git -C "${dir}" config user.name "Test"
+    echo > "${dir}/README"
+    git -C "${dir}" add README
+    git -C "${dir}" commit -qm "init"
+    echo "${dir}"
+}
+
+# ── Test 1: Fresh repo gets hook installed + chmod +x ────────────────────────
+REPO1="$(make_git_repo)"
+output1="$("${INSTALLER}" "${REPO1}" 2>&1)"
+exit1=$?
+
+assert_eq "test1: exit code 0 on fresh install" "0" "${exit1}"
+assert_true "test1: post-merge hook file created" "[[ -f '${REPO1}/.git/hooks/post-merge' ]]"
+assert_true "test1: post-merge hook is executable" "[[ -x '${REPO1}/.git/hooks/post-merge' ]]"
+
+# ── Test 2: Re-run on same repo is idempotent ────────────────────────────────
+mtime_before="$(stat -f '%m' "${REPO1}/.git/hooks/post-merge" 2>/dev/null || stat -c '%Y' "${REPO1}/.git/hooks/post-merge")"
+sleep 1
+"${INSTALLER}" "${REPO1}" > /dev/null 2>&1
+exit2=$?
+mtime_after="$(stat -f '%m' "${REPO1}/.git/hooks/post-merge" 2>/dev/null || stat -c '%Y' "${REPO1}/.git/hooks/post-merge")"
+
+assert_eq "test2: idempotent re-run exits 0" "0" "${exit2}"
+assert_true "test2: hook still exists after re-run" "[[ -f '${REPO1}/.git/hooks/post-merge' ]]"
+assert_true "test2: hook still executable after re-run" "[[ -x '${REPO1}/.git/hooks/post-merge' ]]"
+
+# ── Test 3: Unrecognised existing post-merge hook is skipped, not overwritten ─
+REPO3="$(make_git_repo)"
+FOREIGN_HOOK="${REPO3}/.git/hooks/post-merge"
+cat > "${FOREIGN_HOOK}" <<'EOF'
+#!/usr/bin/env bash
+# Custom hook not written by our installer
+echo "custom hook"
+EOF
+chmod +x "${FOREIGN_HOOK}"
+original_content="$(cat "${FOREIGN_HOOK}")"
+
+output3="$("${INSTALLER}" "${REPO3}" 2>&1)"
+exit3=$?
+current_content="$(cat "${FOREIGN_HOOK}")"
+
+assert_eq "test3: skip exits 0 (non-blocking)" "0" "${exit3}"
+assert_true "test3: skip message printed" "echo '${output3}' | grep -q 'SKIP:'"
+assert_eq "test3: foreign hook not overwritten" "${original_content}" "${current_content}"
+
+# ── Test 4: Hook content has marker comment ──────────────────────────────────
+REPO4="$(make_git_repo)"
+"${INSTALLER}" "${REPO4}" > /dev/null 2>&1
+MARKER="Installed by ~/docs_gh/llm/bin/roborev_install_post_merge_hook.sh"
+
+assert_true "test4: marker comment present in hook" "grep -qF '${MARKER}' '${REPO4}/.git/hooks/post-merge'"
+
+# ── Test 5: Hook content has roborev-availability guard ─────────────────────
+assert_true "test5: availability guard present" "grep -q 'command -v roborev' '${REPO4}/.git/hooks/post-merge'"
+
+# ── Test 6: Generated hook parses cleanly under bash -n ─────────────────────
+bash_n_output="$(bash -n "${REPO4}/.git/hooks/post-merge" 2>&1)"
+bash_n_exit=$?
+
+assert_eq "test6: bash -n exits 0 (hook syntax valid)" "0" "${bash_n_exit}"
+
+# ── Test 7: Non-git directory is rejected with exit 1 ───────────────────────
+NOTGIT="$(mktemp -d "${TMPDIR_ROOT}/notgit_XXXX")"
+"${INSTALLER}" "${NOTGIT}" > /dev/null 2>&1
+exit_notgit=$?
+assert_eq "test7: non-git dir exits non-zero" "1" "${exit_notgit}"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${PASS} PASS, ${FAIL} FAIL"
+
+if [[ ${FAIL} -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes part of #217 (Phase 2 + Phase 3).  Phase 4 (delete the launchd job) deferred pending 7-day post-merge hook soak.

## Summary

### Phase 2 — poller restricted to business hours

- `.claude/launchd/com.claude.roborev-poll-merges.plist`: replaced the prior 09–22 window (14 entries/day) with **09:00–21:00 weekdays-only** (13 entries/day × 5 days = **65 `StartCalendarInterval` entries**).  The job no longer fires outside working hours or on weekends.
- Added `EnvironmentVariables` → `PATH` (mirrors `com.claude.roborev-agent-health.plist`) so the wrapped script can locate `roborev`, `git`, `python3`, and `sqlite3` at runtime.
- `StandardInPath = /dev/null` preserved from PR #342 fix (prevents state-T under bash 3.2 / launchd).
- `plutil -lint` passes.

### Phase 3 — per-repo and all-repos post-merge hook installers

**`bin/roborev_install_post_merge_hook.sh <repo-path>`**

Writes `.git/hooks/post-merge` into the target repo with this content:

```bash
#!/usr/bin/env bash
# Installed by ~/docs_gh/llm/bin/roborev_install_post_merge_hook.sh
set -uo pipefail
if ! command -v roborev > /dev/null 2>&1; then exit 0; fi
roborev review --since "${1:-ORIG_HEAD}" --quiet > /dev/null 2>&1 || true
```

- `--since ORIG_HEAD` is the chosen flag: reviews all commits between the pre-merge HEAD (exclusive) and the current HEAD (inclusive) — exactly the commits brought in by `git pull` / `git merge`.  Evidence: `roborev review --help` confirms `--since <commit>` reviews "commits since this commit (exclusive)".
- Idempotent: re-running on an already-installed repo refreshes the marker comment without changing behaviour.
- Safety: if a repo already has a post-merge hook **not written by this installer** (no marker comment), the script prints `SKIP:` and exits 0 — the foreign hook is never overwritten.
- Exits 1 if the path is not a git repo.

**`bin/roborev_install_post_merge_hook_all.sh`**

Iterates `~/docs_gh/*`, finds git repos, calls the per-repo installer on each, and prints a summary line: `installed=N skipped=M failed=K`.

### Tests — `tests/test_roborev_post_merge_hook.sh`

7 scenarios / 13 assertions — all PASS:

| # | Scenario |
|---|---|
| 1 | Fresh repo: hook file created, chmod +x |
| 2 | Re-run on same repo: idempotent, still executable |
| 3 | Unrecognised existing hook: skip message printed, content unchanged |
| 4 | Hook content contains marker comment |
| 5 | Hook content has roborev-availability guard |
| 6 | `bash -n` on generated hook: syntax valid |
| 7 | Non-git directory: exits 1 |

### Phase 4 decision (deliberately NOT in this PR)

Deleting the launchd job requires a 7-day soak after the post-merge hook is installed across repos to confirm it captures all merge events before the fallback poller is removed.  Phase 4 tracked in #217.

## Activation

```bash
# Install hook in all ~/docs_gh/* repos at once:
bash bin/roborev_install_post_merge_hook_all.sh

# Or per-repo:
bash bin/roborev_install_post_merge_hook.sh ~/docs_gh/llm

# After Phase 4 soak, reload the plist:
launchctl unload ~/Library/LaunchAgents/com.claude.roborev-poll-merges.plist
launchctl load  ~/Library/LaunchAgents/com.claude.roborev-poll-merges.plist
```

## Test plan

- [ ] `plutil -lint .claude/launchd/com.claude.roborev-poll-merges.plist` → OK
- [ ] `bash -n bin/roborev_install_post_merge_hook.sh` → silent
- [ ] `bash -n bin/roborev_install_post_merge_hook_all.sh` → silent
- [ ] `bash tests/test_roborev_post_merge_hook.sh` → 13 PASS, 0 FAIL
- [ ] Manual: `bash bin/roborev_install_post_merge_hook_all.sh` on local machine → check `installed=` count
- [ ] Manual: `git pull` in any installed repo → confirm roborev job enqueued in `reviews.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
