### PR TITLE
feat(roborev): daily backlog aggregator (#355)

### DIFF
--- a/.claude/launchd/com.claude.roborev-daily-backlog.plist
+++ b/.claude/launchd/com.claude.roborev-daily-backlog.plist
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.claude.roborev-daily-backlog.plist
+     Nightly backlog aggregator: iterates all registered projects in
+     ~/.roborev/reviews.db and refreshes per-project .roborev/backlog.md files,
+     then emits a global summary at ~/.claude/logs/roborev_daily_backlog/<date>.md.
+
+     Runs at 02:15 local time — 15 minutes after the metrics-ETL job (02:00)
+     to avoid DB contention.  Implements Component 6 of JohnGavin/llm#163.
+
+     Install:
+       cp ~/docs_gh/llm/.claude/launchd/com.claude.roborev-daily-backlog.plist \
+          ~/Library/LaunchAgents/com.claude.roborev-daily-backlog.plist
+       launchctl load -w ~/Library/LaunchAgents/com.claude.roborev-daily-backlog.plist
+
+     Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.claude.roborev-daily-backlog.plist
+       rm ~/Library/LaunchAgents/com.claude.roborev-daily-backlog.plist
+
+     Manual run:
+       ~/.claude/scripts/roborev_daily_backlog_aggregator.sh
+     Dry-run:
+       ~/.claude/scripts/roborev_daily_backlog_aggregator.sh --dry-run
+
+     Tracked in llm#355.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.roborev-daily-backlog</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_daily_backlog_aggregator.sh</string>
+    </array>
+
+    <!-- PATH must include /usr/local/bin (roborev binary) and /usr/bin (python3, sqlite3) -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+    </dict>
+
+    <!-- Nightly at 02:15 local (offset from metrics-ETL at 02:00) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>15</integer>
+    </dict>
+
+    <!-- StandardInPath=/dev/null: prevents SIGTTIN/state-T hang when the
+         script (or a subprocess) reads from stdin while running under launchd.
+         Same fix as com.claude.roborev-autoclose and com.claude.roborev-poll-merges
+         (llm#342 lesson). -->
+    <key>StandardInPath</key>
+    <string>/dev/null</string>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/roborev_daily_backlog_aggregator.out</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/roborev_daily_backlog_aggregator.err</string>
+
+    <!-- Do NOT run immediately on launchctl load -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- Retry after 60s if job exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+</dict>
+</plist>

--- a/.claude/scripts/roborev_daily_backlog_aggregator.sh
+++ b/.claude/scripts/roborev_daily_backlog_aggregator.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# roborev_daily_backlog_aggregator.sh — daily backlog aggregator across all projects.
+#
+# Iterates every project registered in ~/.roborev/reviews.db (repos table),
+# skipping internal fixture names, then calls roborev_project_backlog.sh for
+# each resolvable project root.  Produces a global summary Markdown at:
+#   ~/.claude/logs/roborev_daily_backlog/<YYYY-MM-DD>.md
+#
+# Implements Component 6 of JohnGavin/llm#163.
+#
+# Usage:
+#   roborev_daily_backlog_aggregator.sh [options]
+#
+# Options:
+#   --dry-run        Pass --dry-run to each per-project script (no file writes)
+#   --db PATH        Override reviews.db path (default: ~/.roborev/reviews.db)
+#   --docs-root DIR  Override docs root for project lookup (default: ~/docs_gh)
+#   --out-dir DIR    Override global summary output directory
+#                    (default: ~/.claude/logs/roborev_daily_backlog)
+#   --help           Usage
+#
+# Self-test:
+#   ROBOREV_AGG_SELFTEST=1 bash roborev_daily_backlog_aggregator.sh
+#
+# Exit codes:
+#   0  ok (per-project failures are soft — logged, not fatal)
+#   1  unexpected error (DB query failure, etc.)
+#
+# Tracked in JohnGavin/llm#355.
+
+set -uo pipefail
+
+# Prepend common tool locations (same convention as per-project script)
+export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+# ── Config ────────────────────────────────────────────────────────────────────
+PYTHON="${PYTHON:-/usr/bin/python3}"
+ROBOREV_DB="${ROBOREV_DB:-$HOME/.roborev/reviews.db}"
+DOCS_ROOT="${DOCS_ROOT:-$HOME/docs_gh}"
+TODAY="$(date -u '+%Y-%m-%d')"
+OUT_DIR="${ROBOREV_AGG_OUT_DIR:-$HOME/.claude/logs/roborev_daily_backlog}"
+DRY_RUN=0
+
+# Resolve directory containing this script to find sibling per-project script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PER_PROJECT_SCRIPT="${SCRIPT_DIR}/roborev_project_backlog.sh"
+
+LOG="$HOME/.claude/logs/roborev_daily_backlog_aggregator.log"
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)   DRY_RUN=1 ;;
+    --db)        shift; ROBOREV_DB="$1" ;;
+    --docs-root) shift; DOCS_ROOT="$1" ;;
+    --out-dir)   shift; OUT_DIR="$1" ;;
+    -h|--help)   sed -n '2,45p' "$0"; exit 0 ;;
+    *)           echo "unknown option: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+mkdir -p "$(dirname "$LOG")"
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$LOG"; }
+
+# ── Helper: enumerate project names from DB ───────────────────────────────────
+# Outputs one name per line on stdout; exits 0 always (fail-open).
+_list_projects() {
+  local db="$1"
+
+  if [ ! -f "$db" ]; then
+    log "skip: DB not found at $db"
+    return 0
+  fi
+
+  "$PYTHON" - "$db" <<'PYEOF'
+import sys, sqlite3
+
+db_path = sys.argv[1]
+
+# Name patterns to skip — internal fixtures and KB repos
+SKIP_PATTERNS = [
+    "kb_",
+    "config_digest_git_fixture_",
+    "fixture_",
+    "file",            # hex-prefixed temp entries like file9afe2d343242
+    "repo_",           # one-off fixture entries repo_XXXX
+    "repo1", "repo2", "repo3", "repo4", "repo5",  # numbered test fixtures
+    "main",            # git-default remote name accidentally stored as repo name
+    "hello_t", "my_t_project", "t_demos",           # demo/test projects
+]
+
+# Names that look like file-hash entries (7–40 hex chars, possibly starting with "file")
+import re
+HEX_ENTRY = re.compile(r'^file[0-9a-f]{6,}$')
+
+try:
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    rows = con.execute(
+        "SELECT DISTINCT name FROM repos ORDER BY name"
+    ).fetchall()
+    con.close()
+except Exception as e:
+    print(f"# DB error: {e}", file=sys.stderr)
+    sys.exit(0)
+
+for (name,) in rows:
+    if not name:
+        continue
+    # Skip hex-prefixed entries
+    if HEX_ENTRY.match(name):
+        continue
+    # Skip known fixture / internal prefixes
+    if any(name.startswith(p) for p in SKIP_PATTERNS):
+        continue
+    print(name)
+PYEOF
+}
+
+# ── Helper: write global summary ─────────────────────────────────────────────
+# Args: out_file, summary_lines (newline-delimited "project|open_count|top_sev|top_id")
+_write_global_summary() {
+  local out_file="$1"
+  local lines="$2"
+  local total_projects=0
+  local total_open=0
+
+  mkdir -p "$(dirname "$out_file")"
+
+  {
+    printf '# roborev global backlog summary\n\n'
+    printf '_Generated: %s (UTC)_\n\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf '## Per-project open counts\n\n'
+    printf '| project | open | top sev | top id |\n'
+    printf '|---------|------|---------|--------|\n'
+
+    while IFS='|' read -r proj open top_sev top_id; do
+      [ -z "$proj" ] && continue
+      total_projects=$((total_projects + 1))
+      local n="${open:-0}"
+      # Strip whitespace from numeric field
+      n="${n// /}"
+      # Only add to total if it looks like a number
+      if [[ "$n" =~ ^[0-9]+$ ]]; then
+        total_open=$((total_open + n))
+      fi
+      printf '| %s | %s | %s | %s |\n' "$proj" "${open:-?}" "${top_sev:--}" "${top_id:--}"
+    done <<< "$lines"
+
+    printf '\n## Summary\n\n'
+    printf '%s\n' "- Projects processed: ${total_projects}"
+    printf '%s\n' "- Total open findings: ${total_open}"
+    printf '%s\n' "- Generated by: \`roborev_daily_backlog_aggregator.sh\`"
+    printf '%s\n' "- Source DB: \`${ROBOREV_DB}\`"
+    printf '%s\n' "- Tracked in: JohnGavin/llm#355"
+  } > "$out_file"
+
+  echo "$out_file"
+}
+
+# ── Self-test ─────────────────────────────────────────────────────────────────
+_selftest() {
+  local pass=0 fail=0
+
+  _t() {
+    local label="$1" expected="$2" got="$3"
+    if [ "$got" = "$expected" ]; then
+      pass=$((pass + 1))
+      echo "  PASS [$label]"
+    else
+      fail=$((fail + 1))
+      echo "  FAIL [$label]: expected='$expected' got='$got'"
+    fi
+  }
+
+  # ── Build a synthetic DB ─────────────────────────────────────────────────
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local db="$tmpdir/reviews.db"
+
+  "$PYTHON" - "$db" <<'PYEOF'
+import sqlite3, sys
+db = sys.argv[1]
+con = sqlite3.connect(db)
+con.executescript("""
+CREATE TABLE IF NOT EXISTS repos (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    name      TEXT    NOT NULL,
+    root_path TEXT
+);
+CREATE TABLE IF NOT EXISTS review_jobs (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id     INTEGER,
+    status      TEXT DEFAULT 'done',
+    finished_at TEXT,
+    enqueued_at TEXT
+);
+CREATE TABLE IF NOT EXISTS reviews (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id  INTEGER,
+    output  TEXT,
+    closed  INTEGER DEFAULT 0
+);
+""")
+# Insert real-looking projects and some that should be filtered
+for name in ('llm', 'mycare', 'fixture_abc123', 'kb_wiki', 'file9afe2d343242',
+             'repo_XXXX', 'main', 'hello_t', 'historical'):
+    con.execute("INSERT INTO repos (name, root_path) VALUES (?, '')", (name,))
+con.commit()
+con.close()
+PYEOF
+
+  # Test 1: _list_projects emits only real project names
+  local listed
+  listed=$(ROBOREV_DB="$db" _list_projects "$db")
+  local listed_count
+  listed_count=$(echo "$listed" | grep -c . || true)
+  # Should have llm, mycare, historical — 3 real projects; not fixture_, kb_, file*, etc.
+  _t "list_projects: emits >=2 real projects" "1" "$([ "$listed_count" -ge 2 ] && echo 1 || echo 0)"
+  _t "list_projects: includes llm" "1" "$(echo "$listed" | grep -qx 'llm' && echo 1 || echo 0)"
+  _t "list_projects: excludes fixture_abc123" "1" "$(if echo "$listed" | grep -qx 'fixture_abc123'; then echo 0; else echo 1; fi)"
+  _t "list_projects: excludes kb_wiki" "1" "$(if echo "$listed" | grep -qx 'kb_wiki'; then echo 0; else echo 1; fi)"
+  _t "list_projects: excludes file hex entry" "1" "$(if echo "$listed" | grep -qx 'file9afe2d343242'; then echo 0; else echo 1; fi)"
+  _t "list_projects: excludes main" "1" "$(if echo "$listed" | grep -qx 'main'; then echo 0; else echo 1; fi)"
+  _t "list_projects: excludes hello_t" "1" "$(if echo "$listed" | grep -qx 'hello_t'; then echo 0; else echo 1; fi)"
+
+  # Test 2: missing DB returns empty (exit 0)
+  local _rc=0
+  local _out
+  _out=$(_list_projects "/tmp/no_such_db_$$" 2>/dev/null) || _rc=$?
+  _t "list_projects missing DB: exit 0" "0" "$_rc"
+  _t "list_projects missing DB: empty output" "" "$_out"
+
+  # Test 3: _write_global_summary produces a valid file
+  local out_file="$tmpdir/summary.md"
+  local summary_lines="llm|3|high|42
+mycare|1|medium|99
+historical|0|-|-"
+  _write_global_summary "$out_file" "$summary_lines" >/dev/null
+  _t "write_global_summary: file written" "1" "$([ -f "$out_file" ] && echo 1 || echo 0)"
+  if [ -f "$out_file" ]; then
+    _t "write_global_summary: has heading" "1" "$(grep -q 'global backlog' "$out_file" && echo 1 || echo 0)"
+    _t "write_global_summary: has per-project row" "1" "$(grep -q 'llm' "$out_file" && echo 1 || echo 0)"
+    _t "write_global_summary: has summary section" "1" "$(grep -q 'Total open findings' "$out_file" && echo 1 || echo 0)"
+    _t "write_global_summary: total open count correct (3+1+0=4)" "4" "$(grep 'Total open findings:' "$out_file" | grep -o '[0-9]*' | head -1)"
+  fi
+
+  # Test 4: bash -n syntax check on this script
+  local _bn_rc=0
+  bash -n "${BASH_SOURCE[0]}" 2>/dev/null || _bn_rc=$?
+  _t "bash -n exits 0 (syntax valid)" "0" "$_bn_rc"
+
+  # Test 5: _write_global_summary is idempotent (same date overwrites)
+  local out_file2="$tmpdir/summary2.md"
+  _write_global_summary "$out_file2" "llm|5|high|10" >/dev/null
+  _write_global_summary "$out_file2" "llm|7|medium|20" >/dev/null
+  _t "write_global_summary: idempotent (file count=1)" "1" "$([ -f "$out_file2" ] && echo 1 || echo 0)"
+  _t "write_global_summary: idempotent (overwritten with new count)" "1" "$(grep -q '7' "$out_file2" && echo 1 || echo 0)"
+
+  rm -rf "$tmpdir"
+
+  echo ""
+  echo "${pass}/$((pass + fail)) PASS"
+  [ "$fail" -eq 0 ] && return 0 || return 1
+}
+
+if [ "${ROBOREV_AGG_SELFTEST:-0}" = "1" ]; then
+  _selftest
+  exit $?
+fi
+
+# ── Main entry ────────────────────────────────────────────────────────────────
+
+# Fail-open: exit 0 if Python missing
+if [ ! -x "$PYTHON" ]; then
+  log "skip: $PYTHON not found"
+  echo "roborev_daily_backlog_aggregator: skipped ($PYTHON missing)"
+  exit 0
+fi
+
+# Fail-open: exit 0 if DB missing
+if [ ! -f "$ROBOREV_DB" ]; then
+  log "skip: DB not found at $ROBOREV_DB"
+  echo "roborev_daily_backlog_aggregator: skipped (DB missing)"
+  exit 0
+fi
+
+# Per-project script must exist
+if [ ! -x "$PER_PROJECT_SCRIPT" ]; then
+  log "error: per-project script not found or not executable: $PER_PROJECT_SCRIPT"
+  echo "roborev_daily_backlog_aggregator: error — per-project script missing" >&2
+  exit 1
+fi
+
+log "start: DB=$ROBOREV_DB dry_run=$DRY_RUN"
+
+# Enumerate projects
+projects=$(_list_projects "$ROBOREV_DB")
+
+if [ -z "$projects" ]; then
+  log "no projects found in DB"
+  echo "roborev_daily_backlog_aggregator: no projects found"
+  exit 0
+fi
+
+# Accumulate per-project results: "project|open_count|top_sev|top_id"
+summary_rows=""
+processed=0
+skipped=0
+
+while IFS= read -r project; do
+  [ -z "$project" ] && continue
+
+  # Resolve repo root
+  repo_root="${DOCS_ROOT}/${project}"
+
+  if [ ! -d "$repo_root" ]; then
+    log "skip: $project — root not found at $repo_root"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  log "running: $project (root=$repo_root)"
+
+  # Build argument list for per-project script
+  run_args=(
+    "$project"
+    --repo-root "$repo_root"
+  )
+  if [ "$DRY_RUN" -eq 1 ]; then
+    run_args+=(--dry-run)
+  fi
+
+  # Capture stdout; failures are soft (logged but not fatal)
+  per_out=""
+  per_rc=0
+  per_out=$(ROBOREV_DB="$ROBOREV_DB" bash "$PER_PROJECT_SCRIPT" "${run_args[@]}" 2>&1) || per_rc=$?
+
+  if [ "$per_rc" -ne 0 ]; then
+    log "warn: $project exited $per_rc — continuing"
+  fi
+
+  # Parse open_count and top-finding from per-project output
+  open_count=$(printf '%s\n' "$per_out" | grep "^OPEN_COUNT:" | head -1 | sed 's/^OPEN_COUNT://' | tr -d ' ')
+  top_id=$(printf '%s\n' "$per_out" | grep "^TOP_FINDING_ID:" | head -1 | sed 's/^TOP_FINDING_ID://' | tr -d ' ')
+  top_sev=$(printf '%s\n' "$per_out" | grep "^TOP_FINDING_SEV:" | head -1 | sed 's/^TOP_FINDING_SEV://' | tr -d ' ')
+
+  row="${project}|${open_count:-?}|${top_sev:--}|${top_id:--}"
+
+  if [ -z "$summary_rows" ]; then
+    summary_rows="$row"
+  else
+    summary_rows="${summary_rows}
+${row}"
+  fi
+
+  log "done: $project open=${open_count:-?} top_sev=${top_sev:--} top_id=${top_id:--}"
+  processed=$((processed + 1))
+
+done <<< "$projects"
+
+log "processed=$processed skipped=$skipped"
+
+# Write global summary (idempotent — same date overwrites)
+out_file="${OUT_DIR}/${TODAY}.md"
+written=$(_write_global_summary "$out_file" "$summary_rows")
+log "summary written: $written"
+
+echo "roborev_daily_backlog_aggregator: processed=$processed skipped=$skipped summary=$written"
+exit 0

--- a/tests/test_roborev_daily_backlog_aggregator.sh
+++ b/tests/test_roborev_daily_backlog_aggregator.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+# tests/test_roborev_daily_backlog_aggregator.sh
+#
+# Unit tests for .claude/scripts/roborev_daily_backlog_aggregator.sh
+#
+# Uses a synthetic SQLite fixture and a mock per-project script.
+# Exits 0 if all tests pass, 1 on any failure.
+#
+# Part of: JohnGavin/llm#355 (Component 6)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGG_SCRIPT="${SCRIPT_DIR}/../.claude/scripts/roborev_daily_backlog_aggregator.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT="$(mktemp -d)"
+
+cleanup() { rm -rf "${TMPDIR_ROOT}"; }
+trap cleanup EXIT
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        pass "${desc}"
+    else
+        fail "${desc} — expected='${expected}' actual='${actual}'"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if echo "${haystack}" | grep -qF "${needle}"; then
+        pass "${desc}"
+    else
+        fail "${desc} — '${needle}' not found in output"
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if echo "${haystack}" | grep -qF "${needle}"; then
+        fail "${desc} — '${needle}' should NOT appear but does"
+    else
+        pass "${desc}"
+    fi
+}
+
+# ── Synthetic DB builder ──────────────────────────────────────────────────────
+make_roborev_db() {
+    local db_path="$1"
+    shift
+    # Remaining args: repo names to insert
+    /usr/bin/python3 - "$db_path" "$@" <<'PYEOF'
+import sqlite3, sys
+db_path = sys.argv[1]
+repo_names = sys.argv[2:]
+con = sqlite3.connect(db_path)
+con.executescript("""
+CREATE TABLE IF NOT EXISTS repos (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    name      TEXT NOT NULL,
+    root_path TEXT
+);
+CREATE TABLE IF NOT EXISTS review_jobs (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id     INTEGER,
+    status      TEXT DEFAULT 'done',
+    finished_at TEXT,
+    enqueued_at TEXT
+);
+CREATE TABLE IF NOT EXISTS reviews (
+    id     INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER,
+    output TEXT,
+    closed INTEGER DEFAULT 0
+);
+""")
+for name in repo_names:
+    con.execute("INSERT INTO repos (name, root_path) VALUES (?, '')", (name,))
+con.commit()
+con.close()
+PYEOF
+}
+
+# ── Mock per-project script builder ──────────────────────────────────────────
+# Creates a bash script at $path that emits fake OPEN_COUNT / TOP_FINDING lines.
+make_mock_per_project_script() {
+    local path="$1"
+    local open_count="${2:-3}"
+    local top_id="${3:-99}"
+    local top_sev="${4:-high}"
+
+    cat > "$path" <<MOCK
+#!/usr/bin/env bash
+# Mock roborev_project_backlog.sh for testing
+# Emits structured metadata lines that aggregator parses
+echo "ROOT_PATH:/tmp/mock_root"
+echo "REPO:\$1"
+echo ""
+echo "OPEN_COUNT:${open_count}"
+echo "| id | sev | category | age_days | touches | priority | summary |"
+echo "|----|-----|----------|----------|---------|----------|---------|"
+echo "| ${top_id} | ${top_sev} | error-handling | 5 | 2 | 12.5 | Mock finding |"
+echo "TOP_FINDING_ID:${top_id}"
+echo "TOP_FINDING_SEV:${top_sev}"
+echo "TOP_FINDING_CAT:error-handling"
+MOCK
+    chmod +x "$path"
+}
+
+# ── Test 0: bash -n syntax check ─────────────────────────────────────────────
+bash_n_rc=0
+bash -n "${AGG_SCRIPT}" 2>/dev/null || bash_n_rc=$?
+assert_eq "test0: bash -n exits 0 (aggregator syntax valid)" "0" "${bash_n_rc}"
+
+# Also check plist file exists
+PLIST="${SCRIPT_DIR}/../.claude/launchd/com.claude.roborev-daily-backlog.plist"
+assert_eq "test0: plist file exists" "1" "$([ -f "${PLIST}" ] && echo 1 || echo 0)"
+
+# ── Test 1: Missing DB → exit 0 (fail-open) ──────────────────────────────────
+out1=""
+rc1=0
+out1=$(ROBOREV_DB="/tmp/no_such_db_agg_$$" \
+    bash "${AGG_SCRIPT}" 2>&1) || rc1=$?
+assert_eq "test1: exit 0 on missing DB" "0" "${rc1}"
+assert_contains "test1: reports skipped" "skipped" "${out1}"
+
+# ── Test 2: DB with real projects and mock per-project script ─────────────────
+DB2="${TMPDIR_ROOT}/db2.sqlite"
+DOCS2="${TMPDIR_ROOT}/docs2"
+OUT2="${TMPDIR_ROOT}/out2"
+MOCK2="${TMPDIR_ROOT}/mock_per_project.sh"
+
+# Create project directories that aggregator will find
+mkdir -p "${DOCS2}/llm"
+mkdir -p "${DOCS2}/mycare"
+mkdir -p "${DOCS2}/historical"
+
+# Create DB with those project names + some fixture names to be filtered
+make_roborev_db "${DB2}" \
+    "llm" "mycare" "historical" \
+    "fixture_abc" "kb_wiki" "file9afe2d343242" "repo_XXXX" "main"
+
+# Create mock per-project script
+make_mock_per_project_script "${MOCK2}" 5 42 "high"
+
+# Point aggregator at our mock script via env; override docs root and out dir
+out2=""
+rc2=0
+out2=$(ROBOREV_DB="${DB2}" \
+    ROBOREV_AGG_OUT_DIR="${OUT2}" \
+    bash "${AGG_SCRIPT}" \
+        --docs-root "${DOCS2}" \
+        2>&1) || rc2=$?
+
+# The aggregator uses PER_PROJECT_SCRIPT from SCRIPT_DIR, which points to the
+# real script.  We need to call it with our mock override instead.
+# Override by placing the mock in SCRIPT_DIR-relative path via symlink trick.
+# Actually, let's use SCRIPT_DIR override via a wrapper approach: create
+# a temp dir that contains both scripts, run AGG from there.
+
+# Create a temp scripts dir with our mock as the per-project script
+SCRIPTS_DIR2="${TMPDIR_ROOT}/scripts2"
+mkdir -p "${SCRIPTS_DIR2}"
+cp "${AGG_SCRIPT}" "${SCRIPTS_DIR2}/roborev_daily_backlog_aggregator.sh"
+cp "${MOCK2}" "${SCRIPTS_DIR2}/roborev_project_backlog.sh"
+chmod +x "${SCRIPTS_DIR2}/roborev_daily_backlog_aggregator.sh"
+chmod +x "${SCRIPTS_DIR2}/roborev_project_backlog.sh"
+
+out2=""
+rc2=0
+out2=$(ROBOREV_DB="${DB2}" \
+    ROBOREV_AGG_OUT_DIR="${OUT2}" \
+    bash "${SCRIPTS_DIR2}/roborev_daily_backlog_aggregator.sh" \
+        --docs-root "${DOCS2}" \
+        2>&1) || rc2=$?
+
+assert_eq "test2: exit 0 with real projects" "0" "${rc2}"
+assert_contains "test2: reports processed count" "processed=" "${out2}"
+# Should have processed llm, mycare, historical (3 projects)
+assert_contains "test2: processed=3" "processed=3" "${out2}"
+
+# Check global summary was written
+TODAY="$(date -u '+%Y-%m-%d')"
+SUMMARY2="${OUT2}/${TODAY}.md"
+assert_eq "test2: summary file written" "1" "$([ -f "${SUMMARY2}" ] && echo 1 || echo 0)"
+
+if [ -f "${SUMMARY2}" ]; then
+    content2="$(cat "${SUMMARY2}")"
+    assert_contains "test2: summary has heading" "global backlog summary" "${content2}"
+    assert_contains "test2: summary has llm row" "llm" "${content2}"
+    assert_contains "test2: summary has mycare row" "mycare" "${content2}"
+    assert_contains "test2: summary has historical row" "historical" "${content2}"
+    assert_contains "test2: summary has per-project table" "| project |" "${content2}"
+    assert_contains "test2: summary has open count" "Total open findings" "${content2}"
+    # Total open = 3 projects × 5 each = 15
+    assert_contains "test2: summary total open=15" "15" "${content2}"
+fi
+
+# ── Test 3: Fixture names are filtered out ────────────────────────────────────
+# summary should NOT contain the fixture/internal project names
+if [ -f "${SUMMARY2}" ]; then
+    content3="$(cat "${SUMMARY2}")"
+    assert_not_contains "test3: fixture_ excluded from summary" "fixture_abc" "${content3}"
+    assert_not_contains "test3: kb_ excluded from summary" "kb_wiki" "${content3}"
+    assert_not_contains "test3: hex file excluded" "file9afe2d343242" "${content3}"
+    assert_not_contains "test3: main excluded" "| main |" "${content3}"
+fi
+
+# ── Test 4: Missing project root → skipped (not fatal) ────────────────────────
+DB4="${TMPDIR_ROOT}/db4.sqlite"
+DOCS4="${TMPDIR_ROOT}/docs4"
+OUT4="${TMPDIR_ROOT}/out4"
+SCRIPTS_DIR4="${TMPDIR_ROOT}/scripts4"
+mkdir -p "${DOCS4}/llm"   # only llm exists; mycare does not
+
+make_roborev_db "${DB4}" "llm" "mycare"
+
+mkdir -p "${SCRIPTS_DIR4}"
+cp "${AGG_SCRIPT}" "${SCRIPTS_DIR4}/roborev_daily_backlog_aggregator.sh"
+cp "${MOCK2}" "${SCRIPTS_DIR4}/roborev_project_backlog.sh"
+chmod +x "${SCRIPTS_DIR4}/roborev_daily_backlog_aggregator.sh"
+chmod +x "${SCRIPTS_DIR4}/roborev_project_backlog.sh"
+
+out4=""
+rc4=0
+out4=$(ROBOREV_DB="${DB4}" \
+    ROBOREV_AGG_OUT_DIR="${OUT4}" \
+    bash "${SCRIPTS_DIR4}/roborev_daily_backlog_aggregator.sh" \
+        --docs-root "${DOCS4}" \
+        2>&1) || rc4=$?
+
+assert_eq "test4: exit 0 when a project root is missing" "0" "${rc4}"
+assert_contains "test4: processed=1" "processed=1" "${out4}"
+# skipped=1 for mycare whose root does not exist
+assert_contains "test4: skipped=1" "skipped=1" "${out4}"
+
+# ── Test 5: --dry-run passes through to per-project script ───────────────────
+# Create a mock that records whether --dry-run was passed
+MOCK5="${TMPDIR_ROOT}/mock_dryrun.sh"
+DRYRUN_FLAG_FILE="${TMPDIR_ROOT}/dryrun_flag"
+cat > "${MOCK5}" <<MOCK5EOF
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [ "\$arg" = "--dry-run" ]; then
+    touch "${DRYRUN_FLAG_FILE}"
+  fi
+done
+echo "OPEN_COUNT:2"
+echo "TOP_FINDING_ID:1"
+echo "TOP_FINDING_SEV:high"
+echo "TOP_FINDING_CAT:other"
+MOCK5EOF
+chmod +x "${MOCK5}"
+
+DB5="${TMPDIR_ROOT}/db5.sqlite"
+DOCS5="${TMPDIR_ROOT}/docs5"
+OUT5="${TMPDIR_ROOT}/out5"
+SCRIPTS_DIR5="${TMPDIR_ROOT}/scripts5"
+mkdir -p "${DOCS5}/llm"
+make_roborev_db "${DB5}" "llm"
+mkdir -p "${SCRIPTS_DIR5}"
+cp "${AGG_SCRIPT}" "${SCRIPTS_DIR5}/roborev_daily_backlog_aggregator.sh"
+cp "${MOCK5}" "${SCRIPTS_DIR5}/roborev_project_backlog.sh"
+chmod +x "${SCRIPTS_DIR5}/roborev_daily_backlog_aggregator.sh"
+
+out5=""
+rc5=0
+out5=$(ROBOREV_DB="${DB5}" \
+    ROBOREV_AGG_OUT_DIR="${OUT5}" \
+    bash "${SCRIPTS_DIR5}/roborev_daily_backlog_aggregator.sh" \
+        --docs-root "${DOCS5}" \
+        --dry-run \
+        2>&1) || rc5=$?
+
+assert_eq "test5: exit 0 with --dry-run" "0" "${rc5}"
+assert_eq "test5: --dry-run passed to per-project script" "1" "$([ -f "${DRYRUN_FLAG_FILE}" ] && echo 1 || echo 0)"
+
+# ── Test 6: Self-test via ROBOREV_AGG_SELFTEST ────────────────────────────────
+selftest_out=""
+selftest_rc=0
+selftest_out=$(ROBOREV_AGG_SELFTEST=1 bash "${AGG_SCRIPT}" 2>&1) || selftest_rc=$?
+assert_eq "test6: ROBOREV_AGG_SELFTEST exits 0" "0" "${selftest_rc}"
+assert_contains "test6: selftest reports PASS" "PASS" "${selftest_out}"
+
+# ── Test 7: Idempotent — same date overwrites summary ─────────────────────────
+DB7="${TMPDIR_ROOT}/db7.sqlite"
+DOCS7="${TMPDIR_ROOT}/docs7"
+OUT7="${TMPDIR_ROOT}/out7"
+SCRIPTS_DIR7="${TMPDIR_ROOT}/scripts7"
+mkdir -p "${DOCS7}/llm"
+make_roborev_db "${DB7}" "llm"
+
+# First mock: open_count=3
+MOCK7A="${TMPDIR_ROOT}/mock7a.sh"
+make_mock_per_project_script "${MOCK7A}" 3 10 "high"
+
+mkdir -p "${SCRIPTS_DIR7}"
+cp "${AGG_SCRIPT}" "${SCRIPTS_DIR7}/roborev_daily_backlog_aggregator.sh"
+cp "${MOCK7A}" "${SCRIPTS_DIR7}/roborev_project_backlog.sh"
+chmod +x "${SCRIPTS_DIR7}/roborev_daily_backlog_aggregator.sh"
+
+ROBOREV_DB="${DB7}" ROBOREV_AGG_OUT_DIR="${OUT7}" \
+    bash "${SCRIPTS_DIR7}/roborev_daily_backlog_aggregator.sh" \
+        --docs-root "${DOCS7}" >/dev/null 2>&1
+
+TODAY7="$(date -u '+%Y-%m-%d')"
+SUMMARY7="${OUT7}/${TODAY7}.md"
+first_count=$(grep 'Total open findings:' "${SUMMARY7}" | grep -o '[0-9]*' | head -1)
+
+# Second run: open_count=7
+MOCK7B="${TMPDIR_ROOT}/mock7b.sh"
+make_mock_per_project_script "${MOCK7B}" 7 20 "medium"
+cp "${MOCK7B}" "${SCRIPTS_DIR7}/roborev_project_backlog.sh"
+
+ROBOREV_DB="${DB7}" ROBOREV_AGG_OUT_DIR="${OUT7}" \
+    bash "${SCRIPTS_DIR7}/roborev_daily_backlog_aggregator.sh" \
+        --docs-root "${DOCS7}" >/dev/null 2>&1
+
+second_count=$(grep 'Total open findings:' "${SUMMARY7}" | grep -o '[0-9]*' | head -1)
+
+assert_eq "test7: first run count=3" "3" "${first_count}"
+assert_eq "test7: second run count=7 (overwritten)" "7" "${second_count}"
+
+# ── Test 8: plutil -lint on plist ────────────────────────────────────────────
+if command -v plutil >/dev/null 2>&1; then
+    plutil_rc=0
+    plutil -lint "${PLIST}" >/dev/null 2>&1 || plutil_rc=$?
+    assert_eq "test8: plutil -lint exits 0" "0" "${plutil_rc}"
+else
+    # plutil not available — skip gracefully
+    pass "test8: plutil not available (skipped)"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${PASS} PASS, ${FAIL} FAIL"
+
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Implements **Component 6** of #163 — the daily backlog aggregator job.
- Adds `roborev_daily_backlog_aggregator.sh` that iterates all projects registered in `~/.roborev/reviews.db`, calls the per-project watcher (from #357) for each resolvable root, and emits a global summary Markdown.
- Adds `com.claude.roborev-daily-backlog.plist` that fires nightly at 02:15 local (offset from metrics-ETL at 02:00 to avoid DB contention).
- Adds 29-test bash test suite covering: syntax check, missing-DB fail-open, fixture filtering, missing-root skip, `--dry-run` passthrough, idempotency, `plutil -lint`.

## Files

| File | Purpose |
|------|---------|
| `.claude/scripts/roborev_daily_backlog_aggregator.sh` | Main aggregator — loops projects, calls per-project script, writes global summary |
| `.claude/launchd/com.claude.roborev-daily-backlog.plist` | launchd job at 02:15 local |
| `tests/test_roborev_daily_backlog_aggregator.sh` | 29-test suite (29 PASS, 0 FAIL) |

## Smoke run (dry-run against real DB)

| Project | Open findings |
|---------|---------------|
| `llm` | 73 |
| `llmtelemetry` | 100 |
| `JohnGavin.github.io` | 30 |
| (30 other repos) | skipped — no `~/docs_gh/` root |

## Activation

```bash
cp ~/docs_gh/llm/.claude/launchd/com.claude.roborev-daily-backlog.plist \
   ~/Library/LaunchAgents/com.claude.roborev-daily-backlog.plist
launchctl load -w ~/Library/LaunchAgents/com.claude.roborev-daily-backlog.plist
```

Manual run:

```bash
~/.claude/scripts/roborev_daily_backlog_aggregator.sh
# or dry-run:
~/.claude/scripts/roborev_daily_backlog_aggregator.sh --dry-run
```

## Dependencies

- Per-project script `roborev_project_backlog.sh` from #357 (Components 1+2 of #163)
- `~/.roborev/reviews.db` (from existing roborev setup)

## References

Closes #355. Part of #163 Component 6. Builds on #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
