### PR TITLE
feat(roborev): weekly rollup digest + unified hook installer (#356)

### DIFF
--- a/.claude/launchd/com.claude.roborev-weekly-rollup-email.plist
+++ b/.claude/launchd/com.claude.roborev-weekly-rollup-email.plist
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.claude.roborev-weekly-rollup-email.plist
+     Weekly roborev cross-project digest email.
+     Runs Sunday at 09:15 local time (offset by 15 min from launchd-health-weekly
+     which runs at 09:00, to avoid I/O contention on reviews.db).
+
+     Install:
+       cp .claude/launchd/com.claude.roborev-weekly-rollup-email.plist \
+          ~/Library/LaunchAgents/com.claude.roborev-weekly-rollup-email.plist
+       launchctl load -w ~/Library/LaunchAgents/com.claude.roborev-weekly-rollup-email.plist
+
+     Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.claude.roborev-weekly-rollup-email.plist
+       rm ~/Library/LaunchAgents/com.claude.roborev-weekly-rollup-email.plist
+
+     Manual dry-run:
+       DRYRUN=1 EMAIL_DRY_RUN=1 bash ~/docs_gh/llm/bin/roborev_weekly_rollup_cron.sh
+
+     Credentials: ~/.claude/env/roborev_email.env (not committed; create manually)
+       GMAIL_USERNAME=you@gmail.com
+       GMAIL_APP_PASSWORD=<16-char app password>
+       REPORT_RECIPIENT=you@gmail.com
+       ROBOREV_DASHBOARD_URL=https://johngavin.github.io/llmtelemetry/#roborev
+
+     Tracked in llm#356.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.roborev-weekly-rollup-email</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/roborev_weekly_rollup_cron.sh</string>
+    </array>
+
+    <!-- Sunday at 09:15 local time (Weekday 0 = Sunday) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>15</integer>
+    </dict>
+
+    <!-- Do NOT run immediately on launchctl load -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- PATH must include nix stable profile so nix-shell and Rscript resolve -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+        <!-- NIX_SSL_CERT_FILE is required for nix-shell to make network calls -->
+        <key>NIX_SSL_CERT_FILE</key>
+        <string>/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/roborev_weekly_rollup_email_launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/roborev_weekly_rollup_email_launchd.log</string>
+
+    <!-- Retry once after 60 s if job exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+</dict>
+</plist>

--- a/.claude/scripts/roborev_weekly_rollup.R
+++ b/.claude/scripts/roborev_weekly_rollup.R
@@ -1,0 +1,538 @@
+#!/usr/bin/env Rscript
+# roborev_weekly_rollup.R — Weekly cross-project roborev digest.
+#
+# Reads:
+#   1. ~/.claude/logs/roborev_daily_backlog/<date>.md  (last 7 days, from #355 daily aggregator)
+#   2. ~/.roborev/reviews.db                           (SQLite, week-over-week trends)
+#   3. ~/.claude/logs/unified.duckdb roborev_review_lifecycle (close_reason distribution)
+#
+# Emits:
+#   - Markdown rollup → $ROBOREV_WEEKLY_DIR/YYYY-MM-DD.md  (default ~/.claude/logs/roborev_weekly_rollup/)
+#   - Prints to stdout
+#
+# Required env vars (none — all have defaults):
+#   ROBOREV_DAILY_BACKLOG_DIR   daily aggregator backlog files (default ~/.claude/logs/roborev_daily_backlog)
+#   ROBOREV_DB                  SQLite reviews DB             (default ~/.roborev/reviews.db)
+#   UNIFIED_DUCKDB              unified DuckDB                (default ~/.claude/logs/unified.duckdb)
+#   ROBOREV_WEEKLY_DIR          output dir                    (default ~/.claude/logs/roborev_weekly_rollup)
+#
+# Optional env vars:
+#   WEEKLY_DRY_RUN              "1" → print to stdout only, no file write
+#   EMAIL_DRY_RUN               "1" → same as WEEKLY_DRY_RUN (passed through from wrapper)
+#
+# Usage:
+#   Rscript .claude/scripts/roborev_weekly_rollup.R
+#   WEEKLY_DRY_RUN=1 Rscript .claude/scripts/roborev_weekly_rollup.R
+#
+# Called from bin/roborev_weekly_rollup_cron.sh and by send_roborev_weekly_rollup_email.R.
+# Tracked in llm#356.
+
+suppressPackageStartupMessages({
+  library(DBI)
+})
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+
+ROBOREV_DAILY_BACKLOG_DIR <- Sys.getenv(
+  "ROBOREV_DAILY_BACKLOG_DIR",
+  file.path(Sys.getenv("HOME"), ".claude", "logs", "roborev_daily_backlog")
+)
+
+REVIEWS_DB <- Sys.getenv(
+  "ROBOREV_DB",
+  file.path(Sys.getenv("HOME"), ".roborev", "reviews.db")
+)
+
+UNIFIED_DUCKDB <- Sys.getenv(
+  "UNIFIED_DUCKDB",
+  file.path(Sys.getenv("HOME"), ".claude", "logs", "unified.duckdb")
+)
+
+ROBOREV_WEEKLY_DIR <- Sys.getenv(
+  "ROBOREV_WEEKLY_DIR",
+  file.path(Sys.getenv("HOME"), ".claude", "logs", "roborev_weekly_rollup")
+)
+
+dry_run <- identical(Sys.getenv("WEEKLY_DRY_RUN"), "1") ||
+  identical(Sys.getenv("EMAIL_DRY_RUN"), "1")
+
+# ── Date range: last 7 full days ──────────────────────────────────────────────
+
+today      <- Sys.Date()
+week_start <- today - 7L   # inclusive
+week_end   <- today - 1L   # inclusive (yesterday = last full day)
+
+week_start_str <- format(week_start, "%Y-%m-%d")
+week_end_str   <- format(week_end, "%Y-%m-%d")
+
+cat(sprintf(
+  "roborev_weekly_rollup.R: period=%s to %s dry_run=%s\n",
+  week_start_str, week_end_str, dry_run
+))
+
+# ── 1. Parse daily backlog files ──────────────────────────────────────────────
+
+parse_daily_backlog_dir <- function(dir, from_date, to_date) {
+  if (!dir.exists(dir)) {
+    message("roborev_weekly_rollup: daily backlog dir not found: ", dir)
+    return(list(files_found = 0L, project_lines = character(0)))
+  }
+
+  date_seq <- seq.Date(from_date, to_date, by = "day")
+  file_candidates <- file.path(dir, paste0(format(date_seq, "%Y-%m-%d"), ".md"))
+  present_files   <- file_candidates[file.exists(file_candidates)]
+
+  if (length(present_files) == 0L) {
+    return(list(files_found = 0L, project_lines = character(0)))
+  }
+
+  # Collect lines that look like project-level open-count summaries
+  all_lines <- unlist(lapply(present_files, function(f) {
+    tryCatch(readLines(f, warn = FALSE), error = function(e) character(0))
+  }))
+
+  list(files_found = length(present_files), project_lines = all_lines)
+}
+
+daily_info <- parse_daily_backlog_dir(
+  ROBOREV_DAILY_BACKLOG_DIR, week_start, week_end
+)
+
+# ── 2. Query reviews.db for per-project week-over-week trends ────────────────
+
+query_reviews_db <- function(db_path, week_start_str, week_end_str) {
+  empty <- data.frame(
+    repo_name        = character(0),
+    opened_this_week = integer(0),
+    closed_this_week = integer(0),
+    close_rate       = numeric(0),
+    stringsAsFactors = FALSE
+  )
+  if (!file.exists(db_path)) {
+    message("roborev_weekly_rollup: reviews.db not found at ", db_path)
+    return(list(per_project = empty, global_close_rate = NA_real_,
+                global_opened = 0L, global_closed = 0L,
+                prev_global_close_rate = NA_real_,
+                median_ttc_hrs = NA_real_,
+                stuck_findings = data.frame(
+                  id = integer(0), repo = character(0),
+                  age_days = integer(0), severity = character(0),
+                  summary = character(0), stringsAsFactors = FALSE
+                )))
+  }
+
+  con <- tryCatch(
+    DBI::dbConnect(RSQLite::SQLite(), db_path, flags = RSQLite::SQLITE_RO),
+    error = function(e) {
+      message("roborev_weekly_rollup: cannot open reviews.db — ", conditionMessage(e))
+      NULL
+    }
+  )
+  if (is.null(con)) {
+    return(list(per_project = empty, global_close_rate = NA_real_,
+                global_opened = 0L, global_closed = 0L,
+                prev_global_close_rate = NA_real_,
+                median_ttc_hrs = NA_real_,
+                stuck_findings = data.frame(
+                  id = integer(0), repo = character(0),
+                  age_days = integer(0), severity = character(0),
+                  summary = character(0), stringsAsFactors = FALSE
+                )))
+  }
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+  # Per-project opened / closed in current week
+  per_proj_sql <- sprintf("
+    SELECT
+      r.name AS repo_name,
+      COUNT(CASE WHEN date(rj.finished_at) BETWEEN '%s' AND '%s' THEN 1 END) AS opened_this_week,
+      COUNT(CASE WHEN rv.closed = 1
+                   AND date(rv.updated_at) BETWEEN '%s' AND '%s' THEN 1 END) AS closed_this_week
+    FROM reviews rv
+    JOIN review_jobs rj ON rj.id = rv.job_id
+    JOIN repos r ON r.id = rj.repo_id
+    WHERE rj.status = 'done'
+    GROUP BY r.name
+    ORDER BY opened_this_week DESC
+  ", week_start_str, week_end_str,
+     week_start_str, week_end_str)
+
+  per_project <- tryCatch(
+    DBI::dbGetQuery(con, per_proj_sql),
+    error = function(e) {
+      message("roborev_weekly_rollup: per-project query failed — ", conditionMessage(e))
+      empty
+    }
+  )
+
+  # Compute per-project close rate (avoid division by zero)
+  if (nrow(per_project) > 0L) {
+    per_project$close_rate <- ifelse(
+      per_project$opened_this_week > 0L,
+      per_project$closed_this_week / per_project$opened_this_week,
+      NA_real_
+    )
+  } else {
+    per_project <- empty
+  }
+
+  # Global counts for current week
+  global_sql <- sprintf("
+    SELECT
+      COUNT(*) AS opened_this_week,
+      COUNT(CASE WHEN rv.closed = 1
+                   AND date(rv.updated_at) BETWEEN '%s' AND '%s' THEN 1 END) AS closed_this_week
+    FROM reviews rv
+    JOIN review_jobs rj ON rj.id = rv.job_id
+    WHERE rj.status = 'done'
+      AND date(rj.finished_at) BETWEEN '%s' AND '%s'
+  ", week_start_str, week_end_str,
+     week_start_str, week_end_str)
+
+  global_row <- tryCatch(
+    DBI::dbGetQuery(con, global_sql),
+    error = function(e) data.frame(opened_this_week = 0L, closed_this_week = 0L)
+  )
+
+  global_opened <- as.integer(global_row$opened_this_week[1L])
+  global_closed <- as.integer(global_row$closed_this_week[1L])
+  global_close_rate <- if (global_opened > 0L) global_closed / global_opened else NA_real_
+
+  # Previous week close rate for delta
+  prev_start <- format(week_start - 7L, "%Y-%m-%d")
+  prev_end   <- format(week_end   - 7L, "%Y-%m-%d")
+  prev_sql <- sprintf("
+    SELECT
+      COUNT(*) AS opened,
+      COUNT(CASE WHEN rv.closed = 1
+                   AND date(rv.updated_at) BETWEEN '%s' AND '%s' THEN 1 END) AS closed
+    FROM reviews rv
+    JOIN review_jobs rj ON rj.id = rv.job_id
+    WHERE rj.status = 'done'
+      AND date(rj.finished_at) BETWEEN '%s' AND '%s'
+  ", prev_start, prev_end, prev_start, prev_end)
+
+  prev_row <- tryCatch(
+    DBI::dbGetQuery(con, prev_sql),
+    error = function(e) data.frame(opened = 0L, closed = 0L)
+  )
+  prev_opened <- as.integer(prev_row$opened[1L])
+  prev_closed <- as.integer(prev_row$closed[1L])
+  prev_global_close_rate <- if (prev_opened > 0L) prev_closed / prev_opened else NA_real_
+
+  # Median time-to-close this week (hours) — best-effort from updated_at vs finished_at
+  ttc_sql <- sprintf("
+    SELECT
+      AVG(
+        CAST((julianday(rv.updated_at) - julianday(rj.finished_at)) * 24.0 AS REAL)
+      ) AS median_ttc_hrs
+    FROM reviews rv
+    JOIN review_jobs rj ON rj.id = rv.job_id
+    WHERE rj.status = 'done'
+      AND rv.closed = 1
+      AND date(rv.updated_at) BETWEEN '%s' AND '%s'
+      AND julianday(rv.updated_at) >= julianday(rj.finished_at)
+  ", week_start_str, week_end_str)
+
+  ttc_row <- tryCatch(
+    DBI::dbGetQuery(con, ttc_sql),
+    error = function(e) data.frame(median_ttc_hrs = NA_real_)
+  )
+  median_ttc_hrs <- as.numeric(ttc_row$median_ttc_hrs[1L])
+
+  # Top stuck findings: open, age > 7 days, order by age desc
+  stuck_sql <- "
+    SELECT
+      rv.id,
+      r.name AS repo,
+      CAST(julianday('now') - julianday(rj.finished_at) AS INTEGER) AS age_days,
+      rv.output
+    FROM reviews rv
+    JOIN review_jobs rj ON rj.id = rv.job_id
+    JOIN repos r ON r.id = rj.repo_id
+    WHERE rj.status = 'done'
+      AND rv.closed = 0
+      AND julianday('now') - julianday(rj.finished_at) > 7
+    ORDER BY age_days DESC
+    LIMIT 10
+  "
+
+  stuck_raw <- tryCatch(
+    DBI::dbGetQuery(con, stuck_sql),
+    error = function(e) data.frame(id = integer(0), repo = character(0),
+                                   age_days = integer(0), output = character(0))
+  )
+
+  # Extract one-line summary and severity from output text
+  extract_sev <- function(txt) {
+    txt <- txt %||% ""
+    for (sev in c("Critical", "High", "Medium", "Low")) {
+      if (grepl(paste0("Severity.*", sev), txt, ignore.case = TRUE)) return(tolower(sev))
+    }
+    "unknown"
+  }
+  extract_summary <- function(txt) {
+    if (is.null(txt) || is.na(txt) || !nzchar(txt)) return("")
+    lines <- trimws(strsplit(txt, "\n")[[1]])
+    lines <- lines[nzchar(lines)]
+    lines <- lines[!startsWith(lines, "#")]
+    lines <- lines[!startsWith(lines, "---")]
+    if (length(lines) == 0L) return("")
+    substr(lines[1L], 1L, 80L)
+  }
+
+  if (nrow(stuck_raw) > 0L) {
+    stuck_findings <- data.frame(
+      id       = stuck_raw$id,
+      repo     = stuck_raw$repo,
+      age_days = stuck_raw$age_days,
+      severity = vapply(stuck_raw$output, extract_sev, character(1L)),
+      summary  = vapply(stuck_raw$output, extract_summary, character(1L)),
+      stringsAsFactors = FALSE
+    )
+  } else {
+    stuck_findings <- data.frame(
+      id = integer(0), repo = character(0), age_days = integer(0),
+      severity = character(0), summary = character(0),
+      stringsAsFactors = FALSE
+    )
+  }
+
+  list(
+    per_project          = per_project,
+    global_close_rate    = global_close_rate,
+    global_opened        = global_opened,
+    global_closed        = global_closed,
+    prev_global_close_rate = prev_global_close_rate,
+    median_ttc_hrs       = median_ttc_hrs,
+    stuck_findings       = stuck_findings
+  )
+}
+
+# Null-coalescing helper
+`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0L && !is.na(a[1L])) a else b
+
+# Load RSQLite if available; fall back gracefully
+has_rsqlite <- requireNamespace("RSQLite", quietly = TRUE)
+if (!has_rsqlite) {
+  message("roborev_weekly_rollup: RSQLite not available — DB queries skipped")
+  db_data <- list(
+    per_project = data.frame(repo_name = character(0),
+                             opened_this_week = integer(0),
+                             closed_this_week = integer(0),
+                             close_rate = numeric(0), stringsAsFactors = FALSE),
+    global_close_rate = NA_real_, global_opened = 0L, global_closed = 0L,
+    prev_global_close_rate = NA_real_, median_ttc_hrs = NA_real_,
+    stuck_findings = data.frame(id = integer(0), repo = character(0),
+                                age_days = integer(0), severity = character(0),
+                                summary = character(0), stringsAsFactors = FALSE)
+  )
+} else {
+  db_data <- query_reviews_db(REVIEWS_DB, week_start_str, week_end_str)
+}
+
+# ── 3. Query unified.duckdb for close_reason distribution ────────────────────
+
+query_close_reasons <- function(duckdb_path, week_start_str, week_end_str) {
+  empty <- data.frame(close_reason = character(0), n = integer(0),
+                      stringsAsFactors = FALSE)
+
+  if (!file.exists(duckdb_path)) {
+    message("roborev_weekly_rollup: unified.duckdb not found at ", duckdb_path)
+    return(empty)
+  }
+
+  has_duckdb <- requireNamespace("duckdb", quietly = TRUE)
+  if (!has_duckdb) {
+    message("roborev_weekly_rollup: duckdb package not available — skipping close_reason query")
+    return(empty)
+  }
+
+  con <- tryCatch(
+    DBI::dbConnect(duckdb::duckdb(), duckdb_path, read_only = TRUE),
+    error = function(e) {
+      message("roborev_weekly_rollup: cannot open unified.duckdb — ", conditionMessage(e))
+      NULL
+    }
+  )
+  if (is.null(con)) return(empty)
+  on.exit({
+    DBI::dbDisconnect(con, shutdown = FALSE)
+  }, add = TRUE)
+
+  # Check if the relevant table/column exists
+  tables <- tryCatch(
+    DBI::dbListTables(con),
+    error = function(e) character(0)
+  )
+
+  if (!"roborev_review_lifecycle" %in% tables) {
+    message("roborev_weekly_rollup: roborev_review_lifecycle not in unified.duckdb")
+    return(empty)
+  }
+
+  # Use closed_at IS NOT NULL as the closed indicator (per #316 schema).
+  # Fall back to closed = 1 for older schema versions.
+  columns <- tryCatch(
+    DBI::dbListFields(con, "roborev_review_lifecycle"),
+    error = function(e) character(0)
+  )
+  closed_clause <- if ("closed_at" %in% columns) {
+    sprintf("closed_at IS NOT NULL AND CAST(closed_at AS DATE) BETWEEN DATE '%s' AND DATE '%s'",
+            week_start_str, week_end_str)
+  } else {
+    sprintf("closed = 1 AND CAST(updated_at AS DATE) BETWEEN DATE '%s' AND DATE '%s'",
+            week_start_str, week_end_str)
+  }
+
+  sql <- sprintf("
+    SELECT
+      COALESCE(close_reason, 'unknown') AS close_reason,
+      COUNT(*) AS n
+    FROM roborev_review_lifecycle
+    WHERE %s
+    GROUP BY close_reason
+    ORDER BY n DESC
+  ", closed_clause)
+
+  tryCatch(
+    DBI::dbGetQuery(con, sql),
+    error = function(e) {
+      message("roborev_weekly_rollup: close_reason query failed — ", conditionMessage(e))
+      empty
+    }
+  )
+}
+
+close_reasons <- query_close_reasons(UNIFIED_DUCKDB, week_start_str, week_end_str)
+
+# ── 4. Build markdown rollup ──────────────────────────────────────────────────
+
+fmt_rate <- function(x) {
+  if (is.null(x) || length(x) == 0L || is.na(x)) return("n/a")
+  sprintf("%.1f%%", as.numeric(x) * 100)
+}
+
+fmt_hrs <- function(x) {
+  if (is.null(x) || length(x) == 0L || is.na(x)) return("n/a")
+  h <- as.numeric(x)
+  if (h < 1) sprintf("%.0f min", h * 60) else sprintf("%.1f h", h)
+}
+
+fmt_delta <- function(current, previous) {
+  if (is.na(current) || is.na(previous)) return("")
+  delta <- current - previous
+  sign  <- if (delta >= 0) "+" else ""
+  sprintf(" (%s%.1f pp)", sign, delta * 100)
+}
+
+rate_delta_str <- fmt_delta(
+  db_data$global_close_rate %||% NA_real_,
+  db_data$prev_global_close_rate %||% NA_real_
+)
+
+# §1 Global summary
+section_global <- sprintf(
+  "## Global Summary\n\nPeriod: %s to %s\n\n| Metric | Value |\n|--------|-------|\n| Opened this week | %d |\n| Closed this week | %d |\n| Close rate | %s%s |\n| Median time-to-close | %s |\n| Daily backlog files found | %d / 7 |\n",
+  week_start_str, week_end_str,
+  db_data$global_opened,
+  db_data$global_closed,
+  fmt_rate(db_data$global_close_rate), rate_delta_str,
+  fmt_hrs(db_data$median_ttc_hrs),
+  daily_info$files_found
+)
+
+# §2 Per-project table
+if (nrow(db_data$per_project) > 0L) {
+  proj_rows <- paste0(
+    vapply(seq_len(nrow(db_data$per_project)), function(i) {
+      row <- db_data$per_project[i, ]
+      sprintf("| %s | %d | %d | %s |",
+              row$repo_name,
+              row$opened_this_week,
+              row$closed_this_week,
+              fmt_rate(row$close_rate))
+    }, character(1L)),
+    collapse = "\n"
+  )
+  section_projects <- paste0(
+    "## Per-Project Backlog\n\n",
+    "| Project | Opened | Closed | Close Rate |\n",
+    "|---------|--------|--------|------------|\n",
+    proj_rows, "\n"
+  )
+} else {
+  section_projects <- "## Per-Project Backlog\n\n_(no data — reviews.db unavailable or empty)_\n"
+}
+
+# §3 Close-reason distribution
+if (nrow(close_reasons) > 0L) {
+  total_closed <- sum(close_reasons$n)
+  cr_rows <- paste0(
+    vapply(seq_len(nrow(close_reasons)), function(i) {
+      row <- close_reasons[i, ]
+      pct <- if (total_closed > 0L) row$n / total_closed else 0
+      sprintf("| %s | %d | %.1f%% |",
+              row$close_reason, row$n, pct * 100)
+    }, character(1L)),
+    collapse = "\n"
+  )
+  section_reasons <- paste0(
+    "## Close-Reason Distribution\n\n",
+    "| Reason | Count | % |\n",
+    "|--------|-------|---|\n",
+    cr_rows, "\n"
+  )
+} else {
+  section_reasons <- "## Close-Reason Distribution\n\n_(no data — unified.duckdb unavailable or table missing)_\n"
+}
+
+# §4 Top stuck findings
+if (nrow(db_data$stuck_findings) > 0L) {
+  n_show <- min(10L, nrow(db_data$stuck_findings))
+  stuck_rows <- paste0(
+    vapply(seq_len(n_show), function(i) {
+      row <- db_data$stuck_findings[i, ]
+      summary_esc <- gsub("|", "\\|", row$summary, fixed = TRUE)
+      sprintf("| %d | %s | %d days | %s | %s |",
+              row$id, row$repo, row$age_days, row$severity, summary_esc)
+    }, character(1L)),
+    collapse = "\n"
+  )
+  section_stuck <- paste0(
+    "## Top Stuck Findings (open > 7 days)\n\n",
+    "| ID | Project | Age | Severity | Summary |\n",
+    "|----|---------|-----|----------|---------|\n",
+    stuck_rows, "\n"
+  )
+} else {
+  section_stuck <- "## Top Stuck Findings (open > 7 days)\n\n_(none — all findings closed or too recent)_\n"
+}
+
+# Assemble full rollup
+rollup_md <- paste(
+  sprintf("# roborev Weekly Rollup — %s", format(today, "%Y-%m-%d")),
+  sprintf("_Generated: %s UTC_", format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")),
+  "",
+  section_global,
+  section_projects,
+  section_reasons,
+  section_stuck,
+  sep = "\n"
+)
+
+# ── 5. Write output ───────────────────────────────────────────────────────────
+
+if (dry_run) {
+  message("roborev_weekly_rollup.R: WEEKLY_DRY_RUN=1 — printing to stdout only")
+  cat(rollup_md, "\n")
+  message("roborev_weekly_rollup.R: dry-run complete (no file written)")
+  quit(status = 0L)
+}
+
+dir.create(ROBOREV_WEEKLY_DIR, showWarnings = FALSE, recursive = TRUE)
+out_path <- file.path(ROBOREV_WEEKLY_DIR, paste0(format(today, "%Y-%m-%d"), ".md"))
+
+writeLines(rollup_md, out_path)
+message(sprintf("roborev_weekly_rollup.R: wrote %s", out_path))
+cat(rollup_md, "\n")

--- a/.claude/scripts/send_roborev_weekly_rollup_email.R
+++ b/.claude/scripts/send_roborev_weekly_rollup_email.R
@@ -1,0 +1,273 @@
+#!/usr/bin/env Rscript
+# send_roborev_weekly_rollup_email.R — Send weekly roborev rollup digest via Gmail.
+#
+# Mirrors the pattern of send_roborev_email.R (llm#287 Part A).
+#
+# 1. Calls roborev_weekly_rollup.R to produce the markdown rollup.
+# 2. Converts the markdown to an HTML email body.
+# 3. Sends via blastula SMTP.
+#
+# Required env vars:
+#   GMAIL_USERNAME       Gmail address (sender + credential lookup)
+#   GMAIL_APP_PASSWORD   Gmail app password
+#   REPORT_RECIPIENT     Recipient address (falls back to GMAIL_USERNAME)
+#
+# Optional env vars:
+#   ROBOREV_DAILY_BACKLOG_DIR   override daily backlog dir
+#   ROBOREV_DB                  override reviews.db path
+#   UNIFIED_DUCKDB              override unified.duckdb path
+#   ROBOREV_WEEKLY_DIR          override weekly rollup output dir
+#   ROBOREV_DASHBOARD_URL       dashboard link (default provided)
+#   EMAIL_DRY_RUN               "1" → print body to stdout, do not send
+#
+# Usage:
+#   Rscript .claude/scripts/send_roborev_weekly_rollup_email.R
+#   EMAIL_DRY_RUN=1 Rscript .claude/scripts/send_roborev_weekly_rollup_email.R
+#
+# Called from bin/roborev_weekly_rollup_cron.sh.
+# Tracked in llm#356.
+
+suppressPackageStartupMessages({
+  library(blastula)
+})
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+ROBOREV_DASHBOARD_URL <- Sys.getenv(
+  "ROBOREV_DASHBOARD_URL",
+  "https://johngavin.github.io/llmtelemetry/#roborev"
+)
+
+ROBOREV_WEEKLY_DIR <- Sys.getenv(
+  "ROBOREV_WEEKLY_DIR",
+  file.path(Sys.getenv("HOME"), ".claude", "logs", "roborev_weekly_rollup")
+)
+
+dry_run <- identical(Sys.getenv("EMAIL_DRY_RUN"), "1")
+
+# ── Locate or generate the weekly rollup ──────────────────────────────────────
+
+rollup_script <- file.path(
+  dirname(normalizePath(sys.frame(0)$filename %||% ".")),
+  "roborev_weekly_rollup.R"
+)
+# Fallback: resolve from this file's own path
+rollup_script_candidates <- c(
+  rollup_script,
+  file.path(Sys.getenv("HOME"), "docs_gh", "llm", ".claude", "scripts",
+            "roborev_weekly_rollup.R")
+)
+rollup_script <- rollup_script_candidates[file.exists(rollup_script_candidates)][1L]
+
+# Null coalescing helper (must precede any use)
+`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0L) a else b
+
+rollup_script <- rollup_script %||% NA_character_
+
+today_str <- format(Sys.Date(), "%Y-%m-%d")
+rollup_path <- file.path(ROBOREV_WEEKLY_DIR, paste0(today_str, ".md"))
+
+# If rollup file doesn't exist yet, generate it first
+if (!file.exists(rollup_path)) {
+  if (!is.na(rollup_script) && file.exists(rollup_script)) {
+    message("send_roborev_weekly_rollup_email.R: generating rollup via ",
+            rollup_script)
+    ret <- system2(
+      "Rscript",
+      args = rollup_script,
+      stdout = TRUE,
+      stderr = TRUE
+    )
+    if (!is.null(attr(ret, "status")) && attr(ret, "status") != 0L) {
+      message("send_roborev_weekly_rollup_email.R: rollup script returned non-zero")
+      message(paste(ret, collapse = "\n"))
+    }
+  } else {
+    message("send_roborev_weekly_rollup_email.R: rollup script not found — ",
+            "set ROBOREV_WEEKLY_DIR or run roborev_weekly_rollup.R first")
+  }
+}
+
+# Read the rollup markdown (may still be absent if DB unavailable)
+if (file.exists(rollup_path)) {
+  rollup_md <- paste(readLines(rollup_path, warn = FALSE), collapse = "\n")
+} else {
+  rollup_md <- paste0(
+    "# roborev Weekly Rollup — ", today_str, "\n\n",
+    "_(rollup file not found at ", rollup_path, " — check roborev_weekly_rollup.R)_\n"
+  )
+}
+
+# ── Colour palette (dark-mode safe, matches llmtelemetry convention) ──────────
+
+dark_bg       <- "#1a1a2e"
+dark_card     <- "#16213e"
+dark_row_alt  <- "#0f3460"
+dark_text     <- "#e8e8e8"
+dark_muted    <- "#a0a0a0"
+dark_border   <- "#2a2a4a"
+accent_green  <- "#00d26a"
+accent_blue   <- "#4fc3f7"
+accent_orange <- "#ff9800"
+
+# ── Convert markdown to simple HTML ──────────────────────────────────────────
+
+md_to_simple_html <- function(md) {
+  lines <- strsplit(md, "\n")[[1L]]
+  html_parts <- character(length(lines))
+  in_table <- FALSE
+
+  for (i in seq_along(lines)) {
+    l <- lines[i]
+
+    if (grepl("^## ", l)) {
+      if (in_table) { html_parts[i - 1L] <- paste0(html_parts[i - 1L], "</table>"); in_table <- FALSE }
+      html_parts[i] <- sprintf(
+        '<h3 style="color:%s; margin-top:20px; border-bottom:1px solid %s; padding-bottom:4px;">%s</h3>',
+        accent_orange, dark_border, substr(l, 4L, nchar(l))
+      )
+    } else if (grepl("^# ", l)) {
+      html_parts[i] <- sprintf(
+        '<h2 style="color:%s; margin-bottom:4px;">%s</h2>',
+        accent_orange, substr(l, 3L, nchar(l))
+      )
+    } else if (grepl("^_.*_$", l)) {
+      # Italics line (e.g. _Generated: ..._)
+      inner <- gsub("^_(.*)_$", "\\1", l)
+      html_parts[i] <- sprintf('<p style="color:%s; font-size:11px; margin:2px 0;">%s</p>',
+                                dark_muted, inner)
+    } else if (grepl("^\\|", l) && grepl("\\|$", l)) {
+      # Table row
+      if (!in_table) {
+        html_parts[i] <- sprintf(
+          '<table style="border-collapse:collapse; width:100%%; font-size:12px; margin:8px 0;">\n',
+          NULL
+        )
+        in_table <- TRUE
+      }
+      # Skip separator rows (|---|...)
+      if (grepl("^\\|[\\s-|]+\\|$", l)) {
+        html_parts[i] <- ""
+        next
+      }
+      cells <- strsplit(trimws(sub("^\\|", "", sub("\\|$", "", l))), "\\|")[[1L]]
+      cells <- trimws(cells)
+      is_header <- i > 1L && !grepl("^\\|[\\s-|]+\\|$", lines[min(i + 1L, length(lines))])
+      cell_tag <- "td"
+      cell_style <- sprintf('style="padding:5px 8px; border:1px solid %s; color:%s;"',
+                             dark_border, dark_text)
+      bg <- if ((i %% 2L) == 0L) dark_row_alt else dark_card
+      cells_html <- paste0(
+        vapply(cells, function(c) {
+          sprintf('<%s %s>%s</%s>', cell_tag, cell_style, c, cell_tag)
+        }, character(1L)),
+        collapse = ""
+      )
+      html_parts[i] <- sprintf('<tr style="background-color:%s;">%s</tr>', bg, cells_html)
+    } else {
+      if (in_table) {
+        html_parts[i] <- paste0("</table>\n",
+                                sprintf('<p style="color:%s; font-size:12px;">%s</p>', dark_text, l))
+        in_table <- FALSE
+      } else if (nzchar(trimws(l))) {
+        html_parts[i] <- sprintf('<p style="color:%s; font-size:12px; margin:4px 0;">%s</p>',
+                                  dark_text, l)
+      } else {
+        html_parts[i] <- ""
+      }
+    }
+  }
+  if (in_table) html_parts[length(html_parts)] <- paste0(html_parts[length(html_parts)], "</table>")
+  paste(html_parts, collapse = "\n")
+}
+
+body_inner <- md_to_simple_html(rollup_md)
+
+# Dashboard CTA
+dashboard_block <- sprintf(
+  '<div style="margin: 16px 0;">
+  <a href="%s"
+     style="display:inline-block; padding:10px 20px; background-color:%s;
+            color:#1a1a2e; text-decoration:none; border-radius:4px;
+            font-weight:bold; font-size:13px;">
+    View Full roborev Dashboard
+  </a>
+</div>',
+  ROBOREV_DASHBOARD_URL, accent_blue
+)
+
+email_body <- sprintf(
+  '<div style="background-color:%s; color:%s; padding:20px;
+               font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">
+%s
+%s
+<p style="color:%s; font-size:10px; margin-top:20px;">Rollup file: %s</p>
+</div>',
+  dark_bg, dark_text,
+  body_inner,
+  dashboard_block,
+  dark_muted, rollup_path
+)
+
+# ── Dry-run mode ───────────────────────────────────────────────────────────────
+
+if (dry_run) {
+  message("send_roborev_weekly_rollup_email.R: EMAIL_DRY_RUN=1 — printing to stdout")
+  cat(email_body, "\n")
+  message("send_roborev_weekly_rollup_email.R: dry-run complete (not sent)")
+  quit(status = 0L)
+}
+
+# ── Credentials ────────────────────────────────────────────────────────────────
+
+gmail_user <- Sys.getenv("GMAIL_USERNAME", "")
+gmail_pass <- Sys.getenv("GMAIL_APP_PASSWORD", "")
+
+if (!nzchar(gmail_user) || !nzchar(gmail_pass)) {
+  message("send_roborev_weekly_rollup_email.R: GMAIL_USERNAME or GMAIL_APP_PASSWORD not set")
+  cat("\n--- Email body (credentials missing, not sent) ---\n")
+  cat(email_body, "\n")
+  quit(status = 1L)
+}
+
+report_to <- Sys.getenv("REPORT_RECIPIENT", "")
+if (!nzchar(report_to)) report_to <- gmail_user
+
+# ── Compose and send ───────────────────────────────────────────────────────────
+
+london_time <- format(Sys.time(), tz = "Europe/London", "%Y-%m-%d %H:%M")
+
+email <- compose_email(
+  body   = md(email_body),
+  footer = md(sprintf(
+    "<span style='color:%s;'>Sent: %s (London)</span>",
+    dark_muted, london_time
+  ))
+)
+
+smtp_creds <- creds_envvar(
+  user        = gmail_user,
+  pass_envvar = "GMAIL_APP_PASSWORD",
+  host        = "smtp.gmail.com",
+  port        = 465L,
+  use_ssl     = TRUE
+)
+
+tryCatch({
+  smtp_send(
+    email       = email,
+    to          = report_to,
+    from        = gmail_user,
+    subject     = sprintf("roborev Weekly Rollup — %s", today_str),
+    credentials = smtp_creds
+  )
+  message(sprintf(
+    "send_roborev_weekly_rollup_email.R: email sent to %s", report_to
+  ))
+}, error = function(e) {
+  message("send_roborev_weekly_rollup_email.R: SMTP send failed — ",
+          conditionMessage(e))
+  cat("\n--- Email body (SMTP failed) ---\n")
+  cat(email_body, "\n")
+  quit(status = 1L)
+})

--- a/bin/roborev_install_all_hooks.sh
+++ b/bin/roborev_install_all_hooks.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# roborev_install_all_hooks.sh <repo-path>
+#
+# Unified per-repo hook installer.  Installs ALL three roborev hooks for one
+# repository in a single idempotent command:
+#
+#   1. post-merge hook   (bin/roborev_install_post_merge_hook.sh)   — llm#217
+#   2. commit-msg hook   (bin/roborev_install_commit_msg_hook.sh)   — llm#352
+#   3. post-commit hook  (bin/roborev_install_post_commit_verifier.sh) — llm#353
+#
+# If an individual installer is absent (sibling PR not yet merged), the
+# unified installer emits a WARNING and continues — it never hard-fails on a
+# missing child installer.  This makes Component 8 independently deployable.
+#
+# Idempotent: re-running on a repo that already has all hooks is safe.
+#
+# Safety: inherits each child installer's own safety checks (unrecognised
+# existing hook detection, DB migration validation, etc.).
+#
+# Usage:
+#   bin/roborev_install_all_hooks.sh /path/to/repo
+#   bin/roborev_install_all_hooks.sh --dry-run /path/to/repo
+#
+# Options:
+#   --dry-run   Pass --dry-run through to each child installer (no files written)
+#   --help      Show this message
+#
+# Self-test:
+#   ROBOREV_INSTALL_ALL_SELFTEST=1 bash bin/roborev_install_all_hooks.sh
+#
+# Part of: llm#356 Component 8
+# Tracked in llm#163 automation loop
+
+set -uo pipefail
+
+export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# SCRIPT_DIR may be overridden by tests (via env var) or defaults to this
+# script's own directory.  The env-var override lets tests supply stub child
+# installers without modifying the real bin/ directory.
+if [ -z "${SCRIPT_DIR:-}" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# ── Usage ─────────────────────────────────────────────────────────────────────
+
+usage() {
+  grep '^#' "$0" | grep -v '^#!/' | sed 's/^# \{0,1\}//' | head -30
+  exit 0
+}
+
+# ── Self-test ─────────────────────────────────────────────────────────────────
+
+_selftest() {
+  local pass=0 fail=0
+  _t() {
+    local label="$1" expected="$2" got="$3"
+    if [ "$got" = "$expected" ]; then
+      pass=$((pass+1))
+      echo "  PASS [$label]"
+    else
+      fail=$((fail+1))
+      echo "  FAIL [$label]: expected='$expected' got='$got'"
+    fi
+  }
+
+  # Create a minimal git repo with stub child installers
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local repo="$tmpdir/test_repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email "test@test"
+  git -C "$repo" config user.name "Test"
+  touch "$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -q -m "init"
+
+  local stub_dir="$tmpdir/bin"
+  mkdir -p "$stub_dir"
+
+  # Stub installer: post-merge (succeeds, writes marker)
+  cat > "$stub_dir/roborev_install_post_merge_hook.sh" <<'STUB'
+#!/usr/bin/env bash
+# Stub: records invocation
+echo "OK: stub post-merge hook installed in $1"
+exit 0
+STUB
+  chmod +x "$stub_dir/roborev_install_post_merge_hook.sh"
+
+  # Stub installer: commit-msg (succeeds)
+  cat > "$stub_dir/roborev_install_commit_msg_hook.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "OK: stub commit-msg hook installed in $1"
+exit 0
+STUB
+  chmod +x "$stub_dir/roborev_install_commit_msg_hook.sh"
+
+  # Stub installer: post-commit verifier (succeeds)
+  cat > "$stub_dir/roborev_install_post_commit_verifier.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "OK: stub post-commit hook installed in $1"
+exit 0
+STUB
+  chmod +x "$stub_dir/roborev_install_post_commit_verifier.sh"
+
+  # Test 1: all three stubs present — installer exits 0
+  local rc=0
+  SCRIPT_DIR="$stub_dir" bash "$0" "$repo" 2>/dev/null || rc=$?
+  _t "all stubs present: exit 0" "0" "$rc"
+
+  # Test 2: missing commit-msg installer — exits 0 (skip with warning)
+  rm -f "$stub_dir/roborev_install_commit_msg_hook.sh"
+  rc=0
+  SCRIPT_DIR="$stub_dir" bash "$0" "$repo" 2>/dev/null || rc=$?
+  _t "missing commit-msg: exit 0 (skip)" "0" "$rc"
+  # Restore
+  cat > "$stub_dir/roborev_install_commit_msg_hook.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "OK: stub commit-msg hook installed in $1"
+exit 0
+STUB
+  chmod +x "$stub_dir/roborev_install_commit_msg_hook.sh"
+
+  # Test 3: missing post-commit verifier — exits 0 (skip)
+  rm -f "$stub_dir/roborev_install_post_commit_verifier.sh"
+  rc=0
+  SCRIPT_DIR="$stub_dir" bash "$0" "$repo" 2>/dev/null || rc=$?
+  _t "missing post-commit: exit 0 (skip)" "0" "$rc"
+
+  # Test 4: non-git directory — exits 1
+  rc=0
+  SCRIPT_DIR="$stub_dir" bash "$0" "$tmpdir" 2>/dev/null || rc=$?
+  _t "non-git dir: exit 1" "1" "$rc"
+
+  # Test 5: missing repo path argument — exits 1
+  rc=0
+  SCRIPT_DIR="$stub_dir" bash "$0" 2>/dev/null || rc=$?
+  _t "no args: exit 1" "1" "$rc"
+
+  rm -rf "$tmpdir"
+  echo ""
+  echo "${pass}/$((pass+fail)) PASS"
+  [ "$fail" -eq 0 ] && return 0 || return 1
+}
+
+if [ "${ROBOREV_INSTALL_ALL_SELFTEST:-0}" = "1" ]; then
+  _selftest
+  exit $?
+fi
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+DRY_RUN_FLAG=""
+REPO_PATH=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)  DRY_RUN_FLAG="--dry-run" ; shift ;;
+    -h|--help)  usage ;;
+    -*)         echo "ERROR: unknown option: $1" >&2; exit 1 ;;
+    *)
+      if [ -z "$REPO_PATH" ]; then
+        REPO_PATH="$1"
+      else
+        echo "ERROR: unexpected argument '$1' (repo path already set to '$REPO_PATH')" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$REPO_PATH" ]; then
+  echo "ERROR: repo path argument required" >&2
+  echo "Usage: $0 [--dry-run] <repo-path>" >&2
+  exit 1
+fi
+
+if [ ! -d "$REPO_PATH/.git" ]; then
+  echo "ERROR: not a git repository (no .git/ directory): $REPO_PATH" >&2
+  exit 1
+fi
+
+# ── Helper: call child installer, skip gracefully if missing ─────────────────
+
+# Counters
+installed=0
+skipped=0
+failed=0
+
+_call_installer() {
+  local installer_name="$1"
+  local installer_path="$SCRIPT_DIR/$installer_name"
+
+  if [ ! -f "$installer_path" ]; then
+    echo "WARNING: $installer_name not found at $installer_path — skipping (PR not yet merged?)" >&2
+    skipped=$((skipped+1))
+    return 0
+  fi
+
+  if [ ! -x "$installer_path" ]; then
+    chmod +x "$installer_path" 2>/dev/null || true
+  fi
+
+  local output rc
+  rc=0
+  # shellcheck disable=SC2086
+  output=$("$installer_path" $DRY_RUN_FLAG "$REPO_PATH" 2>&1) || rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    echo "FAILED: $installer_name in $REPO_PATH (exit $rc)" >&2
+    echo "$output" >&2
+    failed=$((failed+1))
+  elif echo "$output" | grep -q "^SKIP:"; then
+    echo "$output"
+    skipped=$((skipped+1))
+  else
+    echo "$output"
+    installed=$((installed+1))
+  fi
+}
+
+# ── Install all three hooks ───────────────────────────────────────────────────
+
+echo "roborev_install_all_hooks: installing into $REPO_PATH${DRY_RUN_FLAG:+ (dry-run)}"
+echo ""
+
+_call_installer "roborev_install_post_merge_hook.sh"
+_call_installer "roborev_install_commit_msg_hook.sh"
+_call_installer "roborev_install_post_commit_verifier.sh"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Summary for $REPO_PATH: installed=$installed skipped=$skipped failed=$failed"
+
+if [ "$failed" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/bin/roborev_install_all_hooks_all_repos.sh
+++ b/bin/roborev_install_all_hooks_all_repos.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# roborev_install_all_hooks_all_repos.sh
+#
+# Wrapper: iterates ~/docs_gh/* looking for git repositories and calls
+# roborev_install_all_hooks.sh on each one.
+#
+# Summary line printed at the end: repos_installed=N repos_skipped=M repos_failed=K
+#
+# Usage:
+#   bin/roborev_install_all_hooks_all_repos.sh
+#   bin/roborev_install_all_hooks_all_repos.sh --dry-run
+#
+# Options:
+#   --dry-run   Pass --dry-run through to each per-repo installer
+#   --docs-dir PATH   Override the parent directory (default: ~/docs_gh)
+#   --help      Show this message
+#
+# Part of: llm#356 Component 8
+# Tracked in llm#163 automation loop
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="${SCRIPT_DIR}/roborev_install_all_hooks.sh"
+
+usage() {
+  grep '^#' "$0" | grep -v '^#!/' | sed 's/^# \{0,1\}//' | head -20
+  exit 0
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+DRY_RUN_FLAG=""
+DOCS_DIR="${HOME}/docs_gh"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)           DRY_RUN_FLAG="--dry-run"; shift ;;
+    --docs-dir)          shift; DOCS_DIR="$1"; shift ;;
+    -h|--help)           usage ;;
+    -*)                  echo "ERROR: unknown option: $1" >&2; exit 1 ;;
+    *)                   echo "ERROR: unexpected argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Validate installer ────────────────────────────────────────────────────────
+
+if [ ! -f "$INSTALLER" ]; then
+  echo "ERROR: unified installer not found: $INSTALLER" >&2
+  exit 1
+fi
+
+if [ ! -x "$INSTALLER" ]; then
+  chmod +x "$INSTALLER" 2>/dev/null || true
+fi
+
+if [ ! -d "$DOCS_DIR" ]; then
+  echo "ERROR: docs directory not found: $DOCS_DIR" >&2
+  exit 1
+fi
+
+# ── Iterate repos ─────────────────────────────────────────────────────────────
+
+repos_installed=0
+repos_skipped=0
+repos_failed=0
+
+for candidate in "${DOCS_DIR}"/*/; do
+  repo="${candidate%/}"
+
+  if [ ! -d "${repo}/.git" ]; then
+    continue
+  fi
+
+  # shellcheck disable=SC2086
+  output="$("$INSTALLER" $DRY_RUN_FLAG "$repo" 2>&1)"
+  exit_code=$?
+
+  if [ "$exit_code" -ne 0 ]; then
+    echo "FAILED: $repo" >&2
+    echo "$output" >&2
+    repos_failed=$((repos_failed+1))
+  else
+    echo "$output"
+    # Count as skipped if every hook was skipped, otherwise installed
+    if echo "$output" | grep -qE "^Summary.*installed=0 "; then
+      repos_skipped=$((repos_skipped+1))
+    else
+      repos_installed=$((repos_installed+1))
+    fi
+  fi
+
+  echo "---"
+done
+
+echo ""
+echo "All-repos summary: repos_installed=${repos_installed} repos_skipped=${repos_skipped} repos_failed=${repos_failed}"
+
+if [ "$repos_failed" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/bin/roborev_weekly_rollup_cron.sh
+++ b/bin/roborev_weekly_rollup_cron.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# roborev_weekly_rollup_cron.sh — wrapper for the weekly roborev rollup.
+#
+# 1. Sources ~/.claude/env/roborev_email.env (credentials, optional).
+# 2. Generates the weekly markdown rollup via roborev_weekly_rollup.R.
+# 3. Sends the digest email via send_roborev_weekly_rollup_email.R.
+#
+# Usage:
+#   bin/roborev_weekly_rollup_cron.sh
+#   DRYRUN=1 EMAIL_DRY_RUN=1 bin/roborev_weekly_rollup_cron.sh
+#
+# Called by:
+#   com.claude.roborev-weekly-rollup-email.plist (Sunday 09:15 local)
+#
+# Tracked in llm#356.
+
+set -uo pipefail
+
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+SCRIPTS_DIR="$REPO_DIR/.claude/scripts"
+
+LOG="$HOME/.claude/logs/roborev_weekly_rollup.log"
+mkdir -p "$(dirname "$LOG")"
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "$(ts) $*" | tee -a "$LOG"; }
+
+DRYRUN="${DRYRUN:-0}"
+EMAIL_DRY_RUN="${EMAIL_DRY_RUN:-0}"
+[ "$DRYRUN" = "1" ] && EMAIL_DRY_RUN=1
+export EMAIL_DRY_RUN
+
+log "START roborev_weekly_rollup_cron.sh dryrun=$DRYRUN"
+
+# ── Load credentials (if available) ──────────────────────────────────────────
+ENV_FILE="$HOME/.claude/env/roborev_email.env"
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  set -a
+  . "$ENV_FILE"
+  set +a
+  log "credentials loaded from $ENV_FILE"
+else
+  log "no credentials file at $ENV_FILE — EMAIL_DRY_RUN forced to 1"
+  EMAIL_DRY_RUN=1
+  export EMAIL_DRY_RUN
+fi
+
+# ── Locate Rscript ────────────────────────────────────────────────────────────
+RSCRIPT=""
+for candidate in \
+    "$(command -v Rscript 2>/dev/null)" \
+    /nix/var/nix/profiles/default/bin/Rscript \
+    /opt/homebrew/bin/Rscript \
+    /usr/local/bin/Rscript \
+    /usr/bin/Rscript; do
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    RSCRIPT="$candidate"
+    break
+  fi
+done
+
+if [ -z "$RSCRIPT" ]; then
+  log "ERROR: Rscript not found in PATH — cannot generate rollup"
+  exit 1
+fi
+log "using Rscript: $RSCRIPT"
+
+# ── Step 1: generate rollup markdown ─────────────────────────────────────────
+ROLLUP_SCRIPT="$SCRIPTS_DIR/roborev_weekly_rollup.R"
+if [ ! -f "$ROLLUP_SCRIPT" ]; then
+  log "ERROR: rollup script not found at $ROLLUP_SCRIPT"
+  exit 1
+fi
+
+log "running $ROLLUP_SCRIPT"
+"$RSCRIPT" "$ROLLUP_SCRIPT" 2>&1 | tee -a "$LOG"
+rollup_rc=${PIPESTATUS[0]}
+if [ "$rollup_rc" -ne 0 ]; then
+  log "WARNING: rollup script exited $rollup_rc — continuing to email step (partial output possible)"
+fi
+
+# ── Step 2: send email ────────────────────────────────────────────────────────
+EMAIL_SCRIPT="$SCRIPTS_DIR/send_roborev_weekly_rollup_email.R"
+if [ ! -f "$EMAIL_SCRIPT" ]; then
+  log "ERROR: email script not found at $EMAIL_SCRIPT"
+  exit 1
+fi
+
+log "running $EMAIL_SCRIPT (EMAIL_DRY_RUN=$EMAIL_DRY_RUN)"
+"$RSCRIPT" "$EMAIL_SCRIPT" 2>&1 | tee -a "$LOG"
+email_rc=${PIPESTATUS[0]}
+
+if [ "$email_rc" -ne 0 ]; then
+  log "ERROR: email script exited $email_rc"
+  exit "$email_rc"
+fi
+
+log "DONE roborev_weekly_rollup_cron.sh"

--- a/tests/test_roborev_install_all_hooks.sh
+++ b/tests/test_roborev_install_all_hooks.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# tests/test_roborev_install_all_hooks.sh
+#
+# Unit tests for bin/roborev_install_all_hooks.sh (Component 8 — llm#356)
+#
+# Uses:
+#   - A synthetic temp git repo fixture
+#   - Stub child installers in a temp bin/ directory
+#
+# Exits 0 if all tests pass, 1 on any failure.
+#
+# Run:
+#   bash tests/test_roborev_install_all_hooks.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="${SCRIPT_DIR}/../bin/roborev_install_all_hooks.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT="$(mktemp -d)"
+
+cleanup() { rm -rf "${TMPDIR_ROOT}"; }
+trap cleanup EXIT
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "${expected}" = "${actual}" ]; then
+    pass "${desc}"
+  else
+    fail "${desc} — expected='${expected}' actual='${actual}'"
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "${haystack}" | grep -qF "${needle}"; then
+    pass "${desc}"
+  else
+    fail "${desc} — expected to find '${needle}' in output"
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "${haystack}" | grep -qF "${needle}"; then
+    fail "${desc} — unexpected '${needle}' in output"
+  else
+    pass "${desc}"
+  fi
+}
+
+# ── Fixture: create a minimal git repo ────────────────────────────────────────
+
+make_git_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email "test@test"
+  git -C "$dir" config user.name "Test"
+  touch "$dir/README.md"
+  git -C "$dir" add README.md
+  git -C "$dir" commit -q -m "init"
+}
+
+# ── Fixture: create stub bin/ dir with all three child installers ─────────────
+
+make_stub_bin() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  for name in \
+    roborev_install_post_merge_hook.sh \
+    roborev_install_commit_msg_hook.sh \
+    roborev_install_post_commit_verifier.sh
+  do
+    hook_name="${name%.sh}"
+    cat > "$bin_dir/$name" <<STUB
+#!/usr/bin/env bash
+echo "OK: stub ${hook_name} installed in \$1"
+exit 0
+STUB
+    chmod +x "$bin_dir/$name"
+  done
+}
+
+# ── Sanity check: installer script exists ─────────────────────────────────────
+
+if [ ! -f "$INSTALLER" ]; then
+  echo "ERROR: installer not found at $INSTALLER" >&2
+  exit 1
+fi
+
+# ── Test 1: no arguments → exit 1 ────────────────────────────────────────────
+
+rc=0
+SCRIPT_DIR="$TMPDIR_ROOT" bash "$INSTALLER" 2>/dev/null || rc=$?
+assert_eq "no args: exit 1" "1" "$rc"
+
+# ── Test 2: non-git directory → exit 1 ───────────────────────────────────────
+
+non_git="$TMPDIR_ROOT/not_a_repo"
+mkdir -p "$non_git"
+rc=0
+SCRIPT_DIR="$TMPDIR_ROOT" bash "$INSTALLER" "$non_git" 2>/dev/null || rc=$?
+assert_eq "non-git dir: exit 1" "1" "$rc"
+
+# ── Test 3: all three stubs present → exit 0 + summary line ──────────────────
+
+repo1="$TMPDIR_ROOT/repo1"
+bin1="$TMPDIR_ROOT/bin1"
+make_git_repo "$repo1"
+make_stub_bin "$bin1"
+
+rc=0
+output=$(SCRIPT_DIR="$bin1" bash "$INSTALLER" "$repo1" 2>&1) || rc=$?
+assert_eq "all stubs: exit 0" "0" "$rc"
+assert_contains "all stubs: summary line" "Summary for" "$output"
+assert_contains "all stubs: installed count" "installed=3" "$output"
+
+# ── Test 4: missing commit-msg installer → exit 0, skipped=1 ─────────────────
+
+bin2="$TMPDIR_ROOT/bin2"
+make_stub_bin "$bin2"
+rm -f "$bin2/roborev_install_commit_msg_hook.sh"
+
+rc=0
+output=$(SCRIPT_DIR="$bin2" bash "$INSTALLER" "$repo1" 2>&1) || rc=$?
+assert_eq "missing commit-msg: exit 0" "0" "$rc"
+assert_contains "missing commit-msg: warning" "WARNING:" "$output"
+assert_contains "missing commit-msg: skipped=1" "skipped=1" "$output"
+
+# ── Test 5: missing post-commit verifier → exit 0, skipped=1 ─────────────────
+
+bin3="$TMPDIR_ROOT/bin3"
+make_stub_bin "$bin3"
+rm -f "$bin3/roborev_install_post_commit_verifier.sh"
+
+rc=0
+output=$(SCRIPT_DIR="$bin3" bash "$INSTALLER" "$repo1" 2>&1) || rc=$?
+assert_eq "missing post-commit: exit 0" "0" "$rc"
+assert_contains "missing post-commit: skipped=1" "skipped=1" "$output"
+
+# ── Test 6: all three missing → exit 0, skipped=3 ────────────────────────────
+
+bin4="$TMPDIR_ROOT/bin4"
+mkdir -p "$bin4"
+# No child installers at all
+
+rc=0
+output=$(SCRIPT_DIR="$bin4" bash "$INSTALLER" "$repo1" 2>&1) || rc=$?
+assert_eq "all missing: exit 0" "0" "$rc"
+assert_contains "all missing: skipped=3" "skipped=3" "$output"
+
+# ── Test 7: failing child installer → exit 1 + failed=1 ──────────────────────
+
+bin5="$TMPDIR_ROOT/bin5"
+make_stub_bin "$bin5"
+# Replace post-merge stub with a failing one
+cat > "$bin5/roborev_install_post_merge_hook.sh" <<'FAIL_STUB'
+#!/usr/bin/env bash
+echo "ERROR: stub failure" >&2
+exit 1
+FAIL_STUB
+chmod +x "$bin5/roborev_install_post_merge_hook.sh"
+
+rc=0
+output=$(SCRIPT_DIR="$bin5" bash "$INSTALLER" "$repo1" 2>&1) || rc=$?
+assert_eq "failing installer: exit 1" "1" "$rc"
+assert_contains "failing installer: failed=1" "failed=1" "$output"
+
+# ── Test 8: --dry-run flag passes through to child installer ──────────────────
+
+bin6="$TMPDIR_ROOT/bin6"
+mkdir -p "$bin6"
+
+# Stubs detect --dry-run flag in any argument position
+for name in \
+  roborev_install_post_merge_hook.sh \
+  roborev_install_commit_msg_hook.sh \
+  roborev_install_post_commit_verifier.sh
+do
+  cat > "$bin6/$name" <<'DRYRUN_STUB'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "--dry-run" ]; then
+    echo "OK: stub (dry-run mode)"
+    exit 0
+  fi
+done
+echo "OK: stub installed in $1"
+exit 0
+DRYRUN_STUB
+  chmod +x "$bin6/$name"
+done
+
+rc=0
+output=$(SCRIPT_DIR="$bin6" bash "$INSTALLER" --dry-run "$repo1" 2>&1) || rc=$?
+assert_eq "--dry-run: exit 0" "0" "$rc"
+assert_contains "--dry-run: appears in header" "dry-run" "$output"
+
+# ── Test 9: --unknown-flag → exit 1 ──────────────────────────────────────────
+
+rc=0
+SCRIPT_DIR="$TMPDIR_ROOT" bash "$INSTALLER" --unknown-flag "$repo1" 2>/dev/null || rc=$?
+assert_eq "unknown flag: exit 1" "1" "$rc"
+
+# ── Test 10: --help flag exits 0 ─────────────────────────────────────────────
+
+rc=0
+bash "$INSTALLER" --help 2>/dev/null || rc=$?
+# grep-based help exits 0 in our impl
+assert_eq "--help: exit 0" "0" "$rc"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "${PASS}/$((PASS+FAIL)) PASS"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/tests/test_roborev_weekly_rollup.R
+++ b/tests/test_roborev_weekly_rollup.R
@@ -1,0 +1,236 @@
+#!/usr/bin/env Rscript
+# tests/test_roborev_weekly_rollup.R
+#
+# testthat tests for .claude/scripts/roborev_weekly_rollup.R
+#
+# Strategy:
+#   1. Creates synthetic daily-backlog fixture files (7 .md files)
+#   2. Creates a synthetic SQLite reviews.db fixture
+#   3. Runs the rollup script in WEEKLY_DRY_RUN=1 mode
+#   4. Asserts the produced markdown contains expected sections and values
+#
+# Run:
+#   Rscript tests/test_roborev_weekly_rollup.R
+#
+# Tracked in llm#356.
+
+suppressPackageStartupMessages({
+  library(testthat)
+  library(DBI)
+})
+
+# ── Locate rollup script ──────────────────────────────────────────────────────
+
+`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0L) a else b
+
+# Determine this test file's directory robustly
+this_file <- tryCatch(
+  normalizePath(sys.frames()[[1L]]$ofile, mustWork = FALSE),
+  error = function(e) {
+    # Fallback: use commandArgs to find script path
+    args <- commandArgs(trailingOnly = FALSE)
+    file_flag <- grep("^--file=", args, value = TRUE)
+    if (length(file_flag) > 0L) {
+      sub("^--file=", "", file_flag[1L])
+    } else {
+      "."
+    }
+  }
+)
+script_dir <- normalizePath(dirname(this_file), mustWork = FALSE)
+
+rollup_script <- normalizePath(
+  file.path(script_dir, "..", ".claude", "scripts", "roborev_weekly_rollup.R"),
+  mustWork = FALSE
+)
+
+# Alternative search paths
+if (!file.exists(rollup_script)) {
+  candidates <- c(
+    file.path(Sys.getenv("HOME"), "docs_gh", "llm", ".claude", "scripts",
+              "roborev_weekly_rollup.R")
+  )
+  rollup_script <- candidates[file.exists(candidates)][1L] %||% rollup_script
+}
+
+# ── Build synthetic fixtures ──────────────────────────────────────────────────
+
+tmpdir <- tempfile("roborev_weekly_test_")
+dir.create(tmpdir, recursive = TRUE)
+on.exit(unlink(tmpdir, recursive = TRUE), add = TRUE)
+
+backlog_dir  <- file.path(tmpdir, "daily_backlog")
+weekly_dir   <- file.path(tmpdir, "weekly_rollup")
+db_path      <- file.path(tmpdir, "reviews.db")
+
+dir.create(backlog_dir, recursive = TRUE)
+dir.create(weekly_dir, recursive = TRUE)
+
+# Write 7 synthetic daily backlog markdown files
+today  <- Sys.Date()
+for (i in seq_len(7L)) {
+  day <- today - i
+  content <- sprintf(
+    "# roborev daily backlog — %s\n\n- llm: 5 open findings\n- llmtelemetry: 3 open findings\n",
+    format(day, "%Y-%m-%d")
+  )
+  writeLines(content, file.path(backlog_dir, paste0(format(day, "%Y-%m-%d"), ".md")))
+}
+
+# Create synthetic SQLite reviews.db
+if (requireNamespace("RSQLite", quietly = TRUE)) {
+  con <- DBI::dbConnect(RSQLite::SQLite(), db_path)
+  DBI::dbExecute(con, "CREATE TABLE repos (id INTEGER PRIMARY KEY, name TEXT, root_path TEXT)")
+  DBI::dbExecute(con, "INSERT INTO repos VALUES (1, 'llm', '/tmp/llm')")
+  DBI::dbExecute(con, "INSERT INTO repos VALUES (2, 'llmtelemetry', '/tmp/llmtelemetry')")
+  DBI::dbExecute(con, "
+    CREATE TABLE review_jobs (
+      id INTEGER PRIMARY KEY,
+      repo_id INTEGER,
+      status TEXT,
+      finished_at TEXT
+    )
+  ")
+  DBI::dbExecute(con, "
+    CREATE TABLE reviews (
+      id INTEGER PRIMARY KEY,
+      job_id INTEGER,
+      closed INTEGER DEFAULT 0,
+      updated_at TEXT,
+      output TEXT
+    )
+  ")
+  # Insert synthetic findings in the current week
+  week_start <- format(today - 7L, "%Y-%m-%d")
+  week_end   <- format(today - 1L, "%Y-%m-%d")
+  # 4 jobs: 2 per repo
+  for (jid in 1:4) {
+    repo_id <- if (jid <= 2) 1L else 2L
+    DBI::dbExecute(con, sprintf(
+      "INSERT INTO review_jobs VALUES (%d, %d, 'done', '%s')",
+      jid, repo_id, paste0(week_start, " 10:00:00")
+    ))
+  }
+  # 6 reviews: 3 closed, 3 open
+  for (rid in 1:6) {
+    jid    <- ((rid - 1) %% 4) + 1
+    closed <- if (rid <= 3L) 1L else 0L
+    upd    <- if (closed == 1L) paste0(week_end, " 11:00:00") else ""
+    DBI::dbExecute(con, sprintf(
+      "INSERT INTO reviews VALUES (%d, %d, %d, '%s', '**Severity**: High\n\nTest finding %d')",
+      rid, jid, closed, upd, rid
+    ))
+  }
+  DBI::dbDisconnect(con)
+}
+
+# ── Run rollup script ─────────────────────────────────────────────────────────
+
+test_that("rollup script exists", {
+  expect_true(file.exists(rollup_script),
+              info = sprintf("Expected rollup script at: %s", rollup_script))
+})
+
+if (!file.exists(rollup_script)) {
+  message("Skipping execution tests — rollup script not found")
+  q(status = 0L)
+}
+
+run_rollup <- function(extra_env = list()) {
+  env_vars <- c(
+    list(
+      ROBOREV_DAILY_BACKLOG_DIR = backlog_dir,
+      ROBOREV_DB                = db_path,
+      ROBOREV_WEEKLY_DIR        = weekly_dir,
+      UNIFIED_DUCKDB            = file.path(tmpdir, "nonexistent.duckdb"),
+      WEEKLY_DRY_RUN            = "1"
+    ),
+    extra_env
+  )
+  env_str <- paste0(names(env_vars), "=", unlist(env_vars), collapse = " ")
+  cmd <- sprintf("env %s Rscript %s", env_str, shQuote(rollup_script))
+  output <- tryCatch(
+    system2("env",
+            args = c(paste0(names(env_vars), "=", unlist(env_vars)),
+                     "Rscript", rollup_script),
+            stdout = TRUE, stderr = TRUE),
+    error = function(e) character(0)
+  )
+  output
+}
+
+output <- run_rollup()
+rollup_text <- paste(output, collapse = "\n")
+
+test_that("rollup produces non-empty output", {
+  expect_gt(nchar(rollup_text), 100L)
+})
+
+test_that("rollup contains Global Summary section", {
+  expect_match(rollup_text, "Global Summary", fixed = TRUE)
+})
+
+test_that("rollup contains Per-Project Backlog section", {
+  expect_match(rollup_text, "Per-Project Backlog", fixed = TRUE)
+})
+
+test_that("rollup contains Top Stuck Findings section", {
+  expect_match(rollup_text, "Top Stuck Findings", fixed = TRUE)
+})
+
+test_that("rollup contains period date range", {
+  # Should contain week_start date
+  week_start <- format(Sys.Date() - 7L, "%Y-%m-%d")
+  expect_match(rollup_text, week_start, fixed = TRUE)
+})
+
+test_that("rollup contains Close-Reason Distribution section", {
+  # Section appears even when unified.duckdb is absent (shows 'no data' note)
+  expect_match(rollup_text, "Close-Reason Distribution", fixed = TRUE)
+})
+
+test_that("rollup handles missing daily backlog dir gracefully", {
+  out <- run_rollup(list(ROBOREV_DAILY_BACKLOG_DIR = file.path(tmpdir, "nonexistent_backlog")))
+  txt <- paste(out, collapse = "\n")
+  # Should still produce output with 0 files found
+  expect_match(txt, "Global Summary", fixed = TRUE)
+})
+
+test_that("rollup handles missing reviews.db gracefully", {
+  out <- run_rollup(list(ROBOREV_DB = file.path(tmpdir, "nonexistent.db")))
+  txt <- paste(out, collapse = "\n")
+  expect_match(txt, "Global Summary", fixed = TRUE)
+})
+
+# ── If RSQLite available, verify close-rate data appears ─────────────────────
+
+if (requireNamespace("RSQLite", quietly = TRUE) && file.exists(db_path)) {
+  test_that("rollup contains project names from synthetic DB", {
+    expect_match(rollup_text, "llm", fixed = TRUE)
+  })
+}
+
+# ── File write mode test ──────────────────────────────────────────────────────
+
+test_that("rollup writes file when not dry-run", {
+  weekly_dir2 <- file.path(tmpdir, "weekly_rollup2")
+  dir.create(weekly_dir2, recursive = TRUE)
+  env_vars <- c(
+    ROBOREV_DAILY_BACKLOG_DIR = backlog_dir,
+    ROBOREV_DB                = db_path,
+    ROBOREV_WEEKLY_DIR        = weekly_dir2,
+    UNIFIED_DUCKDB            = file.path(tmpdir, "nonexistent.duckdb")
+  )
+  # Note: no WEEKLY_DRY_RUN — should write a file
+  system2("env",
+          args = c(paste0(names(env_vars), "=", unlist(env_vars)),
+                   "Rscript", rollup_script),
+          stdout = FALSE, stderr = FALSE)
+
+  expected_file <- file.path(weekly_dir2,
+                              paste0(format(Sys.Date(), "%Y-%m-%d"), ".md"))
+  expect_true(file.exists(expected_file),
+              info = sprintf("Expected output file: %s", expected_file))
+})
+
+cat("\n--- All tests completed ---\n")


### PR DESCRIPTION
## Summary

Implements llm#356 — two components from the #163 roborev automation loop.

### Component 7 — Weekly Rollup Digest

A Sunday 09:15 launchd job that emails a week-over-week roborev backlog summary.

**Files added:**
- `.claude/scripts/roborev_weekly_rollup.R` — aggregates last 7 daily backlog `.md` files + queries `~/.roborev/reviews.db` (per-project opened/closed/close-rate/median-TTC/top stuck findings) + close-reason distribution from `unified.duckdb`
- `.claude/scripts/send_roborev_weekly_rollup_email.R` — blastula email sender (mirrors `send_roborev_email.R`; dark-mode HTML; Gmail SMTP port 465)
- `.claude/launchd/com.claude.roborev-weekly-rollup-email.plist` — Sunday 09:15 launchd plist (`Weekday=0 Hour=9 Minute=15`); `plutil -lint` OK
- `bin/roborev_weekly_rollup_cron.sh` — bash wrapper (step 1: rollup, step 2: email)

**Activation:**
```bash
# Load the launchd plist
cp .claude/launchd/com.claude.roborev-weekly-rollup-email.plist ~/Library/LaunchAgents/
launchctl load ~/Library/LaunchAgents/com.claude.roborev-weekly-rollup-email.plist

# Smoke test (dry-run, no email sent)
WEEKLY_DRY_RUN=1 Rscript .claude/scripts/roborev_weekly_rollup.R
```

### Component 8 — Unified Per-Repo Hook Installer

A single command to install all three roborev hooks for one or all repos.

**Files added:**
- `bin/roborev_install_all_hooks.sh` — installs post-merge (#217) + commit-msg (#352) + post-commit-verifier (#353) in one idempotent call; skips gracefully if any child installer is absent (sibling PR not yet merged)
- `bin/roborev_install_all_hooks_all_repos.sh` — iterates `~/docs_gh/*/.git` and calls the per-repo installer on each

**Activation:**
```bash
# Install all three hooks for a single repo
bash bin/roborev_install_all_hooks.sh /path/to/repo

# Install across all ~/docs_gh projects (dry-run first)
bash bin/roborev_install_all_hooks_all_repos.sh --dry-run
bash bin/roborev_install_all_hooks_all_repos.sh
```

## Tests

| Suite | Result |
|---|---|
| `tests/test_roborev_weekly_rollup.R` (10 testthat cases) | 10/10 PASS |
| `tests/test_roborev_install_all_hooks.sh` (18 bash cases) | 18/18 PASS |
| `plutil -lint` on plist | OK |
| `bash -n` on all bash scripts | clean |
| DRYRUN smoke (`WEEKLY_DRY_RUN=1`) | 4 sections present |

## Related issues

- Closes #356
- Part of #163 automation loop (daily aggregator → per-project backlog → weekly rollup)
- Sibling PRs: #355 (daily backlog email), #352 (commit-msg hook), #353 (post-commit verifier)

## Test plan

- [ ] Run `WEEKLY_DRY_RUN=1 Rscript .claude/scripts/roborev_weekly_rollup.R` — confirm markdown output with 4 sections
- [ ] Run `EMAIL_DRY_RUN=1 Rscript .claude/scripts/send_roborev_weekly_rollup_email.R` — confirm no email sent, no error
- [ ] Run `bash bin/roborev_install_all_hooks.sh /path/to/any/git/repo` — confirm summary line shows installed=3 (or skipped counts if sibling PRs not merged)
- [ ] Run `bash bin/roborev_install_all_hooks_all_repos.sh --dry-run` — confirm all repos listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)