### PR TITLE
feat(roborev): backlog watcher + prioritizer (#163 C1+C2)

### DIFF
--- a/.claude/scripts/roborev_project_backlog.sh
+++ b/.claude/scripts/roborev_project_backlog.sh
@@ -1,21 +1,30 @@
 #!/usr/bin/env bash
-# roborev_project_backlog.sh — per-project backlog watcher.
+# roborev_project_backlog.sh — per-project backlog watcher + prioritizer.
 #
 # Reads ~/.roborev/reviews.db (read-only) and writes a prioritised markdown
 # table of open high-severity findings to <project-root>/.roborev/backlog.md.
+# Implements Components 1 and 2 of JohnGavin/llm#163.
 #
 # Portability: may be invoked by launchd with a bare PATH; prepend common
 # tool locations so python3 and sqlite3 are visible.
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 #
 # Usage:
-#   roborev_project_backlog.sh [--repo <name>] [--apply | --dry-run]
+#   roborev_project_backlog.sh <project-name> [options]
+#
+# Arguments:
+#   <project-name>          Repo name as stored in reviews.db (positional, required)
 #
 # Options:
-#   --repo <name>  Restrict to a single repo by name (default: llm)
-#   --apply        Write .roborev/backlog.md to the project root (default)
-#   --dry-run      Print table to stdout only; no file writes
-#   --help         Usage
+#   --repo-root PATH        Project root directory (default: ~/docs_gh/<name>)
+#   --out PATH              Output file path (default: <repo-root>/.roborev/backlog.md)
+#   --top-n N               Number of top findings to show (default: 10)
+#   --dry-run               Print table to stdout only; no file writes
+#   --help                  Usage
+#
+# Legacy alias (backward compat):
+#   --repo <name>           Same as positional <project-name>
+#   --apply                 Write file (default; opposite of --dry-run)
 #
 # Self-test:
 #   ROBOREV_BACKLOG_SELFTEST=1 bash roborev_project_backlog.sh
@@ -46,20 +55,43 @@ export _ROBOREV_BACKLOG_DEPTH=$((_DEPTH + 1))
 PYTHON="${PYTHON:-/usr/bin/python3}"
 ROBOREV_DB="${ROBOREV_DB:-$HOME/.roborev/reviews.db}"
 LOG="$HOME/.claude/logs/roborev_project_backlog.log"
-REPO_NAME="${ROBOREV_BACKLOG_REPO:-llm}"
-APPLY=1   # default: write file
+REPO_NAME="${ROBOREV_BACKLOG_REPO:-}"
+REPO_ROOT=""         # populated from --repo-root or default ~/docs_gh/<name>
+OUT_FILE=""          # populated from --out or default <repo-root>/.roborev/backlog.md
+TOP_N=10             # default top-N
+APPLY=1              # default: write file
 
 # ── Parse args ────────────────────────────────────────────────────────────────
 while [ $# -gt 0 ]; do
   case "$1" in
-    --repo)      shift; REPO_NAME="$1" ;;
-    --apply)     APPLY=1 ;;
-    --dry-run)   APPLY=0 ;;
-    -h|--help)   sed -n '2,30p' "$0"; exit 0 ;;
-    *)           echo "unknown arg: $1" >&2; exit 1 ;;
+    --repo)       shift; REPO_NAME="$1" ;;      # legacy alias
+    --repo-root)  shift; REPO_ROOT="$1" ;;
+    --out)        shift; OUT_FILE="$1" ;;
+    --top-n)      shift; TOP_N="$1" ;;
+    --apply)      APPLY=1 ;;
+    --dry-run)    APPLY=0 ;;
+    -h|--help)    sed -n '2,45p' "$0"; exit 0 ;;
+    -*)           echo "unknown option: $1" >&2; exit 1 ;;
+    *)
+      # First positional arg = project name
+      if [ -z "$REPO_NAME" ]; then
+        REPO_NAME="$1"
+      else
+        echo "unexpected argument: $1 (project name already set to '$REPO_NAME')" >&2
+        exit 1
+      fi
+      ;;
   esac
   shift
 done
+
+# Default repo name if still unset
+[ -z "$REPO_NAME" ] && REPO_NAME="llm"
+
+# Derive repo root from name if not explicitly provided
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT="$HOME/docs_gh/$REPO_NAME"
+fi
 
 mkdir -p "$(dirname "$LOG")"
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$LOG"; }
@@ -120,21 +152,24 @@ _query_backlog() {
   local repo_name="$1"
   local db="$2"
   local root_path_override="${3:-}"  # optional: pass project root for file_touches
+  local top_n="${4:-10}"             # optional: top-N, default 10
 
   if [ ! -f "$db" ]; then
     echo "ROOT_PATH:"
     echo "REPO:$repo_name"
+    echo "OPEN_COUNT:0"
     echo ""
-    echo "(DB unavailable — fail open)"
+    echo "_0 open findings (DB unavailable — fail open)._"
     return 0
   fi
 
-  "$PYTHON" - "$db" "$repo_name" "$root_path_override" <<'PYEOF'
+  "$PYTHON" - "$db" "$repo_name" "$root_path_override" "$top_n" <<'PYEOF'
 import sys, sqlite3, math, re, subprocess, os
 
 db_path = sys.argv[1]
 repo_name = sys.argv[2]
 root_path_override = sys.argv[3] if len(sys.argv) > 3 else ""
+top_n = int(sys.argv[4]) if len(sys.argv) > 4 else 10
 
 # ── Severity / category weight tables ────────────────────────────────────────
 SEV_WEIGHT = {"critical": 10, "high": 5, "medium": 2, "low": 1, "unknown": 1}
@@ -286,7 +321,8 @@ except Exception:
 con.close()
 
 if not rows:
-    print("_No open findings._")
+    print(f"OPEN_COUNT:0")
+    print("_0 open findings._")
     sys.exit(0)
 
 # Compute priority for each row, then sort DESC
@@ -309,13 +345,14 @@ for row in rows:
         "output": row["output"],
     })
 
-# Sort by priority DESC, take top 10
+# Sort by priority DESC, take top_n
 scored.sort(key=lambda x: x["priority"], reverse=True)
-top10 = scored[:10]
+top_list = scored[:top_n]
 
+print(f"OPEN_COUNT:{len(scored)}")
 print("| id | sev | category | age_days | touches | priority | summary |")
 print("|----|-----|----------|----------|---------|----------|---------|")
-for r in top10:
+for r in top_list:
     rid = r["rid"]
     sev = r["sev"]
     cat = r["category"]
@@ -332,7 +369,7 @@ for r in top10:
     print(f"| {rid} | {sev} | {cat} | {age} | {t} | {pri} | {summary} |")
 
 # Emit top-finding metadata for session_init banner use
-top = top10[0] if top10 else None
+top = top_list[0] if top_list else None
 if top:
     print(f"TOP_FINDING_ID:{top['rid']}")
     print(f"TOP_FINDING_SEV:{top['sev']}")
@@ -340,26 +377,50 @@ if top:
 PYEOF
 }
 
-# Write backlog.md to <root_path>/.roborev/backlog.md
-# Args: root_path, table_content, repo_name
+# Write backlog.md to the project's .roborev/backlog.md (or --out path).
+# Args: root_path, table_content, repo_name, [out_file_override]
 # Echoes the output file path on success.
 _write_backlog() {
   local root_path="$1"
   local table="$2"
   local repo_name="$3"
-  local out_dir="$root_path/.roborev"
-  local out_file="$out_dir/backlog.md"
+  local out_file_override="${4:-}"
+  local out_file
 
-  mkdir -p "$out_dir"
+  if [ -n "$out_file_override" ]; then
+    out_file="$out_file_override"
+  else
+    out_file="$root_path/.roborev/backlog.md"
+  fi
+
+  mkdir -p "$(dirname "$out_file")"
   {
     printf '# roborev backlog — %s\n\n' "$repo_name"
     printf '_Generated: %s_\n\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-    printf 'Check `.roborev/backlog.md` for prioritised open findings before starting fixes.\n\n'
+    printf 'Check `%s` for prioritised open findings before starting fixes.\n\n' "$out_file"
     printf '%s\n\n' "$table"
-    printf '_Source: `%s` — top 10 open findings, sorted by composite priority (severity × category-risk × age × file-heat)._\n' "$ROBOREV_DB"
+    printf '_Source: `%s` — top-%s open findings, sorted by composite priority (severity × category-risk × age × file-heat)._\n' \
+      "${ROBOREV_DB:-~/.roborev/reviews.db}" "${TOP_N:-10}"
   } > "$out_file"
 
   echo "$out_file"
+}
+
+# Append .roborev/ to <project-root>/.gitignore if not already present.
+# Idempotent — safe to call multiple times.
+_ensure_gitignore() {
+  local root_path="$1"
+  local gitignore="$root_path/.gitignore"
+
+  [ -z "$root_path" ] && return 0
+  [ ! -d "$root_path" ] && return 0
+
+  # Already present
+  if [ -f "$gitignore" ] && grep -qF '.roborev/' "$gitignore" 2>/dev/null; then
+    return 0
+  fi
+
+  printf '\n# roborev per-project backlog (generated by roborev_project_backlog.sh)\n.roborev/\n' >> "$gitignore"
 }
 
 # ── Self-test (no subprocess of $0) ──────────────────────────────────────────
@@ -467,37 +528,38 @@ if [ ! -f "$ROBOREV_DB" ]; then
   exit 0
 fi
 
-# Query backlog
-raw_output=$(_query_backlog "$REPO_NAME" "$ROBOREV_DB")
+# Query backlog (pass TOP_N to Python)
+raw_output=$(_query_backlog "$REPO_NAME" "$ROBOREV_DB" "$REPO_ROOT" "$TOP_N")
 
 # Extract metadata lines
-root_path=$(printf '%s\n' "$raw_output" | grep "^ROOT_PATH:" | head -1 | sed 's/^ROOT_PATH://')
+db_root_path=$(printf '%s\n' "$raw_output" | grep "^ROOT_PATH:" | head -1 | sed 's/^ROOT_PATH://')
+open_count=$(printf '%s\n' "$raw_output" | grep "^OPEN_COUNT:" | head -1 | sed 's/^OPEN_COUNT://')
 top_id=$(printf '%s\n' "$raw_output" | grep "^TOP_FINDING_ID:" | head -1 | sed 's/^TOP_FINDING_ID://')
 top_sev=$(printf '%s\n' "$raw_output" | grep "^TOP_FINDING_SEV:" | head -1 | sed 's/^TOP_FINDING_SEV://')
 top_cat=$(printf '%s\n' "$raw_output" | grep "^TOP_FINDING_CAT:" | head -1 | sed 's/^TOP_FINDING_CAT://')
+
+# Use --repo-root override if provided; else fall back to what the DB says; else ~/docs_gh/<name>
+effective_root="${REPO_ROOT:-${db_root_path:-$HOME/docs_gh/$REPO_NAME}}"
 
 # Strip metadata lines for table content
 table=$(printf '%s\n' "$raw_output" \
   | grep -v "^ROOT_PATH:" \
   | grep -v "^REPO:" \
+  | grep -v "^OPEN_COUNT:" \
   | grep -v "^TOP_FINDING_")
 
 if [ "$APPLY" -eq 0 ]; then
   echo "=== roborev backlog: $REPO_NAME (dry-run) ==="
+  echo "${open_count:-0} open findings"
   echo ""
   printf '%s\n' "$table"
   [ -n "$top_id" ] && echo "Top finding: #${top_id} (${top_sev}:${top_cat})"
-  log "dry-run: repo=$REPO_NAME"
+  log "dry-run: repo=$REPO_NAME open=${open_count:-0}"
 else
-  if [ -z "$root_path" ]; then
-    log "error: could not determine root_path for repo=$REPO_NAME"
-    echo "roborev_project_backlog: error — repo '$REPO_NAME' not in DB or no root_path" >&2
-    exit 1
-  fi
-
-  out_file=$(_write_backlog "$root_path" "$table" "$REPO_NAME")
-  log "apply: wrote $out_file repo=$REPO_NAME top=#${top_id}(${top_sev}:${top_cat})"
-  echo "roborev_project_backlog: wrote $out_file"
+  out_file=$(_write_backlog "$effective_root" "$table" "$REPO_NAME" "${OUT_FILE:-}")
+  _ensure_gitignore "$effective_root"
+  log "apply: wrote $out_file repo=$REPO_NAME open=${open_count:-?} top=#${top_id}(${top_sev}:${top_cat})"
+  echo "roborev_project_backlog: wrote $out_file (${open_count:-?} open findings)"
 fi
 
 exit 0

--- a/tests/test_roborev_project_backlog.sh
+++ b/tests/test_roborev_project_backlog.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# tests/test_roborev_project_backlog.sh
+#
+# Unit tests for .claude/scripts/roborev_project_backlog.sh
+#
+# Uses a synthetic SQLite fixture and a synthetic temp repo dir.
+# Exits 0 if all tests pass, 1 on any failure.
+#
+# Part of: JohnGavin/llm#163 Components 1+2
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKLOG_SCRIPT="${SCRIPT_DIR}/../.claude/scripts/roborev_project_backlog.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT="$(mktemp -d)"
+
+cleanup() { rm -rf "${TMPDIR_ROOT}"; }
+trap cleanup EXIT
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        pass "${desc}"
+    else
+        fail "${desc} — expected='${expected}' actual='${actual}'"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if echo "${haystack}" | grep -qF "${needle}"; then
+        pass "${desc}"
+    else
+        fail "${desc} — '${needle}' not found in output"
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if echo "${haystack}" | grep -qF "${needle}"; then
+        fail "${desc} — '${needle}' should NOT appear in output but does"
+    else
+        pass "${desc}"
+    fi
+}
+
+# Create a synthetic SQLite DB with the roborev schema (minimal subset)
+make_roborev_db() {
+    local db_path="$1"
+    /usr/bin/python3 - "$db_path" <<'PYEOF'
+import sqlite3, sys
+db = sys.argv[1]
+con = sqlite3.connect(db)
+con.executescript("""
+CREATE TABLE IF NOT EXISTS repos (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    name     TEXT    NOT NULL,
+    root_path TEXT
+);
+CREATE TABLE IF NOT EXISTS review_jobs (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id     INTEGER REFERENCES repos(id),
+    status      TEXT DEFAULT 'done',
+    finished_at TEXT,
+    enqueued_at TEXT
+);
+CREATE TABLE IF NOT EXISTS reviews (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id  INTEGER REFERENCES review_jobs(id),
+    output  TEXT,
+    closed  INTEGER DEFAULT 0
+);
+""")
+con.commit()
+con.close()
+PYEOF
+}
+
+# Insert a finding into the synthetic DB
+insert_finding() {
+    local db="$1"
+    local repo_name="$2"
+    local output_text="$3"
+    local age_days="${4:-5}"     # days old
+    local closed="${5:-0}"
+
+    /usr/bin/python3 - "$db" "$repo_name" "$output_text" "$age_days" "$closed" <<'PYEOF'
+import sqlite3, sys
+from datetime import datetime, timedelta, timezone
+db_path, repo_name, output_text, age_days_str, closed_str = sys.argv[1:6]
+age_days = int(age_days_str)
+closed = int(closed_str)
+
+con = sqlite3.connect(db_path)
+finished_at = (datetime.now(timezone.utc) - timedelta(days=age_days)).isoformat()
+
+# Upsert repo
+row = con.execute("SELECT id FROM repos WHERE name = ?", (repo_name,)).fetchone()
+if row:
+    repo_id = row[0]
+else:
+    cur = con.execute("INSERT INTO repos (name, root_path) VALUES (?, '')", (repo_name,))
+    repo_id = cur.lastrowid
+
+# Insert job
+cur = con.execute(
+    "INSERT INTO review_jobs (repo_id, status, finished_at, enqueued_at) VALUES (?, 'done', ?, ?)",
+    (repo_id, finished_at, finished_at)
+)
+job_id = cur.lastrowid
+
+# Insert review
+con.execute(
+    "INSERT INTO reviews (job_id, output, closed) VALUES (?, ?, ?)",
+    (job_id, output_text, closed)
+)
+con.commit()
+con.close()
+PYEOF
+}
+
+# Make a minimal git repo
+make_git_repo() {
+    local dir="$1"
+    git -C "${dir}" init -q
+    git -C "${dir}" config user.email "test@test.local"
+    git -C "${dir}" config user.name "Test"
+    touch "${dir}/README"
+    git -C "${dir}" add README
+    git -C "${dir}" commit -qm "init"
+}
+
+# ── Test 1: Empty backlog → "0 open" placeholder, no error ───────────────────
+DB1="${TMPDIR_ROOT}/db1.sqlite"
+REPO1="${TMPDIR_ROOT}/repo1"
+mkdir -p "${REPO1}"
+make_roborev_db "${DB1}"
+make_git_repo "${REPO1}"
+# Insert a repo record with no findings
+/usr/bin/python3 -c "
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+con.execute(\"INSERT INTO repos (name, root_path) VALUES ('testrepo1', '')\")
+con.commit()
+" "${DB1}"
+
+out1=$(ROBOREV_DB="${DB1}" bash "${BACKLOG_SCRIPT}" testrepo1 \
+    --repo-root "${REPO1}" --dry-run 2>&1)
+exit1=$?
+
+assert_eq "test1: exit 0 on empty backlog" "0" "${exit1}"
+assert_contains "test1: reports 0 open" "0 open" "${out1}"
+
+# ── Test 2: 5 findings of mixed severity → priority ordering ─────────────────
+DB2="${TMPDIR_ROOT}/db2.sqlite"
+REPO2="${TMPDIR_ROOT}/repo2"
+mkdir -p "${REPO2}"
+make_roborev_db "${DB2}"
+make_git_repo "${REPO2}"
+
+# Critical/security (highest expected priority)
+insert_finding "${DB2}" "testpriority" \
+    "**Severity**: Critical\nThis finding involves a sql injection vulnerability token leak." 10 0
+# High/error-handling
+insert_finding "${DB2}" "testpriority" \
+    "**Severity**: High\nError handling issue: missing tryCatch around stop() call." 5 0
+# Medium/other
+insert_finding "${DB2}" "testpriority" \
+    "**Severity**: Medium\nSome general finding." 3 0
+# Low/docs
+insert_finding "${DB2}" "testpriority" \
+    "**Severity**: Low\nMissing @param documentation in README." 2 0
+# Medium/test
+insert_finding "${DB2}" "testpriority" \
+    "**Severity**: Medium\nMissing testthat expect_ coverage." 7 0
+
+out2=$(ROBOREV_DB="${DB2}" bash "${BACKLOG_SCRIPT}" testpriority \
+    --repo-root "${REPO2}" --dry-run 2>&1)
+exit2=$?
+
+assert_eq "test2: exit 0 with mixed findings" "0" "${exit2}"
+assert_contains "test2: table header present" "| id |" "${out2}"
+assert_contains "test2: critical finding in output" "critical" "${out2}"
+# Check that critical appears before low in the output (priority ordering)
+critical_line=$(echo "${out2}" | grep "critical" | head -1)
+low_line=$(echo "${out2}" | grep " low " | head -1)
+critical_pos=$(echo "${out2}" | grep -n "critical" | head -1 | cut -d: -f1)
+low_pos=$(echo "${out2}" | grep -n " low " | head -1 | cut -d: -f1)
+if [ -n "${critical_pos}" ] && [ -n "${low_pos}" ] && [ "${critical_pos}" -lt "${low_pos}" ]; then
+    pass "test2: critical finding ranked before low finding"
+else
+    fail "test2: critical finding should appear before low in priority order (critical_pos=${critical_pos:-?} low_pos=${low_pos:-?})"
+fi
+
+# ── Test 3: Category regex — security vs docs ─────────────────────────────────
+DB3="${TMPDIR_ROOT}/db3.sqlite"
+REPO3="${TMPDIR_ROOT}/repo3"
+mkdir -p "${REPO3}"
+make_roborev_db "${DB3}"
+
+# Security finding: body contains "token"
+insert_finding "${DB3}" "testcat" \
+    "**Severity**: High\nAn API token is exposed in the commit history via credential leak." 5 0
+# Docs finding: body contains "README"
+insert_finding "${DB3}" "testcat" \
+    "**Severity**: Low\nREADME vignette is missing @param documentation comment." 5 0
+
+out3=$(ROBOREV_DB="${DB3}" bash "${BACKLOG_SCRIPT}" testcat \
+    --dry-run 2>&1)
+exit3=$?
+
+assert_eq "test3: exit 0" "0" "${exit3}"
+assert_contains "test3: security category detected" "security" "${out3}"
+assert_contains "test3: docs category detected" "docs" "${out3}"
+# Security should rank higher than docs (risk factor 3.0 vs 0.5)
+sec_pos=$(echo "${out3}" | grep -n "security" | head -1 | cut -d: -f1)
+doc_pos=$(echo "${out3}" | grep -n "docs" | head -1 | cut -d: -f1)
+if [ -n "${sec_pos}" ] && [ -n "${doc_pos}" ] && [ "${sec_pos}" -lt "${doc_pos}" ]; then
+    pass "test3: security finding ranked before docs finding"
+else
+    fail "test3: security should rank higher than docs (sec_pos=${sec_pos:-?} doc_pos=${doc_pos:-?})"
+fi
+
+# ── Test 4: Age factor — same priority base, older one wins ──────────────────
+DB4="${TMPDIR_ROOT}/db4.sqlite"
+REPO4="${TMPDIR_ROOT}/repo4"
+mkdir -p "${REPO4}"
+make_roborev_db "${DB4}"
+
+# Two Medium/other findings, same severity and category, different age
+# Use unique keywords so we can identify which line belongs to which finding
+insert_finding "${DB4}" "testage" \
+    "**Severity**: Medium\nSome general other finding NEWER_AGE_MARKER." 2 0
+insert_finding "${DB4}" "testage" \
+    "**Severity**: Medium\nSome general other finding OLDER_AGE_MARKER." 30 0
+
+out4=$(ROBOREV_DB="${DB4}" bash "${BACKLOG_SCRIPT}" testage \
+    --dry-run 2>&1)
+exit4=$?
+
+assert_eq "test4: exit 0" "0" "${exit4}"
+assert_contains "test4: output has table header" "| id |" "${out4}"
+
+# Extract the two data rows by unique markers in the summary column
+# The table has format: | id | sev | cat | age_days | touches | priority | summary |
+# We find the line number of each marker in the output
+newer_lineno=$(echo "${out4}" | grep -n "NEWER_AGE" | head -1 | cut -d: -f1)
+older_lineno=$(echo "${out4}" | grep -n "OLDER_AGE" | head -1 | cut -d: -f1)
+
+if [ -n "${newer_lineno}" ] && [ -n "${older_lineno}" ]; then
+    if [ "${older_lineno}" -lt "${newer_lineno}" ]; then
+        pass "test4: older finding (age=30) ranked before newer (age=2) — correct priority order"
+    else
+        # Extract priority scores from each line for a clearer failure message
+        newer_pri=$(echo "${out4}" | sed -n "${newer_lineno}p" | awk -F'|' '{gsub(/ /,"",$7); print $7}')
+        older_pri=$(echo "${out4}" | sed -n "${older_lineno}p" | awk -F'|' '{gsub(/ /,"",$7); print $7}')
+        fail "test4: older finding should rank before newer (older_lineno=${older_lineno} newer_lineno=${newer_lineno}; older_pri=${older_pri:-?} newer_pri=${newer_pri:-?})"
+    fi
+else
+    fail "test4: could not locate OLDER/NEWER markers in output — output was: ${out4}"
+fi
+
+# ── Test 5: Markdown output has required sections ────────────────────────────
+DB5="${TMPDIR_ROOT}/db5.sqlite"
+REPO5="${TMPDIR_ROOT}/repo5"
+mkdir -p "${REPO5}"
+make_git_repo "${REPO5}"
+make_roborev_db "${DB5}"
+insert_finding "${DB5}" "testmd" \
+    "**Severity**: High\nA high severity finding for markdown structure test." 5 0
+
+OUT5="${TMPDIR_ROOT}/backlog5.md"
+exit5rc=0
+ROBOREV_DB="${DB5}" bash "${BACKLOG_SCRIPT}" testmd \
+    --repo-root "${REPO5}" --out "${OUT5}" 2>&1 || exit5rc=$?
+
+assert_eq "test5: exit 0 writing file" "0" "${exit5rc}"
+assert_eq "test5: backlog file written" "1" "$([ -f "${OUT5}" ] && echo 1 || echo 0)"
+
+if [ -f "${OUT5}" ]; then
+    content5=$(cat "${OUT5}")
+    assert_contains "test5: has heading" "# roborev backlog" "${content5}"
+    assert_contains "test5: has Generated timestamp" "_Generated:" "${content5}"
+    assert_contains "test5: has table header" "| id |" "${content5}"
+    assert_contains "test5: has priority column" "priority" "${content5}"
+    assert_contains "test5: has source footer" "_Source:" "${content5}"
+fi
+
+# ── Test 6: bash -n syntax check ─────────────────────────────────────────────
+bash_n_out=$(bash -n "${BACKLOG_SCRIPT}" 2>&1)
+bash_n_rc=$?
+assert_eq "test6: bash -n exits 0 (script syntax valid)" "0" "${bash_n_rc}"
+
+# ── Test 7: --gitignore appended when not present ────────────────────────────
+REPO7="${TMPDIR_ROOT}/repo7"
+mkdir -p "${REPO7}"
+DB7="${TMPDIR_ROOT}/db7.sqlite"
+make_roborev_db "${DB7}"
+insert_finding "${DB7}" "testgi" \
+    "**Severity**: Medium\nA finding for gitignore test." 3 0
+OUT7="${REPO7}/.roborev/backlog.md"
+
+# Run in apply mode (not dry-run) so _ensure_gitignore is called
+ROBOREV_DB="${DB7}" bash "${BACKLOG_SCRIPT}" testgi \
+    --repo-root "${REPO7}" 2>&1
+exit7=$?
+assert_eq "test7: exit 0" "0" "${exit7}"
+assert_eq "test7: .gitignore created" "1" "$([ -f "${REPO7}/.gitignore" ] && echo 1 || echo 0)"
+assert_contains "test7: .roborev/ in .gitignore" ".roborev/" "$(cat "${REPO7}/.gitignore" 2>/dev/null || echo '')"
+
+# Run again — must be idempotent (no duplicate lines)
+ROBOREV_DB="${DB7}" bash "${BACKLOG_SCRIPT}" testgi \
+    --repo-root "${REPO7}" 2>&1
+count7=$(grep -c '\.roborev/' "${REPO7}/.gitignore" 2>/dev/null || echo 0)
+assert_eq "test7: .gitignore idempotent (single .roborev/ entry)" "1" "${count7}"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${PASS} PASS, ${FAIL} FAIL"
+
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements **Components 1 and 2** of #163 — the per-project backlog watcher and prioritizer. Components 3–8 are deferred follow-up issues filed at the end of this PR.

- `.claude/scripts/roborev_project_backlog.sh` updated to match the spec in #163: positional `<project-name>` arg, `--repo-root`, `--out`, `--top-n`, `--dry-run` flags, `.gitignore` appending
- `tests/test_roborev_project_backlog.sh` new: 25 bash tests covering empty backlog, priority ordering, category regex, age factor, markdown structure, and gitignore idempotency

## Changes

- `.claude/scripts/roborev_project_backlog.sh` — positional arg + new flags + `_ensure_gitignore()` + `OPEN_COUNT` metadata line + `--out` path override + `--top-n` pass-through to Python
- `tests/test_roborev_project_backlog.sh` — new bash test suite (25/25 PASS)

## Smoke run against real DB (project: llm, dry-run, top-3)

```
| id   | sev  | category | age_days | touches | priority | summary                           |
|------|------|----------|----------|---------|----------|-----------------------------------|
| 3812 | high | security |       10 |      15 |     65.3 | - **Severity**: High              |
| 3841 | high | security |       10 |      15 |     65.3 | - **Severity**: High              |
| 3832 | high | security |       10 |      11 |     61.2 | - **Severity**: High              |
```

70 open findings for `llm`. Top finding: #3812 (high:security).

## Follow-up issues filed (Components 3–8)

- #352 — Component 3: commit-convention pre-commit hook
- #353 — Component 4: post-commit verifier
- #354 — Component 5: auto-close on verified-pass (DB schema + closures table)
- #355 — Component 6: daily aggregator (launchd + global digest)
- #356 — Components 7+8: weekly rollup digest + per-project hook installer

## Test plan

- [x] `bash -n .claude/scripts/roborev_project_backlog.sh` — exits 0
- [x] `bash tests/test_roborev_project_backlog.sh` — 25/25 PASS
- [x] Smoke run `llm --dry-run` against real `~/.roborev/reviews.db` — 70 open, top-3 shown above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
