### PR TITLE
feat(roborev): post-commit verifier on closes citations (#353)

### DIFF
--- a/.claude/scripts/roborev_verify_closure.sh
+++ b/.claude/scripts/roborev_verify_closure.sh
@@ -1,0 +1,531 @@
+#!/usr/bin/env bash
+# roborev_verify_closure.sh <commit_sha> <finding_id> [<finding_id>...]
+#
+# Post-commit verifier for roborev closure citations (Component 4, JohnGavin/llm#353).
+#
+# SIGNAL ONLY — does NOT auto-close findings, does NOT write to closures table,
+# does NOT write to fix_rejected_queue. That is #354's job.  This script produces
+# a verdict JSON and exits.
+#
+# Usage:
+#   ~/.claude/scripts/roborev_verify_closure.sh <commit_sha> <finding_id>...
+#
+# Example:
+#   ~/.claude/scripts/roborev_verify_closure.sh abc1234 675 1551 1545
+#
+# Output (written to ~/.claude/logs/roborev_verify_closure/<commit_sha>.json):
+#
+#   {
+#     "commit_sha": "abc1234",
+#     "review_job_id": 5437,
+#     "review_verdict_bool": 0,
+#     "verdicts": {
+#       "675": {
+#         "status": "verified-pass",
+#         "reason": "review approved and location not re-flagged"
+#       },
+#       "1551": {
+#         "status": "verified-fail",
+#         "reason": "location R/plan_regime.R:241 re-flagged in re-review"
+#       }
+#     },
+#     "timestamp": "2026-05-30T17:00:00Z"
+#   }
+#
+# Verdict status values:
+#   verified-pass  — re-review approved AND the original finding's location is not
+#                    re-flagged in the new review output.
+#   verified-fail  — re-review re-flags the same location as the original finding
+#                    (the "fix" did not resolve it).
+#   inconclusive   — ambiguous: timeout, roborev unavailable, or finding not in DB.
+#
+# Exit codes:
+#   0 = verdict JSON written (or skipped cleanly — fail-open)
+#   1 = hard error (unexpected)
+#
+# Invoked asynchronously (nohup &) by the post-commit hook — must never block.
+#
+# Log: ~/.claude/logs/roborev_verify_closure.log
+# Issue: JohnGavin/llm#353
+
+export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+set -uo pipefail
+
+LOGFILE="${HOME}/.claude/logs/roborev_verify_closure.log"
+VERDICT_DIR="${HOME}/.claude/logs/roborev_verify_closure"
+ROBOREV_DB="${ROBOREV_DB:-${HOME}/.roborev/reviews.db}"
+ROBOREV_BIN="${ROBOREV:-$(command -v roborev 2>/dev/null || echo /usr/local/bin/roborev)}"
+
+POLL_TIMEOUT_SECS="${ROBOREV_VERIFY_TIMEOUT:-300}"
+POLL_INTERVAL_SECS=5
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+
+log() {
+  local ts
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')
+  echo "${ts} $*" >> "$LOGFILE"
+}
+
+# ── Self-test ─────────────────────────────────────────────────────────────────
+
+if [ "${SELFTEST:-0}" = "1" ]; then
+  PASS=0
+  FAIL=0
+
+  _check() {
+    local label="$1" result="$2"
+    if [ "$result" = "pass" ]; then
+      PASS=$((PASS+1))
+      echo "  PASS [$label]"
+    else
+      FAIL=$((FAIL+1))
+      echo "  FAIL [$label]: $result"
+    fi
+  }
+
+  # Test 1: extract job_id from "Enqueued job NNN for ..." line
+  JID=$( echo "Enqueued job 5437 for abc1234 (agent: codex)" \
+    | /usr/bin/python3 -c "
+import sys, re
+for line in sys.stdin:
+    m = re.search(r'Enqueued job\s+(\d+)', line)
+    if m:
+        print(m.group(1))
+        break
+")
+  if [ "$JID" = "5437" ]; then
+    _check "parse-job-id" "pass"
+  else
+    _check "parse-job-id" "fail: got '$JID'"
+  fi
+
+  # Test 2: location-match helper — finding location appears in review output
+  OUTPUT="- **Severity**: Medium\n- **Location**: R/plan_regime.R:241\n- **Problem**: bad thing"
+  LOC="R/plan_regime.R:241"
+  MATCH=$(/usr/bin/python3 -c "
+import sys
+output = sys.argv[1]
+loc = sys.argv[2]
+print('yes' if loc in output else 'no')
+" "$OUTPUT" "$LOC")
+  if [ "$MATCH" = "yes" ]; then
+    _check "location-match-found" "pass"
+  else
+    _check "location-match-found" "fail: got '$MATCH'"
+  fi
+
+  # Test 3: location-match helper — location NOT in output
+  OUTPUT2="- **Location**: R/other_file.R:10\n- **Problem**: different thing"
+  MATCH2=$(/usr/bin/python3 -c "
+import sys
+output = sys.argv[1]
+loc = sys.argv[2]
+print('yes' if loc in output else 'no')
+" "$OUTPUT2" "$LOC")
+  if [ "$MATCH2" = "no" ]; then
+    _check "location-match-absent" "pass"
+  else
+    _check "location-match-absent" "fail: got '$MATCH2'"
+  fi
+
+  # Test 4: verdict JSON structure — python can produce valid JSON
+  JSON=$(/usr/bin/python3 -c "
+import json
+d = {
+    'commit_sha': 'abc1234',
+    'review_job_id': 5437,
+    'review_verdict_bool': 1,
+    'verdicts': {
+        '675': {'status': 'verified-pass', 'reason': 'review approved and location not re-flagged'}
+    },
+    'timestamp': '2026-05-30T17:00:00Z'
+}
+print(json.dumps(d))
+")
+  STATUS=$(/usr/bin/python3 -c "import json,sys; d=json.loads(sys.argv[1]); print(d['verdicts']['675']['status'])" "$JSON")
+  if [ "$STATUS" = "verified-pass" ]; then
+    _check "verdict-json-structure" "pass"
+  else
+    _check "verdict-json-structure" "fail: got '$STATUS'"
+  fi
+
+  # Test 5: inconclusive when review_verdict_bool is null/None
+  STATUS2=$(/usr/bin/python3 -c "
+verdict_bool = None
+status = 'inconclusive' if verdict_bool is None else ('verified-pass' if verdict_bool == 1 else 'verified-fail')
+print(status)
+")
+  if [ "$STATUS2" = "inconclusive" ]; then
+    _check "null-verdict-inconclusive" "pass"
+  else
+    _check "null-verdict-inconclusive" "fail: got '$STATUS2'"
+  fi
+
+  TOTAL=$((PASS+FAIL))
+  echo ""
+  if [ "$FAIL" -eq 0 ]; then
+    echo "${PASS}/${TOTAL} PASS"
+    exit 0
+  else
+    echo "${PASS}/${TOTAL} PASS — ${FAIL} FAILED"
+    exit 1
+  fi
+fi
+
+# ── Argument validation ───────────────────────────────────────────────────────
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <commit_sha> <finding_id> [<finding_id>...]" >&2
+  echo "  commit_sha: full or abbreviated git commit SHA" >&2
+  echo "  finding_id: one or more roborev finding IDs (integers)" >&2
+  exit 1
+fi
+
+COMMIT_SHA="$1"
+shift
+FINDING_IDS=("$@")
+
+# Validate finding IDs are integers
+for fid in "${FINDING_IDS[@]}"; do
+  if ! printf '%s' "$fid" | grep -qE '^[0-9]+$'; then
+    echo "ERROR: finding_id must be an integer, got: $fid" >&2
+    exit 1
+  fi
+done
+
+# ── Ensure output directory exists ───────────────────────────────────────────
+
+mkdir -p "$VERDICT_DIR"
+mkdir -p "$(dirname "$LOGFILE")"
+
+VERDICT_FILE="${VERDICT_DIR}/${COMMIT_SHA}.json"
+
+log "START: commit=${COMMIT_SHA} finding_ids=$(printf '%s ' "${FINDING_IDS[@]}")"
+
+# ── Fail-open: prerequisites ──────────────────────────────────────────────────
+
+_write_inconclusive() {
+  local reason="$1"
+  /usr/bin/python3 - "$COMMIT_SHA" "$reason" "${FINDING_IDS[@]}" <<'PY'
+import sys, json
+from datetime import datetime, timezone
+
+commit_sha  = sys.argv[1]
+reason      = sys.argv[2]
+finding_ids = sys.argv[3:]
+
+ts = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+verdicts = {}
+for fid in finding_ids:
+    verdicts[fid] = {"status": "inconclusive", "reason": reason}
+
+out = {
+    "commit_sha":          commit_sha,
+    "review_job_id":       None,
+    "review_verdict_bool": None,
+    "verdicts":            verdicts,
+    "timestamp":           ts
+}
+print(json.dumps(out, indent=2))
+PY
+}
+
+if [ ! -x "$ROBOREV_BIN" ]; then
+  log "SKIP: roborev binary not found at ${ROBOREV_BIN}"
+  _write_inconclusive "roborev binary not available" > "$VERDICT_FILE"
+  echo "roborev_verify_closure: roborev not found — verdict=inconclusive written to ${VERDICT_FILE}" >&2
+  exit 0
+fi
+
+if [ ! -f "$ROBOREV_DB" ]; then
+  log "SKIP: reviews.db not found at ${ROBOREV_DB}"
+  _write_inconclusive "reviews.db not found" > "$VERDICT_FILE"
+  echo "roborev_verify_closure: reviews.db not found — verdict=inconclusive written to ${VERDICT_FILE}" >&2
+  exit 0
+fi
+
+# ── Look up each finding's location from DB (for re-flag detection) ───────────
+#
+# The original review output is stored in reviews.output.  We extract the
+# "Location:" line(s) for each finding so we can compare against the new
+# review output to detect whether the finding was actually fixed.
+
+FINDING_LOCATIONS=$(/usr/bin/python3 - "$ROBOREV_DB" "${FINDING_IDS[@]}" <<'PY'
+import sys, sqlite3, re, json
+
+db_path     = sys.argv[1]
+finding_ids = [int(x) for x in sys.argv[2:]]
+
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
+    result = {}
+    for fid in finding_ids:
+        row = conn.execute(
+            "SELECT output FROM reviews WHERE id = ?", (fid,)
+        ).fetchone()
+        if row is None:
+            result[str(fid)] = None
+        else:
+            output = row[0] or ''
+            # Extract all Location: lines from the finding output
+            locs = re.findall(r'\*\*Location\*\*:\s*`?([^`\n]+)`?', output)
+            result[str(fid)] = locs if locs else None
+    conn.close()
+    print(json.dumps(result))
+except Exception as e:
+    # On any DB error, return null for all IDs — verifier treats as inconclusive
+    result = {str(fid): None for fid in finding_ids}
+    print(json.dumps(result))
+PY
+)
+
+log "INFO: finding_locations=${FINDING_LOCATIONS}"
+
+# ── Trigger roborev re-review on the commit ───────────────────────────────────
+#
+# roborev review --sha <sha> --wait enqueues, waits for completion, and outputs
+# "Enqueued job NNN for <sha> ..." as its first line.  The --wait flag means
+# we don't need a separate poll loop for job completion.
+
+log "INFO: triggering re-review for commit=${COMMIT_SHA}"
+
+REVIEW_OUTPUT=""
+REVIEW_EXIT=0
+
+if ! REVIEW_OUTPUT=$("$ROBOREV_BIN" review --sha "$COMMIT_SHA" --wait 2>&1); then
+  REVIEW_EXIT=$?
+  log "WARN: roborev review exited ${REVIEW_EXIT} for commit=${COMMIT_SHA}: ${REVIEW_OUTPUT}"
+fi
+
+# Parse job ID from "Enqueued job NNN" line
+REVIEW_JOB_ID=$(printf '%s\n' "$REVIEW_OUTPUT" | /usr/bin/python3 -c "
+import sys, re
+for line in sys.stdin:
+    m = re.search(r'Enqueued job\s+(\d+)', line)
+    if m:
+        print(m.group(1))
+        break
+")
+
+if [ -z "$REVIEW_JOB_ID" ]; then
+  log "WARN: could not parse job_id from roborev output for commit=${COMMIT_SHA}"
+  # Fallback: find the most recent review_job for this git_ref in the DB
+  REVIEW_JOB_ID=$(/usr/bin/python3 - "$ROBOREV_DB" "$COMMIT_SHA" <<'PY'
+import sys, sqlite3
+
+db_path = sys.argv[1]
+sha     = sys.argv[2]
+
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
+    row = conn.execute(
+        """SELECT rj.id FROM review_jobs rj
+           WHERE rj.git_ref LIKE ?
+           ORDER BY rj.id DESC LIMIT 1""",
+        (f"{sha}%",)
+    ).fetchone()
+    conn.close()
+    if row:
+        print(row[0])
+except Exception:
+    pass
+PY
+  )
+fi
+
+if [ -z "$REVIEW_JOB_ID" ]; then
+  log "WARN: no job_id found for commit=${COMMIT_SHA}; writing inconclusive"
+  _write_inconclusive "could not determine re-review job_id" > "$VERDICT_FILE"
+  exit 0
+fi
+
+log "INFO: review_job_id=${REVIEW_JOB_ID} for commit=${COMMIT_SHA}"
+
+# ── Read verdict from DB (--wait should have completed it, but poll as safety) ─
+#
+# We write the review output to a temp file to avoid bash $() stripping content
+# (null bytes or trailing newlines from multi-line review text).
+
+_POLL_TMPFILE=$(mktemp)
+trap 'rm -f "$_POLL_TMPFILE"' EXIT
+
+ELAPSED=0
+VERDICT_BOOL=""
+REVIEW_STATUS=""
+
+while [ "$ELAPSED" -lt "$POLL_TIMEOUT_SECS" ]; do
+  REVIEW_STATUS=$(/usr/bin/python3 - "$ROBOREV_DB" "$REVIEW_JOB_ID" "$_POLL_TMPFILE" <<'PY'
+import sys, sqlite3, json
+
+db_path   = sys.argv[1]
+job_id    = int(sys.argv[2])
+tmpfile   = sys.argv[3]
+
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
+    row = conn.execute(
+        """SELECT rj.status, rv.verdict_bool, rv.output
+           FROM review_jobs rj
+           LEFT JOIN reviews rv ON rv.job_id = rj.id
+           WHERE rj.id = ?
+           LIMIT 1""",
+        (job_id,)
+    ).fetchone()
+    conn.close()
+    if row:
+        status  = row[0] or 'unknown'
+        verdict = '' if row[1] is None else str(row[1])
+        output  = row[2] or ''
+        # Write a JSON payload to tmpfile so multi-line output survives
+        with open(tmpfile, 'w') as f:
+            json.dump({"verdict": verdict, "output": output}, f)
+        print(status)
+    else:
+        print("notfound")
+except Exception as e:
+    print(f"error")
+PY
+  )
+
+  case "$REVIEW_STATUS" in
+    done|applied)
+      # Read verdict and output from tmpfile
+      VERDICT_BOOL=$(/usr/bin/python3 -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+print(d['verdict'])
+" "$_POLL_TMPFILE" 2>/dev/null || true)
+      break ;;
+    failed|canceled|skipped)
+      log "WARN: job_id=${REVIEW_JOB_ID} ended with status=${REVIEW_STATUS}"
+      _write_inconclusive "re-review job ended with status=${REVIEW_STATUS}" > "$VERDICT_FILE"
+      exit 0 ;;
+    running|queued)
+      : ;;   # still in flight — keep polling
+    notfound)
+      log "WARN: job_id=${REVIEW_JOB_ID} not found in DB"
+      _write_inconclusive "review_job ${REVIEW_JOB_ID} not found in DB" > "$VERDICT_FILE"
+      exit 0 ;;
+    *)
+      log "WARN: unexpected job status '${REVIEW_STATUS}' for job_id=${REVIEW_JOB_ID}"
+      ;;
+  esac
+
+  /usr/bin/python3 -c "import time; time.sleep(${POLL_INTERVAL_SECS})"
+  ELAPSED=$((ELAPSED + POLL_INTERVAL_SECS))
+done
+
+if [ "$REVIEW_STATUS" != "done" ] && [ "$REVIEW_STATUS" != "applied" ]; then
+  log "WARN: poll timed out (${POLL_TIMEOUT_SECS}s) for job_id=${REVIEW_JOB_ID}"
+  _write_inconclusive "poll timed out after ${POLL_TIMEOUT_SECS}s" > "$VERDICT_FILE"
+  exit 0
+fi
+
+log "INFO: re-review complete job_id=${REVIEW_JOB_ID} verdict_bool=${VERDICT_BOOL}"
+
+# ── Classify each finding ─────────────────────────────────────────────────────
+#
+# Rules (from #353 spec):
+#   verified-pass:  verdict_bool=1 AND the finding's Location is NOT re-flagged
+#                   in the new review output.
+#   verified-fail:  the finding's Location IS re-flagged in the new review output
+#                   (regardless of overall verdict_bool).
+#   inconclusive:   verdict_bool is null/empty, OR the finding was not in DB,
+#                   OR the location could not be matched.
+
+/usr/bin/python3 - "$COMMIT_SHA" "$REVIEW_JOB_ID" "$VERDICT_BOOL" \
+    "$FINDING_LOCATIONS" "$_POLL_TMPFILE" "$VERDICT_FILE" "${FINDING_IDS[@]}" <<'PY'
+import sys, json
+from datetime import datetime, timezone
+
+commit_sha       = sys.argv[1]
+review_job_id    = int(sys.argv[2]) if sys.argv[2] else None
+verdict_bool_raw = sys.argv[3]   # "1", "0", or ""
+locs_json        = sys.argv[4]
+poll_tmpfile     = sys.argv[5]
+verdict_file     = sys.argv[6]
+finding_ids      = sys.argv[7:]
+
+# Read new review output from tmpfile (avoids bash $() stripping multi-line content)
+try:
+    poll_data = json.load(open(poll_tmpfile))
+    new_output = poll_data.get("output", "")
+except Exception:
+    new_output = ""
+
+# Parse overall verdict
+if verdict_bool_raw == "1":
+    overall_approved = True
+elif verdict_bool_raw == "0":
+    overall_approved = False
+else:
+    overall_approved = None  # inconclusive
+
+# Parse per-finding locations from DB lookup
+try:
+    locs_by_id = json.loads(locs_json)
+except Exception:
+    locs_by_id = {}
+
+verdicts = {}
+for fid in finding_ids:
+    locs = locs_by_id.get(fid)   # list of location strings, or None
+
+    if overall_approved is None:
+        verdicts[fid] = {
+            "status": "inconclusive",
+            "reason": "re-review verdict_bool is null — no clear approval or rejection"
+        }
+        continue
+
+    if locs is None:
+        # Finding not found in DB — can't match location, call inconclusive
+        verdicts[fid] = {
+            "status": "inconclusive",
+            "reason": f"finding #{fid} not found in reviews DB; location unknown"
+        }
+        continue
+
+    # Check whether any of the finding's locations are re-flagged in the new output
+    reflagged_locs = [loc for loc in locs if loc and loc in new_output]
+
+    if reflagged_locs:
+        verdicts[fid] = {
+            "status": "verified-fail",
+            "reason": f"location(s) {reflagged_locs!r} re-flagged in re-review output"
+        }
+    elif overall_approved:
+        verdicts[fid] = {
+            "status": "verified-pass",
+            "reason": "re-review approved and finding location not re-flagged"
+        }
+    else:
+        # Overall rejected, location not directly re-flagged — could be a
+        # different finding caused the rejection.  Classify as inconclusive
+        # rather than pass, since we can't confirm the specific fix landed.
+        verdicts[fid] = {
+            "status": "inconclusive",
+            "reason": "re-review rejected overall but this finding's location was not directly re-flagged"
+        }
+
+ts = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+result = {
+    "commit_sha":          commit_sha,
+    "review_job_id":       review_job_id,
+    "review_verdict_bool": None if overall_approved is None else (1 if overall_approved else 0),
+    "verdicts":            verdicts,
+    "timestamp":           ts
+}
+
+with open(verdict_file, 'w') as f:
+    json.dump(result, f, indent=2)
+    f.write('\n')
+
+print(f"verdict JSON written to {verdict_file}")
+PY
+
+log "DONE: verdict written to ${VERDICT_FILE}"
+echo "roborev_verify_closure: verdict written to ${VERDICT_FILE}"

--- a/bin/roborev_install_post_commit_verifier.sh
+++ b/bin/roborev_install_post_commit_verifier.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# roborev_install_post_commit_verifier.sh <repo-path>
+#
+# Installs a post-commit git hook that asynchronously runs the roborev
+# post-commit verifier whenever a commit message contains "closes roborev #N"
+# citations.
+#
+# The hook:
+#   - Parses cited finding IDs from the commit message via grep.
+#   - Nohups ~/.claude/scripts/roborev_verify_closure.sh so it does NOT block
+#     the git commit.
+#   - Exits 0 immediately regardless of verifier outcome (fail-open).
+#   - Respects ROBOREV_VERIFY_SKIP=1 to opt out per-invocation.
+#
+# Idempotent: re-running refreshes the marker comment but changes nothing else
+# when the hook was previously installed by this script.
+#
+# Safety: refuses to overwrite an UNRECOGNISED existing post-commit hook that
+# lacks the installer marker.  Instead prints a CHAIN: message with
+# instructions for chaining manually.
+#
+# Usage:
+#   bin/roborev_install_post_commit_verifier.sh /path/to/repo
+#
+# Issue: JohnGavin/llm#353
+# Installed-by marker (must stay on line ~28 for idempotency detection):
+#   Installed by ~/docs_gh/llm/bin/roborev_install_post_commit_verifier.sh
+
+set -uo pipefail
+
+INSTALLER_MARKER="Installed by ~/docs_gh/llm/bin/roborev_install_post_commit_verifier.sh"
+
+# Resolve the verifier script path relative to this installer's location so
+# that the script works from both the main checkout and worktrees.
+# Canonical form: always use ~/docs_gh/llm (the permanent install location).
+# ROBOREV_VERIFIER_SCRIPT env var overrides — used by tests.
+_INSTALLER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(cd "${_INSTALLER_DIR}/.." && pwd)"
+VERIFIER_SCRIPT="${ROBOREV_VERIFIER_SCRIPT:-${_REPO_ROOT}/.claude/scripts/roborev_verify_closure.sh}"
+
+usage() {
+  echo "Usage: $0 <repo-path>" >&2
+  echo "  repo-path: path to a git working tree (must contain .git/)" >&2
+  exit 1
+}
+
+# ── Argument validation ───────────────────────────────────────────────────────
+
+if [ $# -ne 1 ]; then
+  usage
+fi
+
+REPO_PATH="$1"
+
+if [ ! -d "${REPO_PATH}/.git" ]; then
+  echo "ERROR: not a git repository (no .git/ directory): ${REPO_PATH}" >&2
+  exit 1
+fi
+
+HOOKS_DIR="${REPO_PATH}/.git/hooks"
+HOOK_FILE="${HOOKS_DIR}/post-commit"
+
+# ── Check for unrecognised existing hook ──────────────────────────────────────
+
+if [ -f "${HOOK_FILE}" ]; then
+  if grep -qF "${INSTALLER_MARKER}" "${HOOK_FILE}" 2>/dev/null; then
+    : # our hook — safe to overwrite / refresh
+  else
+    echo "CHAIN: ${REPO_PATH} already has a post-commit hook not written by this installer." >&2
+    echo "       To add the verifier, append the following to ${HOOK_FILE}:" >&2
+    echo "" >&2
+    echo "  # ── roborev post-commit verifier (#353) ──────────────────────────────────" >&2
+    echo "  [ \"\${ROBOREV_VERIFY_SKIP:-0}\" = \"1\" ] && exit 0" >&2
+    echo "  _sha=\$(git rev-parse HEAD)" >&2
+    echo "  _ids=\$(git log -1 --pretty=format:%B \"\$_sha\" \\" >&2
+    echo "    | grep -oE 'closes roborev #[0-9]+' \\" >&2
+    echo "    | grep -oE '[0-9]+' | sort -u)" >&2
+    echo "  [ -z \"\$_ids\" ] && exit 0" >&2
+    # shellcheck disable=SC2016
+    echo "  nohup \"${VERIFIER_SCRIPT}\" \"\$_sha\" \$_ids >/dev/null 2>&1 &" >&2
+    echo "" >&2
+    exit 0
+  fi
+fi
+
+# ── Write the hook ────────────────────────────────────────────────────────────
+
+cat > "${HOOK_FILE}" <<HOOK
+#!/usr/bin/env bash
+# Installed by ~/docs_gh/llm/bin/roborev_install_post_commit_verifier.sh
+# Post-commit verifier for roborev closure citations (JohnGavin/llm#353).
+#
+# When the commit message contains "closes roborev #N" (or "fixes/fix/close/
+# wontfix roborev #N"), this hook asynchronously invokes the verifier so that
+# a verdict JSON is produced without blocking git.
+#
+# Set ROBOREV_VERIFY_SKIP=1 to skip for a single commit.
+[ "\${ROBOREV_VERIFY_SKIP:-0}" = "1" ] && exit 0
+
+_sha=\$(git rev-parse HEAD 2>/dev/null || true)
+[ -z "\$_sha" ] && exit 0
+
+_msg=\$(git log -1 --pretty=format:%B "\$_sha" 2>/dev/null || true)
+[ -z "\$_msg" ] && exit 0
+
+# Parse "closes/fixes/fix/close/wontfix roborev #N" citations
+_ids=\$(printf '%s\n' "\$_msg" \
+  | grep -oiE '(closes?|fixes?|wontfix)[[:space:]]+roborev[[:space:]#]+[0-9]+([[:space:],#]+[0-9]+)*' \
+  | grep -oE '[0-9]+' \
+  | sort -u)
+[ -z "\$_ids" ] && exit 0
+
+VERIFIER="${VERIFIER_SCRIPT}"
+if [ ! -x "\$VERIFIER" ]; then
+  exit 0
+fi
+
+# nohup so the verifier runs asynchronously — never blocks git
+# shellcheck disable=SC2086
+nohup "\$VERIFIER" "\$_sha" \$_ids >/dev/null 2>&1 &
+
+exit 0
+HOOK
+
+chmod +x "${HOOK_FILE}"
+
+echo "OK: installed post-commit verifier hook in ${REPO_PATH}"

--- a/bin/roborev_install_post_commit_verifier_all.sh
+++ b/bin/roborev_install_post_commit_verifier_all.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# roborev_install_post_commit_verifier_all.sh
+#
+# Wrapper: iterates ~/docs_gh/* looking for git repositories and calls
+# roborev_install_post_commit_verifier.sh on each one.
+#
+# Prints a summary at the end: installed=N chained=M skipped=K failed=L
+# where:
+#   installed — hook written by this installer (fresh or refreshed)
+#   chained   — existing foreign hook detected; chaining instructions printed
+#   skipped   — directory is not a git repo
+#   failed    — installer exited non-zero
+#
+# Usage:
+#   bin/roborev_install_post_commit_verifier_all.sh
+#
+# Issue: JohnGavin/llm#353
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="${SCRIPT_DIR}/roborev_install_post_commit_verifier.sh"
+
+if [ ! -x "${INSTALLER}" ]; then
+  echo "ERROR: installer not found or not executable: ${INSTALLER}" >&2
+  exit 1
+fi
+
+DOCS_DIR="${HOME}/docs_gh"
+
+if [ ! -d "${DOCS_DIR}" ]; then
+  echo "ERROR: ${DOCS_DIR} not found" >&2
+  exit 1
+fi
+
+installed=0
+chained=0
+skipped=0
+failed=0
+
+for candidate in "${DOCS_DIR}"/*/; do
+  repo="${candidate%/}"
+  if [ ! -d "${repo}/.git" ]; then
+    skipped=$((skipped+1))
+    continue
+  fi
+
+  output=$("${INSTALLER}" "${repo}" 2>&1)
+  exit_code=$?
+
+  if [ "${exit_code}" -ne 0 ]; then
+    echo "FAILED: ${repo} — ${output}" >&2
+    failed=$((failed+1))
+  elif printf '%s\n' "${output}" | grep -q '^CHAIN:'; then
+    printf '%s\n' "${output}"
+    chained=$((chained+1))
+  else
+    printf '%s\n' "${output}"
+    installed=$((installed+1))
+  fi
+done
+
+echo ""
+echo "Summary: installed=${installed} chained=${chained} skipped=${skipped} failed=${failed}"

--- a/tests/test_roborev_verify_closure.sh
+++ b/tests/test_roborev_verify_closure.sh
@@ -1,0 +1,569 @@
+#!/usr/bin/env bash
+# tests/test_roborev_verify_closure.sh
+#
+# Integration tests for roborev_verify_closure.sh.
+#
+# Sets up a synthetic git repository and a mock roborev binary backed by a
+# fixture SQLite DB.  The mock roborev:
+#   - On "review --sha <sha> --wait": writes a review_jobs + reviews row with
+#     a configurable verdict, then prints "Enqueued job <N> for <sha>".
+#   - On "close <id>": no-op (verifier never calls close anyway).
+#
+# Test scenarios:
+#   1. verified-pass  — review approved, original finding location not re-flagged
+#   2. verified-fail  — review re-flags original finding location
+#   3. inconclusive (verdict_bool NULL)  — review completed but no verdict
+#   4. inconclusive (roborev missing)   — binary unavailable
+#   5. inconclusive (db missing)        — DB file does not exist
+#   6. multi-finding: one pass, one fail
+#   7. installer writes post-commit hook (idempotent)
+#   8. installer refuses to overwrite a foreign post-commit hook
+#
+# Issue: JohnGavin/llm#353
+
+set -uo pipefail
+
+export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+PASS=0
+FAIL=0
+
+# Resolve paths relative to this test file's location, then fall back to
+# installed locations under ~/docs_gh/llm/.
+_TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(cd "${_TEST_DIR}/.." && pwd)"
+
+VERIFIER="${_REPO_ROOT}/.claude/scripts/roborev_verify_closure.sh"
+INSTALLER="${_REPO_ROOT}/bin/roborev_install_post_commit_verifier.sh"
+
+# Scratch directory — cleaned up on exit
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# ── Helper: check ─────────────────────────────────────────────────────────────
+
+_check() {
+  local label="$1" result="$2"
+  if [ "$result" = "pass" ]; then
+    PASS=$((PASS+1))
+    echo "  PASS [$label]"
+  else
+    FAIL=$((FAIL+1))
+    echo "  FAIL [$label]: $result"
+  fi
+}
+
+# ── Helper: create a minimal SQLite DB with the roborev schema ────────────────
+
+_create_db() {
+  local db_path="$1"
+  /usr/bin/python3 - "$db_path" <<'PY'
+import sqlite3, sys
+
+db = sys.argv[1]
+conn = sqlite3.connect(db)
+c = conn.cursor()
+
+c.executescript("""
+CREATE TABLE repos (
+  id   INTEGER PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  root_path TEXT
+);
+
+CREATE TABLE commits (
+  id      INTEGER PRIMARY KEY,
+  repo_id INTEGER NOT NULL REFERENCES repos(id),
+  sha     TEXT    NOT NULL
+);
+
+CREATE TABLE review_jobs (
+  id          INTEGER PRIMARY KEY,
+  repo_id     INTEGER NOT NULL REFERENCES repos(id),
+  commit_id   INTEGER REFERENCES commits(id),
+  git_ref     TEXT    NOT NULL,
+  branch      TEXT,
+  agent       TEXT    NOT NULL DEFAULT 'codex',
+  status      TEXT    NOT NULL DEFAULT 'queued',
+  enqueued_at TEXT    NOT NULL DEFAULT (datetime('now')),
+  started_at  TEXT,
+  finished_at TEXT,
+  job_type    TEXT    NOT NULL DEFAULT 'review',
+  review_type TEXT    NOT NULL DEFAULT ''
+);
+
+CREATE TABLE reviews (
+  id           INTEGER PRIMARY KEY,
+  job_id       INTEGER UNIQUE NOT NULL REFERENCES review_jobs(id),
+  agent        TEXT    NOT NULL,
+  prompt       TEXT    NOT NULL DEFAULT '',
+  output       TEXT    NOT NULL,
+  created_at   TEXT    NOT NULL DEFAULT (datetime('now')),
+  closed       INTEGER NOT NULL DEFAULT 0,
+  verdict_bool INTEGER
+);
+
+CREATE TABLE closures (
+  id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+  finding_id            INTEGER NOT NULL REFERENCES reviews(id),
+  closure_commit_sha    TEXT    NOT NULL,
+  closure_review_job_id INTEGER REFERENCES review_jobs(id),
+  closure_type          TEXT    NOT NULL,
+  closure_reason        TEXT,
+  created_at            TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE fix_rejected_queue (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  finding_ids_json    TEXT    NOT NULL,
+  fix_commit_sha      TEXT    NOT NULL,
+  rejection_job_id    INTEGER REFERENCES review_jobs(id),
+  rejection_summary   TEXT,
+  attempted_at        TEXT    NOT NULL DEFAULT (datetime('now')),
+  resolved            INTEGER NOT NULL DEFAULT 0,
+  resolved_at         TEXT
+);
+
+INSERT INTO repos (id, name) VALUES (1, 'test_repo');
+""")
+conn.commit()
+conn.close()
+PY
+}
+
+# ── Helper: seed an existing finding in the DB ────────────────────────────────
+# _seed_finding <db> <finding_id> <output_text>
+
+_seed_finding() {
+  local db="$1" fid="$2" output="$3"
+  /usr/bin/python3 - "$db" "$fid" "$output" <<'PY'
+import sqlite3, sys
+
+db, fid = sys.argv[1], int(sys.argv[2])
+# Convert literal \n sequences to real newlines so location regex matches
+output = sys.argv[3].replace('\\n', '\n')
+conn = sqlite3.connect(db)
+
+# Need a review_jobs row to satisfy FK for the finding
+conn.execute(
+    "INSERT INTO review_jobs (id, repo_id, git_ref, status) VALUES (?, 1, 'original_sha', 'done')",
+    (fid,)
+)
+conn.execute(
+    "INSERT INTO reviews (id, job_id, agent, output) VALUES (?, ?, 'codex', ?)",
+    (fid, fid, output)
+)
+conn.commit()
+conn.close()
+PY
+}
+
+# ── Helper: write a mock roborev binary ───────────────────────────────────────
+# The mock reads MOCK_VERDICT_BOOL (1, 0, or "null") from env and
+# writes a review_jobs + reviews row into MOCK_DB.
+# It prints "Enqueued job <N> for <sha>" and exits 0.
+
+_write_mock_roborev() {
+  local mock_path="$1"
+  cat > "$mock_path" <<'MOCK'
+#!/usr/bin/env bash
+# Mock roborev binary for tests
+# Env vars:
+#   MOCK_DB           — path to test SQLite DB
+#   MOCK_VERDICT_BOOL — 1, 0, or "null"
+#   MOCK_OUTPUT       — review output text
+
+export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+case "${1:-}" in
+  review)
+    # Parse --sha flag
+    SHA=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --sha) shift; SHA="$1" ;;
+        --wait|--quiet|-q) ;;
+        *) ;;
+      esac
+      shift
+    done
+    SHA="${SHA:-HEAD}"
+
+    DB="${MOCK_DB:-}"
+    VERDICT="${MOCK_VERDICT_BOOL:-1}"
+    OUTPUT="${MOCK_OUTPUT:-## Review Findings\n- No issues found.}"
+
+    if [ -n "$DB" ] && [ -f "$DB" ]; then
+      /usr/bin/python3 - "$DB" "$SHA" "$VERDICT" "$OUTPUT" <<'PY'
+import sqlite3, sys
+
+db_path  = sys.argv[1]
+sha      = sys.argv[2]
+verdict  = sys.argv[3]
+# Convert literal \n sequences to real newlines so location regex matches
+output   = sys.argv[4].replace('\\n', '\n')
+
+conn = sqlite3.connect(db_path)
+c = conn.cursor()
+
+# Insert a commit row
+c.execute("INSERT INTO commits (repo_id, sha) VALUES (1, ?)", (sha,))
+commit_id = c.lastrowid
+
+# Insert a review_jobs row
+c.execute(
+    "INSERT INTO review_jobs (repo_id, commit_id, git_ref, status, finished_at, started_at) "
+    "VALUES (1, ?, ?, 'done', datetime('now'), datetime('now'))",
+    (commit_id, sha)
+)
+job_id = c.lastrowid
+
+# Insert reviews row with verdict
+v_bool = None if verdict == "null" else int(verdict)
+c.execute(
+    "INSERT INTO reviews (job_id, agent, output, verdict_bool) VALUES (?, 'codex', ?, ?)",
+    (job_id, output, v_bool)
+)
+conn.commit()
+conn.close()
+
+print(f"Enqueued job {job_id} for {sha[:7]} (agent: codex)")
+PY
+    else
+      echo "Enqueued job 9999 for ${SHA:0:7} (agent: codex)"
+    fi
+    ;;
+  close)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+MOCK
+  chmod +x "$mock_path"
+}
+
+# ── Self-test of verifier unit tests ─────────────────────────────────────────
+
+echo "Running verifier self-test..."
+if SELFTEST=1 bash "$VERIFIER"; then
+  _check "verifier-selftest" "pass"
+else
+  _check "verifier-selftest" "fail: SELFTEST exited non-zero"
+fi
+
+# ── Test 1: verified-pass ─────────────────────────────────────────────────────
+
+echo ""
+echo "Test 1: verified-pass (approved, location not re-flagged)"
+
+T1="${SCRATCH}/t1"
+mkdir -p "$T1"
+T1_DB="${T1}/reviews.db"
+T1_MOCK="${T1}/roborev"
+T1_LOG="${T1}/verify_log"
+T1_VERDICT_DIR="${T1}/verdicts"
+
+_create_db "$T1_DB"
+
+# Seed finding #10 with a specific location
+_seed_finding "$T1_DB" 10 \
+  "## Review Findings\n- **Location**: R/foo.R:42\n- **Problem**: unhandled NA"
+
+_write_mock_roborev "$T1_MOCK"
+
+mkdir -p "$T1_VERDICT_DIR"
+
+ROBOREV="$T1_MOCK" \
+ROBOREV_DB="$T1_DB" \
+MOCK_DB="$T1_DB" \
+MOCK_VERDICT_BOOL="1" \
+MOCK_OUTPUT="## Review Findings\n- No issues found.\n## Summary\nLooks good." \
+HOME="$T1" \
+  bash "$VERIFIER" "abc1234" 10 2>/dev/null
+
+VERDICT_FILE="${T1}/.claude/logs/roborev_verify_closure/abc1234.json"
+if [ -f "$VERDICT_FILE" ]; then
+  STATUS=$(/usr/bin/python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(d['verdicts']['10']['status'])
+" "$VERDICT_FILE")
+  if [ "$STATUS" = "verified-pass" ]; then
+    _check "t1-verified-pass" "pass"
+  else
+    _check "t1-verified-pass" "fail: got status='${STATUS}'"
+  fi
+else
+  _check "t1-verified-pass" "fail: verdict file not written"
+fi
+
+# ── Test 2: verified-fail ─────────────────────────────────────────────────────
+
+echo ""
+echo "Test 2: verified-fail (location re-flagged in new review)"
+
+T2="${SCRATCH}/t2"
+mkdir -p "$T2"
+T2_DB="${T2}/reviews.db"
+T2_MOCK="${T2}/roborev"
+
+_create_db "$T2_DB"
+
+# Seed finding #20 with location R/bar.R:99
+_seed_finding "$T2_DB" 20 \
+  "## Review Findings\n- **Location**: R/bar.R:99\n- **Problem**: missing check"
+
+_write_mock_roborev "$T2_MOCK"
+
+# New review STILL flags R/bar.R:99
+ROBOREV="$T2_MOCK" \
+ROBOREV_DB="$T2_DB" \
+MOCK_DB="$T2_DB" \
+MOCK_VERDICT_BOOL="0" \
+MOCK_OUTPUT="## Review Findings\n- **Severity**: High\n- **Location**: R/bar.R:99\n- **Problem**: still missing check" \
+HOME="$T2" \
+  bash "$VERIFIER" "def5678" 20 2>/dev/null
+
+VERDICT_FILE="${T2}/.claude/logs/roborev_verify_closure/def5678.json"
+if [ -f "$VERDICT_FILE" ]; then
+  STATUS=$(/usr/bin/python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(d['verdicts']['20']['status'])
+" "$VERDICT_FILE")
+  if [ "$STATUS" = "verified-fail" ]; then
+    _check "t2-verified-fail" "pass"
+  else
+    _check "t2-verified-fail" "fail: got status='${STATUS}'"
+  fi
+else
+  _check "t2-verified-fail" "fail: verdict file not written"
+fi
+
+# ── Test 3: inconclusive (NULL verdict_bool) ──────────────────────────────────
+
+echo ""
+echo "Test 3: inconclusive (verdict_bool=NULL)"
+
+T3="${SCRATCH}/t3"
+mkdir -p "$T3"
+T3_DB="${T3}/reviews.db"
+T3_MOCK="${T3}/roborev"
+
+_create_db "$T3_DB"
+_seed_finding "$T3_DB" 30 "## Review Findings\n- **Location**: R/baz.R:5\n- **Problem**: something"
+_write_mock_roborev "$T3_MOCK"
+
+ROBOREV="$T3_MOCK" \
+ROBOREV_DB="$T3_DB" \
+MOCK_DB="$T3_DB" \
+MOCK_VERDICT_BOOL="null" \
+MOCK_OUTPUT="## Review Findings\n- No issues found." \
+HOME="$T3" \
+  bash "$VERIFIER" "fff9999" 30 2>/dev/null
+
+VERDICT_FILE="${T3}/.claude/logs/roborev_verify_closure/fff9999.json"
+if [ -f "$VERDICT_FILE" ]; then
+  STATUS=$(/usr/bin/python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(d['verdicts']['30']['status'])
+" "$VERDICT_FILE")
+  if [ "$STATUS" = "inconclusive" ]; then
+    _check "t3-inconclusive-null-verdict" "pass"
+  else
+    _check "t3-inconclusive-null-verdict" "fail: got status='${STATUS}'"
+  fi
+else
+  _check "t3-inconclusive-null-verdict" "fail: verdict file not written"
+fi
+
+# ── Test 4: inconclusive (roborev binary missing) ─────────────────────────────
+
+echo ""
+echo "Test 4: inconclusive (roborev binary not found)"
+
+T4="${SCRATCH}/t4"
+mkdir -p "$T4"
+T4_DB="${T4}/reviews.db"
+_create_db "$T4_DB"
+
+ROBOREV="${T4}/no_such_binary" \
+ROBOREV_DB="$T4_DB" \
+HOME="$T4" \
+  bash "$VERIFIER" "aaa1111" 40 2>/dev/null
+
+VERDICT_FILE="${T4}/.claude/logs/roborev_verify_closure/aaa1111.json"
+if [ -f "$VERDICT_FILE" ]; then
+  STATUS=$(/usr/bin/python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(d['verdicts']['40']['status'])
+" "$VERDICT_FILE")
+  if [ "$STATUS" = "inconclusive" ]; then
+    _check "t4-inconclusive-no-binary" "pass"
+  else
+    _check "t4-inconclusive-no-binary" "fail: got status='${STATUS}'"
+  fi
+else
+  _check "t4-inconclusive-no-binary" "fail: verdict file not written"
+fi
+
+# ── Test 5: inconclusive (DB missing) ────────────────────────────────────────
+
+echo ""
+echo "Test 5: inconclusive (DB file not present)"
+
+T5="${SCRATCH}/t5"
+mkdir -p "$T5"
+T5_MOCK="${T5}/roborev"
+_write_mock_roborev "$T5_MOCK"
+
+ROBOREV="$T5_MOCK" \
+ROBOREV_DB="${T5}/no_such.db" \
+HOME="$T5" \
+  bash "$VERIFIER" "bbb2222" 50 2>/dev/null
+
+VERDICT_FILE="${T5}/.claude/logs/roborev_verify_closure/bbb2222.json"
+if [ -f "$VERDICT_FILE" ]; then
+  STATUS=$(/usr/bin/python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(d['verdicts']['50']['status'])
+" "$VERDICT_FILE")
+  if [ "$STATUS" = "inconclusive" ]; then
+    _check "t5-inconclusive-no-db" "pass"
+  else
+    _check "t5-inconclusive-no-db" "fail: got status='${STATUS}'"
+  fi
+else
+  _check "t5-inconclusive-no-db" "fail: verdict file not written"
+fi
+
+# ── Test 6: multi-finding — one pass, one fail ────────────────────────────────
+
+echo ""
+echo "Test 6: multi-finding (one verified-pass, one verified-fail)"
+
+T6="${SCRATCH}/t6"
+mkdir -p "$T6"
+T6_DB="${T6}/reviews.db"
+T6_MOCK="${T6}/roborev"
+
+_create_db "$T6_DB"
+
+# Finding #60: location R/alpha.R:10 (will NOT be re-flagged → pass)
+_seed_finding "$T6_DB" 60 \
+  "## Review Findings\n- **Location**: R/alpha.R:10\n- **Problem**: issue A"
+
+# Finding #61: location R/beta.R:20 (WILL be re-flagged → fail)
+_seed_finding "$T6_DB" 61 \
+  "## Review Findings\n- **Location**: R/beta.R:20\n- **Problem**: issue B"
+
+_write_mock_roborev "$T6_MOCK"
+
+# New review only re-flags beta
+ROBOREV="$T6_MOCK" \
+ROBOREV_DB="$T6_DB" \
+MOCK_DB="$T6_DB" \
+MOCK_VERDICT_BOOL="0" \
+MOCK_OUTPUT="## Review Findings\n- **Location**: R/beta.R:20\n- **Problem**: still issue B" \
+HOME="$T6" \
+  bash "$VERIFIER" "ccc3333" 60 61 2>/dev/null
+
+VERDICT_FILE="${T6}/.claude/logs/roborev_verify_closure/ccc3333.json"
+if [ -f "$VERDICT_FILE" ]; then
+  STATUS60=$(/usr/bin/python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(d['verdicts']['60']['status'])
+" "$VERDICT_FILE")
+  STATUS61=$(/usr/bin/python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(d['verdicts']['61']['status'])
+" "$VERDICT_FILE")
+
+  if [ "$STATUS60" = "inconclusive" ] && [ "$STATUS61" = "verified-fail" ]; then
+    # Finding 60's location not re-flagged, but overall verdict=0, so 60 is inconclusive
+    _check "t6-multi-finding" "pass"
+  else
+    _check "t6-multi-finding" "fail: status60='${STATUS60}' status61='${STATUS61}' (expected inconclusive + verified-fail)"
+  fi
+else
+  _check "t6-multi-finding" "fail: verdict file not written"
+fi
+
+# ── Test 7: installer writes hook (idempotent) ────────────────────────────────
+
+echo ""
+echo "Test 7: installer writes post-commit hook (idempotent)"
+
+T7="${SCRATCH}/t7"
+mkdir -p "${T7}/.git/hooks"
+# First install (point installed hook at our worktree's verifier for testing)
+ROBOREV_VERIFIER_SCRIPT="$VERIFIER" bash "$INSTALLER" "$T7" 2>/dev/null
+HOOK_FILE="${T7}/.git/hooks/post-commit"
+if [ -f "$HOOK_FILE" ] && [ -x "$HOOK_FILE" ]; then
+  _check "t7-hook-created" "pass"
+else
+  _check "t7-hook-created" "fail: hook file missing or not executable"
+fi
+
+# Re-run should be idempotent (still OK marker)
+OUT2=$(ROBOREV_VERIFIER_SCRIPT="$VERIFIER" bash "$INSTALLER" "$T7" 2>/dev/null)
+if printf '%s\n' "$OUT2" | grep -q '^OK:'; then
+  _check "t7-hook-idempotent" "pass"
+else
+  _check "t7-hook-idempotent" "fail: re-run did not print OK:"
+fi
+
+# Hook should contain ROBOREV_VERIFY_SKIP guard
+if grep -q 'ROBOREV_VERIFY_SKIP' "$HOOK_FILE"; then
+  _check "t7-skip-guard" "pass"
+else
+  _check "t7-skip-guard" "fail: ROBOREV_VERIFY_SKIP not in hook"
+fi
+
+# ── Test 8: installer refuses foreign hook ────────────────────────────────────
+
+echo ""
+echo "Test 8: installer refuses to overwrite foreign post-commit hook"
+
+T8="${SCRATCH}/t8"
+mkdir -p "${T8}/.git/hooks"
+FOREIGN="${T8}/.git/hooks/post-commit"
+cat > "$FOREIGN" <<'EOF'
+#!/usr/bin/env bash
+# Foreign hook — not installed by our installer
+echo "foreign hook"
+EOF
+chmod +x "$FOREIGN"
+
+OUT8=$(ROBOREV_VERIFIER_SCRIPT="$VERIFIER" bash "$INSTALLER" "$T8" 2>&1)
+if printf '%s\n' "$OUT8" | grep -q '^CHAIN:'; then
+  _check "t8-refuses-foreign-hook" "pass"
+else
+  _check "t8-refuses-foreign-hook" "fail: expected CHAIN: output, got: ${OUT8}"
+fi
+
+# The original foreign hook must be unchanged
+if grep -q 'foreign hook' "$FOREIGN"; then
+  _check "t8-foreign-hook-preserved" "pass"
+else
+  _check "t8-foreign-hook-preserved" "fail: foreign hook was overwritten"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+TOTAL=$((PASS+FAIL))
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo "${PASS}/${TOTAL} PASS"
+  exit 0
+else
+  echo "${PASS}/${TOTAL} PASS — ${FAIL} FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `.claude/scripts/roborev_verify_closure.sh` — signal-only post-commit verifier (Component 4 of the #163 automation loop). Triggers roborev re-review on cited finding IDs, classifies each as `verified-pass` / `verified-fail` / `inconclusive`, writes verdict JSON to `~/.claude/logs/roborev_verify_closure/<sha>.json`. SIGNAL ONLY — does NOT write to `closures` or `fix_rejected_queue` tables (that is #354's job).
- Adds `bin/roborev_install_post_commit_verifier.sh` — idempotent hook installer that nohup-forks the verifier asynchronously so git is never blocked. Refuses to overwrite foreign hooks (prints `CHAIN:` instructions).
- Adds `bin/roborev_install_post_commit_verifier_all.sh` — all-repos wrapper.
- Adds `tests/test_roborev_verify_closure.sh` — 12/12 integration tests passing.

## Test plan

- [x] `bash -n` passes on all 4 new files
- [x] `SELFTEST=1 bash .claude/scripts/roborev_verify_closure.sh` — 5/5 PASS
- [x] `bash tests/test_roborev_verify_closure.sh` — 12/12 PASS
  - verified-pass: approved review + location not re-flagged
  - verified-fail: location re-flagged in new review output
  - inconclusive: NULL verdict_bool
  - inconclusive: roborev binary missing
  - inconclusive: DB file missing
  - multi-finding: one pass + one fail in same commit
  - installer idempotency (3 sub-checks)
  - installer refuses foreign hook (2 sub-checks)

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)