### PR TITLE
feat(roborev): merge-gate pilot HIGH (#241)

### DIFF
--- a/.claude/rules/roborev-resolution.md
+++ b/.claude/rules/roborev-resolution.md
@@ -471,13 +471,57 @@ Set `SKIP_MERGE_GATE=1` in your shell environment to bypass the gate in dry-run 
 (the gate script exits 0 immediately). For enforce mode the kill switch is simply
 not invoking `--enforce`.
 
+## Merge-gate policy (#241, pilot HIGH)
+
+> No PR merges to `main` while any related roborev finding at severity ≥ `review_min_severity`
+> (currently `High` in the pilot) is `closed=0` AND not cited by a `closes roborev #N`
+> (or `acks roborev #N --reason …`) line in the PR's commits.
+
+### Definitions
+
+| Term | Meaning |
+|------|---------|
+| **Related** | A roborev review whose `commit_sha` is in `git log origin/main..<head>` (commit-scope, Alternative C from #241 — tightest scope, avoids day-1 backlog freeze) |
+| **Resolved** | `closed=1` in `~/.roborev/reviews.db` AND has a commit message citing it — OR — an explicit `acks roborev #N --reason "…"` commit |
+| **Threshold** | Pilot: `High` (enforced by `bin/roborev_merge_gate.sh`). Per-repo override via `.roborev.toml` `review_min_severity` in Phase 3. |
+| **Acked** | Waiver written to `~/.roborev/acks.jsonl` via `roborev_ack.sh --apply` with a written reason. Does NOT close the finding; closure is via fix-commit + auto-verifier (#163). |
+
+### Pilot escalation path
+
+1. **Pilot (now):** `bin/roborev_merge_gate.sh` enforces HIGH only. Run before every merge.
+2. **After 1 week of signal:** review `~/.claude/logs/merge_gate.log`. If block rate is low, escalate threshold to MEDIUM.
+3. **Phase 3 (per-repo):** read threshold from `.roborev.toml` `review_min_severity` instead of hardcoded High. Different projects can set different thresholds.
+
+### Local invocation
+
+```bash
+# Check before merging PR #253
+bin/roborev_merge_gate.sh 253
+
+# With explicit severity threshold
+bin/roborev_merge_gate.sh --min-severity High 253
+
+# JSON output (for scripting)
+bin/roborev_merge_gate.sh --json 253
+
+# Explicit repo (when not in a git checkout)
+bin/roborev_merge_gate.sh --repo JohnGavin/llm 253
+```
+
+Exit codes: `0` = PASS (no unresolved findings), `1` = BLOCK (unresolved findings found).
+
+The `bin/` script exits 1 on block (enforcing mode). The predecessor
+`~/.claude/scripts/roborev_merge_gate.sh` is dry-run only (always exits 0) and
+is kept for week-1 signal logging. See that script's header for `--dry-run` /
+`--enforce` flags.
+
 ## Related
 
 - `auto-delegation` — model selection for Claude Code agents (separate from roborev agents)
 - `btw-timeouts` — MCP tool timeout pattern (similar "bounded execution" principle)
 - `orchestrator-protocol` — background agent timeout protocol
 - llm#110 — tracking issue
-- llm#241 — merge gate policy (Merge Gate section above)
+- llm#241 — merge gate policy (Merge Gate sections above)
 - llm#163 — closure-loop automation (Auto-Verifier section above — Component 4, Slice 3)
 - llm#224 — severity autoclose (sibling policy)
 - llm#217 — poller schedule + ephemeral-repos cleanup

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,10 +14,9 @@
 - [ ] SELFTEST=1 passes for any new `.claude/scripts/*.sh`
 - [ ] `devtools::test()` passes (if R package code changed)
 
-## roborev checklist
+## Reviewer checklist
 
-- [ ] `roborev_merge_gate.sh <pr#>` ran — no unresolved High/Critical findings on PR commits
-  (run: `~/.claude/scripts/roborev_merge_gate.sh <pr#>`)
+- [ ] All related roborev findings ≥ HIGH severity are either closed (cited as `closes roborev #N`) or acked (`acks roborev #N --reason "…"`). See `bin/roborev_merge_gate.sh <pr#>`.
 
 ## Notes
 

--- a/bin/roborev_merge_gate.sh
+++ b/bin/roborev_merge_gate.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+# bin/roborev_merge_gate.sh — merge-gate: block PR merges with open roborev
+# findings >= min-severity threshold (default: High, pilot scope).
+#
+# Usage:
+#   bin/roborev_merge_gate.sh <pr#>
+#   bin/roborev_merge_gate.sh --repo OWNER/NAME <pr#>
+#   bin/roborev_merge_gate.sh --min-severity {Critical,High,Medium,Low} <pr#>
+#   bin/roborev_merge_gate.sh --json <pr#>
+#
+# Exit codes:
+#   0   All related findings >= threshold are cited or acked  (PASS)
+#   1   One or more unresolved findings >= threshold          (BLOCK)
+#   2   Usage error
+#
+# "Related" definition: commit_sha IN PR commits (commit-scope, Alternative C
+# from llm#241).  This is the tightest scope and avoids the day-1 backlog freeze.
+#
+# Severity is parsed from the review output text: "**Severity**: High" regex.
+# This mirrors roborev_severity_autoclose.sh (llm#224).
+#
+# Citation patterns recognised in PR commit messages (case-insensitive):
+#   closes roborev #N
+#   close roborev #N
+#   fixes roborev #N
+#   fix roborev #N
+#   acks roborev #N
+#   ack roborev #N
+#   acks roborev #N --reason "…"
+# Also reads ~/.roborev/acks.jsonl (written by roborev_ack.sh).
+#
+# Pilot scope: --min-severity High (default).  Escalate to Medium after 1 week
+# of signal data (see llm#241 escalation path).
+#
+# Part of: JohnGavin/llm#241
+# Related:
+#   ~/.claude/scripts/roborev_merge_gate.sh  — dry-run predecessor (keep as-is)
+#   .claude/rules/roborev-resolution.md      — policy documentation
+#   .github/PULL_REQUEST_TEMPLATE.md         — checklist row
+#   tests/test_roborev_merge_gate.sh         — test suite
+
+set -euo pipefail
+
+# ── Tool paths (survive launchd bare PATH) ───────────────────────────────────
+export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+PYTHON="${PYTHON:-/usr/bin/python3}"
+GH="${GH:-/usr/local/bin/gh}"
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+ROBOREV_DB="${ROBOREV_DB:-$HOME/.roborev/reviews.db}"
+ACKS_JSONL="${ACKS_JSONL:-$HOME/.roborev/acks.jsonl}"
+DEFAULT_MIN_SEVERITY="High"
+EMIT_JSON=0
+REPO=""    # auto-detected from gh repo view if not provided
+
+# ── Severity ordering ─────────────────────────────────────────────────────────
+# Python helper used in multiple places; defined once as a heredoc constant.
+_SEV_PY='
+SEV_ORDER = ["low", "medium", "high", "critical"]
+
+def sev_idx(s):
+    s = (s or "").strip().lower()
+    try:
+        return SEV_ORDER.index(s)
+    except ValueError:
+        return -1
+'
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  bin/roborev_merge_gate.sh [OPTIONS] <pr#>
+
+Options:
+  --repo OWNER/NAME          GitHub repo (default: current repo via gh)
+  --min-severity LEVEL       Threshold: Critical|High|Medium|Low (default: High)
+  --json                     Emit JSON result instead of table
+  -h, --help                 Show this message
+
+Exit codes:
+  0  PASS — no unresolved findings >= threshold
+  1  BLOCK — unresolved findings found
+  2  Usage error
+
+Pilot scope: High only.  Cite findings in commits with:
+  closes roborev #N   |   acks roborev #N --reason "…"
+See .claude/rules/roborev-resolution.md for full policy.
+USAGE
+}
+
+# Resolve OWNER/REPO from gh if not supplied.
+_resolve_repo() {
+  local repo="$1"
+  if [ -n "$repo" ]; then
+    echo "$repo"
+    return 0
+  fi
+  "$GH" repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo ""
+}
+
+# Fetch commit SHAs for a PR.
+_get_pr_commits() {
+  local pr_num="$1" repo="$2"
+  "$GH" pr view "$pr_num" --repo "$repo" \
+    --json commits --jq '.commits[].oid' 2>/dev/null || echo ""
+}
+
+# Query reviews.db for open findings on the given commit SHAs.
+# Severity is parsed from review output text ("**Severity**: High").
+# Returns JSON list: [{"id":N,"severity":"high","commit_sha":"abc","location":"...","problem":"..."}]
+_query_open_findings() {
+  local shas_newline="$1"   # newline-separated SHAs
+  local min_sev="$2"        # threshold string e.g. "high"
+  local db="$3"
+
+  [ -f "$db" ] || { echo "[]"; return 0; }
+  [ -z "$shas_newline" ] && { echo "[]"; return 0; }
+
+  "$PYTHON" - "$db" "$min_sev" <<PYEOF
+import sys, sqlite3, json, re
+
+db_path = sys.argv[1]
+min_sev  = sys.argv[2].strip().lower()
+
+${_SEV_PY}
+
+# Read SHAs from stdin (passed via heredoc below)
+shas_raw = """${shas_newline}"""
+shas = [s.strip() for s in shas_raw.splitlines() if s.strip()]
+
+if not shas:
+    print("[]")
+    sys.exit(0)
+
+min_idx = sev_idx(min_sev)
+
+try:
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    placeholders = ",".join("?" * len(shas))
+    rows = con.execute("""
+        SELECT r.id, r.output, c.sha
+        FROM reviews r
+        JOIN review_jobs rj ON r.job_id = rj.id
+        JOIN commits    c  ON rj.commit_id = c.id
+        WHERE c.sha IN ({ph})
+          AND r.closed = 0
+          AND r.verdict_bool = 0
+    """.format(ph=placeholders), shas).fetchall()
+    con.close()
+except Exception as e:
+    # Fail-open: DB error → pass gate
+    print("[]")
+    sys.exit(0)
+
+sev_re = re.compile(r"\*\*Severity\*\*:\s*(Critical|High|Medium|Low)", re.IGNORECASE)
+loc_re = re.compile(r"\*\*(?:Location|File)\*\*:\s*([^\n]+)", re.IGNORECASE)
+prb_re = re.compile(r"\*\*Problem\*\*:\s*([^\n]+)", re.IGNORECASE)
+
+results = []
+for (rid, output, sha) in rows:
+    output = output or ""
+    sevs = sev_re.findall(output)
+    if not sevs:
+        continue  # no parseable severity → skip (conservative: don't block on unparseable)
+    max_sev = max(sevs, key=lambda s: sev_idx(s))
+    if sev_idx(max_sev) < min_idx:
+        continue  # below threshold
+    loc_m   = loc_re.search(output)
+    prb_m   = prb_re.search(output)
+    location = loc_m.group(1).strip() if loc_m else "(location unknown)"
+    problem  = prb_m.group(1).strip()[:120] if prb_m else "(see review output)"
+    results.append({
+        "id":         rid,
+        "severity":   max_sev.capitalize(),
+        "commit_sha": sha[:12],
+        "location":   location,
+        "problem":    problem,
+    })
+
+print(json.dumps(results))
+PYEOF
+}
+
+# Parse "closes/acks/fixes roborev #N" from commit messages.
+# Returns a Python set literal encoded as JSON array of integers.
+_parse_citations() {
+  local shas_newline="$1"   # newline-separated SHAs
+
+  [ -z "$shas_newline" ] && { echo "[]"; return 0; }
+
+  # Collect commit messages
+  local all_msgs=""
+  while IFS= read -r sha; do
+    [ -z "$sha" ] && continue
+    local msg
+    msg=$(git log --format="%s%n%b" -1 "$sha" 2>/dev/null) || continue
+    all_msgs="${all_msgs}${msg}"$'\n'
+  done <<< "$shas_newline"
+
+  "$PYTHON" - "$all_msgs" <<'PYEOF'
+import sys, re, json
+text = sys.argv[1]
+pattern = re.compile(
+    r"(?:close[sd]?|fix(?:es)?|wontfix|acks?)\s+roborev\s*#(\d+)",
+    re.IGNORECASE
+)
+ids = [int(x) for x in pattern.findall(text)]
+print(json.dumps(sorted(set(ids))))
+PYEOF
+}
+
+# Parse acks.jsonl.  Returns JSON array of integers.
+_parse_acked_ids() {
+  local acks_file="$1"
+  [ -f "$acks_file" ] || { echo "[]"; return 0; }
+  "$PYTHON" - "$acks_file" <<'PYEOF'
+import sys, json
+acks_file = sys.argv[1]
+ids = []
+try:
+    with open(acks_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                v = obj.get("id", "")
+                if str(v).isdigit():
+                    ids.append(int(v))
+            except Exception:
+                continue
+except Exception:
+    pass
+print(json.dumps(sorted(set(ids))))
+PYEOF
+}
+
+# Print structured table of unresolved findings.
+_print_table() {
+  local findings_json="$1"
+  "$PYTHON" - "$findings_json" <<'PYEOF'
+import sys, json
+
+findings = json.loads(sys.argv[1])
+if not findings:
+    print("  (none)")
+    return
+
+# column widths
+hdr = ("ID", "Severity", "Commit", "Location", "Problem")
+rows = [(str(f["id"]), f["severity"], f["commit_sha"],
+         f["location"][:40], f["problem"][:60]) for f in findings]
+
+widths = [max(len(h), max(len(r[i]) for r in rows))
+          for i, h in enumerate(hdr)]
+fmt = "  {:<{w0}}  {:<{w1}}  {:<{w2}}  {:<{w3}}  {:<{w4}}"
+line = fmt.format(*hdr, w0=widths[0], w1=widths[1],
+                  w2=widths[2], w3=widths[3], w4=widths[4])
+print(line)
+print("  " + "-" * (sum(widths) + 8))
+for r in rows:
+    print(fmt.format(*r, w0=widths[0], w1=widths[1],
+                     w2=widths[2], w3=widths[3], w4=widths[4]))
+PYEOF
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+_main() {
+  local pr_num=""
+  local min_sev="$DEFAULT_MIN_SEVERITY"
+
+  # Parse arguments
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --repo)
+        REPO="$2"; shift 2 ;;
+      --min-severity)
+        min_sev="$2"; shift 2 ;;
+      --json)
+        EMIT_JSON=1; shift ;;
+      -h|--help)
+        _usage; exit 0 ;;
+      [0-9]*)
+        pr_num="$1"; shift ;;
+      *)
+        echo "ERROR: unknown argument: $1" >&2
+        _usage
+        exit 2 ;;
+    esac
+  done
+
+  if [ -z "$pr_num" ]; then
+    echo "ERROR: <pr#> is required" >&2
+    _usage
+    exit 2
+  fi
+
+  # Validate min-severity
+  case "${min_sev,,}" in
+    critical|high|medium|low) ;;
+    *)
+      echo "ERROR: --min-severity must be one of Critical|High|Medium|Low" >&2
+      exit 2 ;;
+  esac
+
+  # Resolve repo
+  local repo
+  repo=$(_resolve_repo "$REPO")
+  if [ -z "$repo" ]; then
+    # Fail-open: can't determine repo
+    echo "merge-gate: PASS (could not determine repo — fail-open)" >&2
+    exit 0
+  fi
+
+  # Fail-open: DB absent
+  if [ ! -f "$ROBOREV_DB" ]; then
+    if [ "$EMIT_JSON" = "1" ]; then
+      printf '{"verdict":"pass","reason":"db_absent","pr":%s,"unresolved":[]}\n' "$pr_num"
+    else
+      echo "merge-gate: PASS (reviews.db not found — fail-open)"
+    fi
+    exit 0
+  fi
+
+  # Fetch PR commits
+  local commit_shas
+  commit_shas=$(_get_pr_commits "$pr_num" "$repo")
+
+  if [ -z "$commit_shas" ]; then
+    if [ "$EMIT_JSON" = "1" ]; then
+      printf '{"verdict":"pass","reason":"no_commits","pr":%s,"unresolved":[]}\n' "$pr_num"
+    else
+      echo "merge-gate: PASS (no commits found for PR #${pr_num} — fail-open)"
+    fi
+    exit 0
+  fi
+
+  # Query open findings
+  local findings_json
+  findings_json=$(_query_open_findings "$commit_shas" "${min_sev,,}" "$ROBOREV_DB")
+
+  # Parse citations and acks
+  local cited_json acked_json
+  cited_json=$(_parse_citations "$commit_shas")
+  acked_json=$(_parse_acked_ids "$ACKS_JSONL")
+
+  # Compute unresolved = open - (cited ∪ acked)
+  local unresolved_json
+  unresolved_json=$("$PYTHON" - "$findings_json" "$cited_json" "$acked_json" <<'PYEOF'
+import sys, json
+
+findings = json.loads(sys.argv[1])
+cited    = set(json.loads(sys.argv[2]))
+acked    = set(json.loads(sys.argv[3]))
+resolved = cited | acked
+
+unresolved = [f for f in findings if f["id"] not in resolved]
+print(json.dumps(unresolved))
+PYEOF
+)
+
+  local unresolved_count
+  unresolved_count=$("$PYTHON" -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$unresolved_json")
+
+  if [ "$EMIT_JSON" = "1" ]; then
+    "$PYTHON" - "$pr_num" "$min_sev" "$unresolved_json" <<'PYEOF'
+import sys, json
+pr_num   = sys.argv[1]
+min_sev  = sys.argv[2]
+findings = json.loads(sys.argv[3])
+verdict  = "pass" if not findings else "block"
+print(json.dumps({
+    "verdict":       verdict,
+    "pr":            int(pr_num),
+    "min_severity":  min_sev,
+    "unresolved_count": len(findings),
+    "unresolved":    findings,
+}))
+PYEOF
+    [ "$unresolved_count" -eq 0 ] && exit 0 || exit 1
+  fi
+
+  if [ "$unresolved_count" -eq 0 ]; then
+    printf "merge-gate: PASS (no unresolved %s-severity findings)\n" "$min_sev"
+    exit 0
+  fi
+
+  # BLOCK path — print structured table
+  printf "merge-gate: BLOCK — %d unresolved finding(s) >= %s severity for PR #%s\n" \
+    "$unresolved_count" "$min_sev" "$pr_num"
+  echo ""
+  _print_table "$unresolved_json"
+  echo ""
+  echo "Resolve with one of:"
+  echo "  closes roborev #N       — in a commit message on this branch"
+  echo "  acks roborev #N --reason \"…\"   — explicit waiver"
+  echo ""
+  echo "See .claude/rules/roborev-resolution.md for policy."
+  exit 1
+}
+
+_main "$@"

--- a/tests/test_roborev_merge_gate.sh
+++ b/tests/test_roborev_merge_gate.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+# tests/test_roborev_merge_gate.sh
+#
+# Test suite for bin/roborev_merge_gate.sh
+#
+# Uses:
+#   - A synthetic SQLite fixture with reviews data
+#   - A mock `gh` wrapper that returns preset JSON
+#   - A mock git repo so commit-message parsing works
+#
+# Exits 0 if all tests pass, 1 on any failure.
+#
+# Tracked in JohnGavin/llm#241.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="${SCRIPT_DIR}/../bin/roborev_merge_gate.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT="$(mktemp -d /tmp/test_merge_gate_XXXXXX)"
+
+cleanup() { rm -rf "${TMPDIR_ROOT}"; }
+trap cleanup EXIT
+
+# ── Test helpers ─────────────────────────────────────────────────────────────
+
+pass() { echo "PASS: $1"; (( PASS += 1 )); }
+fail() { echo "FAIL: $1 — ${2:-}"; (( FAIL += 1 )); }
+
+assert_exit() {
+  local desc="$1" expected_exit="$2"
+  shift 2
+  local actual_exit=0
+  "$@" > /dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" = "$expected_exit" ]; then
+    pass "$desc"
+  else
+    fail "$desc" "expected exit=$expected_exit got exit=$actual_exit"
+  fi
+}
+
+assert_output_contains() {
+  local desc="$1" needle="$2"
+  shift 2
+  local out
+  out=$("$@" 2>&1) || true
+  if echo "$out" | grep -qF "$needle"; then
+    pass "$desc"
+  else
+    fail "$desc" "expected output to contain '${needle}' but got: $out"
+  fi
+}
+
+# ── Fixture builder ──────────────────────────────────────────────────────────
+
+# Creates a minimal SQLite DB at $1 with synthetic data.
+# Inserts:
+#   repo id=1, root_path=/tmp/fakerepo
+#   commit sha=aaa001 (has HIGH finding, id=1)
+#   commit sha=bbb002 (has HIGH finding, id=2, will be cited)
+#   commit sha=ccc003 (has MEDIUM finding only, id=3)
+#   commit sha=ddd004 (has HIGH finding, id=4, will be acked via acks.jsonl)
+#   review_jobs and reviews for each
+make_fixture_db() {
+  local db="$1"
+  /usr/bin/python3 - "$db" <<'PYEOF'
+import sqlite3, sys
+
+db = sys.argv[1]
+con = sqlite3.connect(db)
+cur = con.cursor()
+
+# Minimal schema
+cur.executescript("""
+  CREATE TABLE repos (
+    id INTEGER PRIMARY KEY,
+    root_path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    identity TEXT
+  );
+  CREATE TABLE commits (
+    id INTEGER PRIMARY KEY,
+    repo_id INTEGER NOT NULL,
+    sha TEXT NOT NULL,
+    author TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now'))
+  );
+  CREATE TABLE review_jobs (
+    id INTEGER PRIMARY KEY,
+    repo_id INTEGER NOT NULL,
+    commit_id INTEGER,
+    git_ref TEXT NOT NULL,
+    branch TEXT,
+    session_id TEXT,
+    agent TEXT NOT NULL DEFAULT 'codex',
+    model TEXT,
+    reasoning TEXT NOT NULL DEFAULT 'thorough',
+    status TEXT NOT NULL DEFAULT 'done',
+    enqueued_at TEXT NOT NULL DEFAULT (datetime('now')),
+    min_severity TEXT NOT NULL DEFAULT ''
+  );
+  CREATE TABLE reviews (
+    id INTEGER PRIMARY KEY,
+    job_id INTEGER NOT NULL,
+    agent TEXT NOT NULL,
+    prompt TEXT NOT NULL DEFAULT '',
+    output TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    closed INTEGER NOT NULL DEFAULT 0,
+    verdict_bool INTEGER DEFAULT 0
+  );
+""")
+
+# Repo
+cur.execute("INSERT INTO repos VALUES (1, '/tmp/fakerepo', 'fakerepo', datetime('now'), NULL)")
+
+# Commits: sha => (id, subject)
+commits = [
+    (1, 'aaa001aaa001aaa001aaa001aaa001aaa001aaa001', 'Add feature A'),    # HIGH open
+    (2, 'bbb002bbb002bbb002bbb002bbb002bbb002bbb002', 'Fix bug B'),         # HIGH open → will be cited
+    (3, 'ccc003ccc003ccc003ccc003ccc003ccc003ccc003', 'Refactor C'),        # MEDIUM open only
+    (4, 'ddd004ddd004ddd004ddd004ddd004ddd004ddd004', 'Update docs D'),     # HIGH open → will be acked
+]
+for cid, sha, subj in commits:
+    cur.execute(
+        "INSERT INTO commits VALUES (?,1,?,?,?,?,datetime('now'))",
+        (cid, sha, 'author', subj, '2026-01-01T00:00:00Z')
+    )
+
+# review_jobs
+for jid, cid in [(1,1),(2,2),(3,3),(4,4)]:
+    cur.execute(
+        "INSERT INTO review_jobs (id,repo_id,commit_id,git_ref) VALUES (?,1,?,?)",
+        (jid, cid, f'refs/heads/feat/test')
+    )
+
+# reviews — severity is embedded in output text
+HIGH_OUTPUT = """\
+## Review findings
+
+**Severity**: High
+**Location**: R/foo.R:42
+**Problem**: Missing input validation before division by zero.
+"""
+MEDIUM_OUTPUT = """\
+## Review findings
+
+**Severity**: Medium
+**Location**: R/bar.R:10
+**Problem**: Variable naming could be clearer.
+"""
+
+reviews = [
+    (1, 1, HIGH_OUTPUT,   0, 0),   # id=1, job=1 (aaa001), HIGH, open
+    (2, 2, HIGH_OUTPUT,   0, 0),   # id=2, job=2 (bbb002), HIGH, open → cited
+    (3, 3, MEDIUM_OUTPUT, 0, 0),   # id=3, job=3 (ccc003), MEDIUM, open
+    (4, 4, HIGH_OUTPUT,   0, 0),   # id=4, job=4 (ddd004), HIGH, open → acked
+]
+for rid, jid, out, closed, verdict in reviews:
+    cur.execute(
+        "INSERT INTO reviews (id,job_id,agent,output,closed,verdict_bool) VALUES (?,?,'codex',?,?,?)",
+        (rid, jid, out, closed, verdict)
+    )
+
+con.commit()
+con.close()
+PYEOF
+}
+
+# Creates a minimal git repo with commits corresponding to our fixture SHAs.
+# Because we can't control git's SHA, we instead create a git repo and then
+# create commit-message files separately for the citation parser.
+# The test injects commit messages directly via a mock git log wrapper.
+make_git_repo() {
+  local dir="$1"
+  git -C "$dir" init -q 2>/dev/null
+  git -C "$dir" config user.email "test@test.local"
+  git -C "$dir" config user.name "Test"
+  echo "init" > "$dir/README"
+  git -C "$dir" add README
+  git -C "$dir" commit -qm "init" 2>/dev/null
+}
+
+# Write a mock `gh` script to $1/gh that echoes preset JSON.
+# $2 = JSON array of commit oid strings
+make_mock_gh() {
+  local bin_dir="$1"
+  local commits_json="$2"
+  cat > "$bin_dir/gh" <<MOCKEOF
+#!/usr/bin/env bash
+# Mock gh that echoes preset commit SHAs for 'pr view'
+if [[ "\$*" == *"--json commits"* ]]; then
+  # gh pr view <n> --repo <r> --json commits --jq '.commits[].oid'
+  echo '${commits_json}' | /usr/bin/python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for oid in data:
+    print(oid)
+"
+  exit 0
+fi
+# gh repo view
+if [[ "\$*" == *"nameWithOwner"* ]]; then
+  echo "JohnGavin/fakerepo"
+  exit 0
+fi
+exit 0
+MOCKEOF
+  chmod +x "$bin_dir/gh"
+}
+
+# ── Build shared fixtures ─────────────────────────────────────────────────────
+
+FIXTURE_DIR="${TMPDIR_ROOT}/fixture"
+mkdir -p "$FIXTURE_DIR"
+
+FIXTURE_DB="${FIXTURE_DIR}/reviews.db"
+make_fixture_db "$FIXTURE_DB"
+
+GIT_REPO="${FIXTURE_DIR}/repo"
+mkdir -p "$GIT_REPO"
+make_git_repo "$GIT_REPO"
+
+# SHA values matching DB
+SHA_HIGH_OPEN="aaa001aaa001aaa001aaa001aaa001aaa001aaa001"
+SHA_HIGH_CITED="bbb002bbb002bbb002bbb002bbb002bbb002bbb002"
+SHA_MEDIUM_ONLY="ccc003ccc003ccc003ccc003ccc003ccc003ccc003"
+SHA_HIGH_ACKED="ddd004ddd004ddd004ddd004ddd004ddd004ddd004"
+
+# Acks file
+ACKS_FILE="${FIXTURE_DIR}/acks.jsonl"
+printf '{"id":4,"reason":"false positive — test fixture","pr":99,"acked_at":"2026-01-01T00:00:00","acked_by":"test"}\n' \
+  > "$ACKS_FILE"
+
+# ── Helper to run the gate in an isolated env ─────────────────────────────────
+# Takes: mock_gh_dir commits_json cited_msg test_name expected_exit
+run_gate() {
+  local bin_dir="$1"     # directory with mock gh
+  local commits_json="$2"  # JSON array
+  local cite_msg="$3"    # commit message text (or empty) to inject
+  local args_after="$4"  # extra args to gate (e.g. "--min-severity Medium")
+  local expected_exit="$5"
+  local test_name="$6"
+
+  make_mock_gh "$bin_dir" "$commits_json"
+
+  # If we have a citation message, put it in a git commit on our test repo
+  # so git log can read it.  We create a new file each time to force a commit.
+  local git_sha=""
+  if [ -n "$cite_msg" ]; then
+    local tmpfile
+    tmpfile=$(mktemp "${GIT_REPO}/cite_XXXXXX")
+    echo "$cite_msg" > "$tmpfile"
+    git -C "$GIT_REPO" add "$(basename "$tmpfile")" 2>/dev/null
+    git -C "$GIT_REPO" commit -qm "$cite_msg" 2>/dev/null
+    git_sha=$(git -C "$GIT_REPO" rev-parse HEAD 2>/dev/null)
+  fi
+
+  # Build the SHA list including real git SHA if we have it
+  local shas_list
+  shas_list=$(echo "$commits_json" | /usr/bin/python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for s in data:
+    print(s)
+")
+  # Add the real git SHA so _parse_citations can find the commit message
+  if [ -n "$git_sha" ]; then
+    shas_list="${shas_list}"$'\n'"${git_sha}"
+  fi
+
+  # Create a per-test mock gh that outputs both DB shas AND the real git sha
+  # (for commit-message parsing)
+  local all_shas_json
+  all_shas_json=$(echo "$shas_list" | /usr/bin/python3 -c "
+import sys, json
+lines = [l.strip() for l in sys.stdin if l.strip()]
+print(json.dumps(lines))
+")
+  make_mock_gh "$bin_dir" "$all_shas_json"
+
+  local actual_exit=0
+  local out
+  out=$(
+    GH="$bin_dir/gh" \
+    ROBOREV_DB="$FIXTURE_DB" \
+    ACKS_JSONL="$ACKS_FILE" \
+    GIT_DIR="$GIT_REPO/.git" \
+    GIT_WORK_TREE="$GIT_REPO" \
+      bash "$GATE" $args_after 99 2>&1
+  ) || actual_exit=$?
+
+  if [ "$actual_exit" = "$expected_exit" ]; then
+    pass "$test_name"
+  else
+    fail "$test_name" "expected exit=${expected_exit} got=${actual_exit} | output: ${out}"
+  fi
+}
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+# Test 1 — PR with no commits → exit 0 (fail-open)
+BIN1="${TMPDIR_ROOT}/bin1"
+mkdir -p "$BIN1"
+cat > "$BIN1/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"--json commits"* ]]; then exit 0; fi
+if [[ "$*" == *"nameWithOwner"* ]]; then echo "JohnGavin/fakerepo"; fi
+exit 0
+EOF
+chmod +x "$BIN1/gh"
+
+actual_exit=0
+GH="$BIN1/gh" ROBOREV_DB="$FIXTURE_DB" ACKS_JSONL="$ACKS_FILE" \
+  bash "$GATE" 99 2>/dev/null || actual_exit=$?
+if [ "$actual_exit" = "0" ]; then
+  pass "test1: no commits → exit 0 (fail-open)"
+else
+  fail "test1: no commits → exit 0 (fail-open)" "got exit=$actual_exit"
+fi
+
+# Test 2 — PR with open HIGH finding, no citation → exit 1 (BLOCK)
+BIN2="${TMPDIR_ROOT}/bin2"
+mkdir -p "$BIN2"
+run_gate "$BIN2" \
+  "[\"${SHA_HIGH_OPEN}\"]" \
+  "" \
+  "--min-severity High" \
+  "1" \
+  "test2: open HIGH finding uncited → exit 1 (BLOCK)"
+
+# Test 3 — PR with open HIGH finding cited via 'closes roborev #1' → exit 0 (PASS)
+BIN3="${TMPDIR_ROOT}/bin3"
+mkdir -p "$BIN3"
+run_gate "$BIN3" \
+  "[\"${SHA_HIGH_CITED}\"]" \
+  "closes roborev #2" \
+  "--min-severity High" \
+  "0" \
+  "test3: open HIGH finding cited via closes roborev #2 → exit 0 (PASS)"
+
+# Test 4 — PR with open HIGH finding acked via acks.jsonl → exit 0 (PASS)
+# finding id=4 is in acks.jsonl
+BIN4="${TMPDIR_ROOT}/bin4"
+mkdir -p "$BIN4"
+run_gate "$BIN4" \
+  "[\"${SHA_HIGH_ACKED}\"]" \
+  "" \
+  "--min-severity High" \
+  "0" \
+  "test4: open HIGH finding acked via acks.jsonl → exit 0 (PASS)"
+
+# Test 5 — PR with MEDIUM-only finding, threshold=High → exit 0 (below threshold)
+BIN5="${TMPDIR_ROOT}/bin5"
+mkdir -p "$BIN5"
+run_gate "$BIN5" \
+  "[\"${SHA_MEDIUM_ONLY}\"]" \
+  "" \
+  "--min-severity High" \
+  "0" \
+  "test5: MEDIUM-only finding below High threshold → exit 0"
+
+# Test 6 — syntax check
+bash_n_exit=0
+bash -n "$GATE" 2>/dev/null || bash_n_exit=$?
+if [ "$bash_n_exit" = "0" ]; then
+  pass "test6: bash -n syntax check passes"
+else
+  fail "test6: bash -n syntax check passes" "bash -n exited $bash_n_exit"
+fi
+
+# Test 7 — --json flag emits JSON with verdict=pass when no unresolved findings
+BIN7="${TMPDIR_ROOT}/bin7"
+mkdir -p "$BIN7"
+make_mock_gh "$BIN7" "[\"${SHA_MEDIUM_ONLY}\"]"
+
+json_out=""
+json_exit=0
+json_out=$(
+  GH="$BIN7/gh" ROBOREV_DB="$FIXTURE_DB" ACKS_JSONL="$ACKS_FILE" \
+    bash "$GATE" --json --min-severity High 99 2>&1
+) || json_exit=$?
+
+if echo "$json_out" | /usr/bin/python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d.get('verdict') == 'pass', f'verdict={d.get(\"verdict\")}'
+" 2>/dev/null; then
+  pass "test7: --json emits verdict=pass"
+else
+  fail "test7: --json emits verdict=pass" "got: $json_out"
+fi
+
+# Test 8 — --json flag emits JSON with verdict=block when open findings
+BIN8="${TMPDIR_ROOT}/bin8"
+mkdir -p "$BIN8"
+make_mock_gh "$BIN8" "[\"${SHA_HIGH_OPEN}\"]"
+
+json_out8=""
+json_exit8=0
+json_out8=$(
+  GH="$BIN8/gh" ROBOREV_DB="$FIXTURE_DB" ACKS_JSONL="$ACKS_FILE" \
+    bash "$GATE" --json --min-severity High 99 2>&1
+) || json_exit8=$?
+
+if echo "$json_out8" | /usr/bin/python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read())
+assert d.get('verdict') == 'block', f'verdict={d.get(\"verdict\")}'
+assert d.get('unresolved_count', 0) > 0
+" 2>/dev/null; then
+  pass "test8: --json emits verdict=block with unresolved_count>0"
+else
+  fail "test8: --json emits verdict=block with unresolved_count>0" "got: $json_out8"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${PASS} PASS, ${FAIL} FAIL"
+
+if [ "${FAIL}" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `bin/roborev_merge_gate.sh` — a local merge-gate that exits 1 when a PR has open roborev findings ≥ HIGH severity that are not cited (`closes roborev #N`) or acked (`acks roborev #N --reason "…"`) in its commits
- Updates `.claude/rules/roborev-resolution.md` with the official policy section (definitions table, escalation path, local invocation snippet)
- Updates `.github/PULL_REQUEST_TEMPLATE.md` checklist row to reference `bin/roborev_merge_gate.sh`

Closes #241 (pilot scope: HIGH only, as recommended by the issue's sequencing).

## Pilot scope

**Severity threshold: High only** (pilot lock, `--min-severity High` default).  
Escalation path: High now → Medium after 1 week of signal → per-repo `.roborev.toml` in Phase 3.

## Deliverables

### A — `bin/roborev_merge_gate.sh`

- Resolves PR commits via `gh pr view --json commits --jq '.commits[].oid'`
- Queries `~/.roborev/reviews.db` using native `python3 sqlite3` (WAL-aware; no duckdb-sqlite-scanner)
- SQL filter: `WHERE r.closed=0 AND r.verdict_bool=0 AND c.sha IN (…)`; severity parsed from `output` text using `**Severity**: High` regex (mirrors `roborev_severity_autoclose.sh`)
- Parses commit messages for `closes/fixes/acks roborev #N` patterns (case-insensitive)
- Reads `~/.roborev/acks.jsonl` for explicit acks (written by `roborev_ack.sh`)
- `unresolved = open_findings - cited - acked`
- On non-empty: prints structured table (review_id, severity, commit, location, problem) → exit 1
- On empty: prints `merge-gate: PASS …` → exit 0
- Flags: `--repo OWNER/NAME`, `--min-severity {Critical,High,Medium,Low}`, `--json`
- Fail-open on DB absent, gh errors, or any internal exception

### B — `.claude/rules/roborev-resolution.md`

New section "## Merge-gate policy (#241, pilot HIGH)" with:
- Exact policy wording from issue body
- Definitions table (Related / Resolved / Threshold / Acked)
- Pilot escalation path subsection
- Local invocation code block

Existing "Merge Gate (dry-run mode)" section for `~/.claude/scripts/roborev_merge_gate.sh` is untouched — the two scripts serve different purposes (dry-run logging vs enforcing).

### C — `.github/PULL_REQUEST_TEMPLATE.md`

- Renamed "roborev checklist" → "Reviewer checklist"
- Updated checklist row to reference `bin/roborev_merge_gate.sh <pr#>` with the exact wording from #241

## Tests — `tests/test_roborev_merge_gate.sh`

8 tests using a synthetic SQLite fixture + mock `gh` wrapper:

| # | Scenario | Expected exit |
|---|----------|---------------|
| 1 | No commits found (gh returns empty) | 0 (fail-open) |
| 2 | Open HIGH finding, no citation | 1 (BLOCK) |
| 3 | Open HIGH finding cited via `closes roborev #N` | 0 (PASS) |
| 4 | Open HIGH finding acked via `acks.jsonl` | 0 (PASS) |
| 5 | MEDIUM-only finding, threshold=High | 0 (below threshold) |
| 6 | `bash -n` syntax check | 0 |
| 7 | `--json` flag, no unresolved | 0, `verdict=pass` |
| 8 | `--json` flag, unresolved found | 1, `verdict=block` |

All 8 PASS.

## Verification

```
bash -n bin/roborev_merge_gate.sh   → exit 0
bash tests/test_roborev_merge_gate.sh → 8/8 PASS
```

## Interaction with existing scripts

- `~/.claude/scripts/roborev_merge_gate.sh` — dry-run predecessor; kept as-is for week-1 logging
- `~/.roborev/acks.jsonl` — shared between both scripts
- Severity-autoclose (#224): operates on **aged** findings (>7d); this gate operates on **PR-current** findings — no conflict

## Escalation path

1. **Now (pilot):** run `bin/roborev_merge_gate.sh <pr#>` before every merge. Threshold: High.
2. **After 1 week:** review `~/.claude/logs/merge_gate.log`; file follow-up issue with block rate data.
3. **If block rate is manageable:** lower to Medium. Update `DEFAULT_MIN_SEVERITY` in the script.
4. **Phase 3:** read threshold from `.roborev.toml` `review_min_severity` per repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)