### PR TITLE
feat(#150): codex↔gemini auto-fallback wrapper (Phase 1)

### DIFF
--- a/.claude/scripts/codex_with_fallback.sh
+++ b/.claude/scripts/codex_with_fallback.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# codex_with_fallback.sh — invoke codex; auto-fall back to gemini on 429.
+#
+# Phase 1 of JohnGavin/llm#150 (codex↔gemini auto-fallback wrapper).
+#
+# Behaviour:
+#   1. Invoke $CODEX_BIN (default: codex) with all supplied args.
+#   2. Classify the result: success | rate_limit_429 | auth_failed |
+#      provider_error | other.
+#   3. On rate_limit_429: retry once with $GEMINI_BIN (default: gemini).
+#   4. On auth_failed: fail immediately (do NOT fall back silently).
+#   5. On any other non-zero: fail immediately, log the error.
+#   6. Emit one JSON line per invocation to
+#        ~/.claude/logs/codex_fallback/YYYY-MM-DD.jsonl
+#
+# Environment overrides (for testing):
+#   CODEX_BIN         Path to primary binary     (default: codex)
+#   GEMINI_BIN        Path to fallback binary    (default: gemini)
+#   FALLBACK_LOG_DIR  Parent of YYYY-MM-DD.jsonl (default: ~/.claude/logs/codex_fallback)
+#
+# Exit codes match the final provider's exit code.
+#
+# Constraints:
+#   - No compound && commands (single command per line; subshell exception OK).
+#   - Passes bash -n.
+#   - Handles gemini absent from PATH with a clear error.
+#
+# Tracked: JohnGavin/llm#150
+
+# NOTE: do NOT use set -e here — we capture exit codes manually and must not
+# exit on non-zero from the provider binaries.
+set -uo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+CODEX_BIN="${CODEX_BIN:-codex}"
+GEMINI_BIN="${GEMINI_BIN:-gemini}"
+FALLBACK_LOG_DIR="${FALLBACK_LOG_DIR:-$HOME/.claude/logs/codex_fallback}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Generate a UUID-like token without external deps or pipelines from /dev/urandom
+_uuid() {
+  local hex=""
+  # Read 16 bytes as hex using xxd if available, else od with safe head
+  if command -v xxd >/dev/null 2>&1; then
+    hex=$(xxd -l 16 -p /dev/urandom 2>/dev/null)
+  else
+    # od approach: read exactly 16 bytes, output hex, first token only
+    hex=$(od -An -tx1 -N16 /dev/urandom 2>/dev/null | tr -d ' \n')
+  fi
+  # If both fail, use time+pid
+  if [ -z "$hex" ] || [ "${#hex}" -lt 32 ]; then
+    hex=$(printf '%x%x' "$(date +%s)" "$$")
+    # pad to 32 chars
+    while [ "${#hex}" -lt 32 ]; do
+      hex="${hex}0"
+    done
+  fi
+  # Format as xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  printf '%s-%s-%s-%s-%s' \
+    "${hex:0:8}" "${hex:8:4}" "${hex:12:4}" "${hex:16:4}" "${hex:20:12}"
+}
+
+# Redact secrets from the args array, returning a JSON array string
+_redact_args() {
+  local out="["
+  local first=1
+  local val
+  for arg in "$@"; do
+    val="$arg"
+    # Case-insensitive check for sensitive keywords
+    local upper
+    upper=$(printf '%s' "$arg" | tr '[:lower:]' '[:upper:]')
+    case "$upper" in
+      *KEY*|*TOKEN*|*SECRET*|*PASSWORD*|*PASS*)
+        val="<redacted>"
+        ;;
+    esac
+    # Escape backslash and double-quote in val
+    val=$(printf '%s' "$val" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    if [ "$first" -eq 1 ]; then
+      out="${out}\"${val}\""
+      first=0
+    else
+      out="${out},\"${val}\""
+    fi
+  done
+  out="${out}]"
+  printf '%s' "$out"
+}
+
+# Classify a provider invocation result.
+# Uses grep (not case) to handle multi-line combined output reliably.
+# Outputs one of: success rate_limit_429 auth_failed provider_error other
+_classify() {
+  local exit_code="$1"
+  local combined="$2"
+
+  if [ "$exit_code" -eq 0 ]; then
+    printf 'success'
+    return
+  fi
+
+  # Rate-limit signals (case-insensitive grep)
+  if printf '%s' "$combined" | grep -qiE '429|rate_limit_exceeded|rate.limit|quota exceeded|RateLimitError'; then
+    printf 'rate_limit_429'
+    return
+  fi
+
+  # Auth failure signals
+  if printf '%s' "$combined" | grep -qiE '^.*(401|unauthori[sz]ed|invalid.api.key|authentication error|AuthenticationError).*$'; then
+    printf 'auth_failed'
+    return
+  fi
+  # Extra plain-word auth check
+  if printf '%s' "$combined" | grep -qiE '401|unauthorized|invalid.api.key|AuthenticationError'; then
+    printf 'auth_failed'
+    return
+  fi
+
+  # Distinguish provider error vs truly unknown
+  if printf '%s' "$combined" | grep -qiE 'error|fail'; then
+    printf 'provider_error'
+    return
+  fi
+
+  printf 'other'
+}
+
+# Emit one JSONL record to the daily log file.
+# Arguments (positional):
+#   1  invocation_id
+#   2  primary_exit
+#   3  primary_classification
+#   4  fallback_used        (true|false)
+#   5  fallback_provider    (gemini|"")
+#   6  fallback_exit        (int or "")
+#   7  final_provider       (codex|gemini)
+#   8  duration_sec
+#   9+ original args (redacted)
+_emit_jsonl() {
+  local inv_id="$1"
+  local prim_exit="$2"
+  local prim_class="$3"
+  local fb_used="$4"
+  local fb_provider="$5"
+  local fb_exit="$6"
+  local final_prov="$7"
+  local dur="$8"
+  shift 8
+
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  local date_part
+  date_part=$(date -u +%Y-%m-%d)
+
+  mkdir -p "$FALLBACK_LOG_DIR"
+  local logfile="${FALLBACK_LOG_DIR}/${date_part}.jsonl"
+
+  local args_json
+  args_json=$(_redact_args "$@")
+
+  local fb_provider_json='null'
+  if [ -n "$fb_provider" ]; then
+    fb_provider_json="\"${fb_provider}\""
+  fi
+
+  local fb_exit_json='null'
+  if [ -n "$fb_exit" ]; then
+    fb_exit_json="${fb_exit}"
+  fi
+
+  printf '{"ts":"%s","invocation_id":"%s","primary_provider":"codex","primary_exit":%s,"primary_classification":"%s","fallback_used":%s,"fallback_provider":%s,"fallback_exit":%s,"final_provider":"%s","duration_sec":%s,"args_redacted":%s}\n' \
+    "$ts" "$inv_id" "$prim_exit" "$prim_class" "$fb_used" \
+    "$fb_provider_json" "$fb_exit_json" "$final_prov" "$dur" "$args_json" \
+    >> "$logfile"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+INV_ID=$(_uuid)
+T_START=$(date +%s)
+
+# ── Step 1: invoke primary (codex) ───────────────────────────────────────────
+
+if ! command -v "$CODEX_BIN" >/dev/null 2>&1; then
+  echo "codex_with_fallback: ERROR — primary '$CODEX_BIN' not found on PATH" >&2
+  _emit_jsonl "$INV_ID" 127 "other" false "" "" "codex" 0 "$@"
+  exit 127
+fi
+
+PRIMARY_STDOUT=$(mktemp /tmp/codex_fallback_stdout_XXXXXX)
+PRIMARY_STDERR=$(mktemp /tmp/codex_fallback_stderr_XXXXXX)
+
+# Cleanup tempfiles on exit
+cleanup() {
+  rm -f "${PRIMARY_STDOUT:-}" "${PRIMARY_STDERR:-}" \
+        "${FB_STDOUT:-}" "${FB_STDERR:-}" 2>/dev/null
+}
+trap cleanup EXIT
+
+PRIMARY_EXIT=0
+"$CODEX_BIN" "$@" >"$PRIMARY_STDOUT" 2>"$PRIMARY_STDERR" || PRIMARY_EXIT=$?
+
+T_END=$(date +%s)
+DURATION=$(( T_END - T_START ))
+
+# Combine stdout+stderr for classification
+PRIMARY_COMBINED=""
+PRIMARY_COMBINED=$(cat "$PRIMARY_STDOUT" "$PRIMARY_STDERR" 2>/dev/null) || true
+PRIMARY_CLASS=$(_classify "$PRIMARY_EXIT" "$PRIMARY_COMBINED")
+
+# ── Step 2: handle classification ────────────────────────────────────────────
+
+case "$PRIMARY_CLASS" in
+  success)
+    _emit_jsonl "$INV_ID" "$PRIMARY_EXIT" "success" false "" "" "codex" "$DURATION" "$@"
+    cat "$PRIMARY_STDOUT"
+    exit 0
+    ;;
+
+  rate_limit_429)
+    echo "codex_with_fallback: codex 429 — falling back to gemini" >&2
+
+    if ! command -v "$GEMINI_BIN" >/dev/null 2>&1; then
+      echo "codex_with_fallback: ERROR — fallback '$GEMINI_BIN' not found on PATH" >&2
+      echo "  Install hint: npm install -g @google/gemini-cli" >&2
+      _emit_jsonl "$INV_ID" "$PRIMARY_EXIT" "rate_limit_429" false "" "" "codex" "$DURATION" "$@"
+      cat "$PRIMARY_STDERR" >&2
+      exit "$PRIMARY_EXIT"
+    fi
+
+    FB_STDOUT=$(mktemp /tmp/codex_fallback_fb_stdout_XXXXXX)
+    FB_STDERR=$(mktemp /tmp/codex_fallback_fb_stderr_XXXXXX)
+
+    FB_EXIT=0
+    "$GEMINI_BIN" "$@" >"$FB_STDOUT" 2>"$FB_STDERR" || FB_EXIT=$?
+    T_FB_END=$(date +%s)
+    TOTAL_DURATION=$(( T_FB_END - T_START ))
+
+    _emit_jsonl "$INV_ID" "$PRIMARY_EXIT" "rate_limit_429" true "gemini" "$FB_EXIT" "gemini" "$TOTAL_DURATION" "$@"
+
+    if [ "$FB_EXIT" -ne 0 ]; then
+      echo "codex_with_fallback: gemini fallback also failed (exit $FB_EXIT)" >&2
+      cat "$FB_STDERR" >&2
+      exit "$FB_EXIT"
+    fi
+
+    cat "$FB_STDOUT"
+    exit 0
+    ;;
+
+  auth_failed)
+    echo "codex_with_fallback: authentication failure — not falling back (check API key)" >&2
+    _emit_jsonl "$INV_ID" "$PRIMARY_EXIT" "auth_failed" false "" "" "codex" "$DURATION" "$@"
+    cat "$PRIMARY_STDERR" >&2
+    exit "$PRIMARY_EXIT"
+    ;;
+
+  provider_error|other)
+    echo "codex_with_fallback: provider error (exit $PRIMARY_EXIT, class $PRIMARY_CLASS) — not falling back" >&2
+    _emit_jsonl "$INV_ID" "$PRIMARY_EXIT" "$PRIMARY_CLASS" false "" "" "codex" "$DURATION" "$@"
+    cat "$PRIMARY_STDERR" >&2
+    exit "$PRIMARY_EXIT"
+    ;;
+esac

--- a/tests/codex_fallback/test_codex_fallback.sh
+++ b/tests/codex_fallback/test_codex_fallback.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# tests/codex_fallback/test_codex_fallback.sh
+#
+# Test suite for .claude/scripts/codex_with_fallback.sh
+#
+# Uses stub binaries placed in a tmpdir-on-PATH. No bats dependency.
+# Exits 0 if all tests pass, 1 on any failure.
+#
+# Covered cases (≥10 tests, aligns with task specification):
+#   1.  codex success → final_provider=codex, exit 0
+#   2.  codex 429    + gemini success → final_provider=gemini, exit 0
+#   3.  codex 429    + gemini fail    → final_provider=gemini, exit non-zero
+#   4.  codex 401    (auth fail)      → no fallback, exit non-zero
+#   5.  codex other error             → no fallback, exit non-zero
+#   6.  JSON record emitted on every case
+#   7.  codex 429 + gemini absent → clear error, no crash, exit non-zero
+#   8.  codex absent                  → clear error, exit 127
+#   9.  Secret args are redacted in JSONL
+#   10. fallback_used=false in JSONL for success case
+#   11. fallback_used=true  in JSONL for 429+gemini-success case
+#   12. provider_error classification (non-auth non-429 error with "Error" text)
+#   13. duration_sec present and numeric in JSONL
+#   14. JSONL file is append-only (two runs → two lines)
+#
+# Tracked: JohnGavin/llm#150
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="${SCRIPT_DIR}/../../.claude/scripts/codex_with_fallback.sh"
+
+PASS=0
+FAIL=0
+TMPROOT=$(mktemp -d /tmp/test_codex_fallback_XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# ── Test helpers ─────────────────────────────────────────────────────────────
+
+pass() { echo "PASS: $1"; (( PASS += 1 )); }
+fail() { echo "FAIL: $1 — ${2:-}"; (( FAIL += 1 )); }
+
+# Run wrapper with stub PATH; capture stdout, stderr, exit code.
+# Usage: run_wrapper [--codex-stub FILE] [--gemini-stub FILE] -- [args...]
+#
+# Stubs are executable scripts written into a fresh tmpdir-based bin.
+# If a stub is NOT provided, that binary is absent from the test PATH
+# (the test PATH is isolated — real codex/gemini are hidden).
+run_wrapper() {
+  local codex_stub="" gemini_stub=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --codex-stub)  codex_stub="$2"; shift 2 ;;
+      --gemini-stub) gemini_stub="$2"; shift 2 ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  # Fresh bindir per call so stubs don't leak between tests
+  local bindir
+  bindir=$(mktemp -d "${TMPROOT}/bin_XXXXXX")
+  local logdir
+  logdir=$(mktemp -d "${TMPROOT}/logs_XXXXXX")
+  mkdir -p "${logdir}/codex_fallback"
+  local logsubdir="${logdir}/codex_fallback"
+
+  if [ -n "$codex_stub" ]; then
+    cp "$codex_stub" "${bindir}/codex"
+    chmod +x "${bindir}/codex"
+  fi
+  if [ -n "$gemini_stub" ]; then
+    cp "$gemini_stub" "${bindir}/gemini"
+    chmod +x "${bindir}/gemini"
+  fi
+  # Replace PATH completely with the isolated bindir plus only safe system paths.
+  # This ensures real codex/gemini are NOT found when no stub is provided.
+  local ISOLATED_PATH="${bindir}:/usr/bin:/bin"
+
+  local stdout_f stderr_f exit_f
+  stdout_f=$(mktemp "${TMPROOT}/stdout_XXXXXX")
+  stderr_f=$(mktemp "${TMPROOT}/stderr_XXXXXX")
+  exit_f=$(mktemp "${TMPROOT}/exit_XXXXXX")
+
+  # Run wrapper; capture exit code via a sentinel file inside the subshell.
+  # Use ISOLATED_PATH so real codex/gemini are hidden when no stub provided.
+  (
+    export PATH="${ISOLATED_PATH}"
+    export FALLBACK_LOG_DIR="${logsubdir}"
+    unset CODEX_BIN GEMINI_BIN
+    "$WRAPPER" "$@"
+    printf '%s' "$?" > "$exit_f"
+  ) >"$stdout_f" 2>"$stderr_f" || printf '%s' "$?" > "$exit_f"
+
+  _LAST_STDOUT=$(cat "$stdout_f")
+  _LAST_STDERR=$(cat "$stderr_f")
+  _LAST_EXIT=$(cat "$exit_f" 2>/dev/null || printf '0')
+  _LAST_LOGDIR="$logsubdir"
+
+  rm -f "$stdout_f" "$stderr_f" "$exit_f"
+}
+
+# Read most recent JSONL line from _LAST_LOGDIR
+last_jsonl() {
+  local date_part
+  date_part=$(date -u +%Y-%m-%d)
+  local logfile="${_LAST_LOGDIR}/${date_part}.jsonl"
+  if [ -f "$logfile" ]; then
+    tail -1 "$logfile"
+  else
+    echo ""
+  fi
+}
+
+jsonl_field() {
+  local field="$1"
+  local json
+  json=$(last_jsonl)
+  # Simple grep-based extraction for portability (no jq required)
+  printf '%s' "$json" | grep -oE "\"${field}\":[^,}]+" | head -1 | sed "s/\"${field}\"://"
+}
+
+# ── Stub scripts ─────────────────────────────────────────────────────────────
+
+write_stub() {
+  local path="$1"
+  local body="$2"
+  printf '%s\n' "#!/usr/bin/env bash" "$body" > "$path"
+  chmod +x "$path"
+}
+
+STUB_CODEX_SUCCESS=$(mktemp "${TMPROOT}/stub_codex_success_XXXXXX")
+write_stub "$STUB_CODEX_SUCCESS" \
+  "echo 'fake codex review result'; exit 0"
+
+STUB_CODEX_429=$(mktemp "${TMPROOT}/stub_codex_429_XXXXXX")
+write_stub "$STUB_CODEX_429" \
+  "echo '429 rate_limit_exceeded: quota exhausted' >&2; exit 1"
+
+STUB_CODEX_401=$(mktemp "${TMPROOT}/stub_codex_401_XXXXXX")
+write_stub "$STUB_CODEX_401" \
+  "echo '401 unauthorized: invalid API key' >&2; exit 1"
+
+STUB_CODEX_OTHER=$(mktemp "${TMPROOT}/stub_codex_other_XXXXXX")
+write_stub "$STUB_CODEX_OTHER" \
+  "echo 'internal server Error occurred' >&2; exit 1"
+
+STUB_GEMINI_SUCCESS=$(mktemp "${TMPROOT}/stub_gemini_success_XXXXXX")
+write_stub "$STUB_GEMINI_SUCCESS" \
+  "echo 'fake gemini review result'; exit 0"
+
+STUB_GEMINI_FAIL=$(mktemp "${TMPROOT}/stub_gemini_fail_XXXXXX")
+write_stub "$STUB_GEMINI_FAIL" \
+  "echo 'gemini internal error' >&2; exit 2"
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+# Reset shared log dir for each test to avoid cross-contamination
+fresh_logdir() {
+  mkdir -p "${TMPROOT}/logs_${PASS}_${FAIL}/codex_fallback"
+  echo "${TMPROOT}/logs_${PASS}_${FAIL}/codex_fallback"
+}
+
+# ── Test 1: codex success → exit 0, stdout relayed ──────────────────────────
+run_wrapper --codex-stub "$STUB_CODEX_SUCCESS" -- review myfile.R
+if [ "$_LAST_EXIT" -eq 0 ]; then
+  pass "1: codex success exits 0"
+else
+  fail "1: codex success exits 0" "exit was $_LAST_EXIT"
+fi
+
+if printf '%s' "$_LAST_STDOUT" | grep -q "fake codex review result"; then
+  pass "2: codex success stdout relayed"
+else
+  fail "2: codex success stdout relayed" "stdout was: $_LAST_STDOUT"
+fi
+
+# ── Test 3: codex 429 + gemini success → exit 0, gemini stdout ───────────────
+run_wrapper --codex-stub "$STUB_CODEX_429" --gemini-stub "$STUB_GEMINI_SUCCESS" -- review myfile.R
+if [ "$_LAST_EXIT" -eq 0 ]; then
+  pass "3: 429+gemini success exits 0"
+else
+  fail "3: 429+gemini success exits 0" "exit was $_LAST_EXIT"
+fi
+
+if printf '%s' "$_LAST_STDOUT" | grep -q "fake gemini review result"; then
+  pass "4: 429+gemini success stdout from gemini"
+else
+  fail "4: 429+gemini success stdout from gemini" "stdout was: $_LAST_STDOUT"
+fi
+
+# ── Test 5: codex 429 + gemini fail → non-zero exit ──────────────────────────
+run_wrapper --codex-stub "$STUB_CODEX_429" --gemini-stub "$STUB_GEMINI_FAIL" -- review myfile.R
+if [ "$_LAST_EXIT" -ne 0 ]; then
+  pass "5: 429+gemini fail exits non-zero"
+else
+  fail "5: 429+gemini fail exits non-zero" "exit was $_LAST_EXIT (expected non-zero)"
+fi
+
+# ── Test 6: codex 401 → no fallback, non-zero ────────────────────────────────
+run_wrapper --codex-stub "$STUB_CODEX_401" --gemini-stub "$STUB_GEMINI_SUCCESS" -- review myfile.R
+if [ "$_LAST_EXIT" -ne 0 ]; then
+  pass "6: codex 401 exits non-zero"
+else
+  fail "6: codex 401 exits non-zero" "exit was $_LAST_EXIT"
+fi
+
+if printf '%s' "$_LAST_STDERR" | grep -qi "auth"; then
+  pass "7: codex 401 stderr mentions auth"
+else
+  fail "7: codex 401 stderr mentions auth" "stderr was: $_LAST_STDERR"
+fi
+
+# Gemini stdout should NOT appear (no fallback for auth errors)
+if printf '%s' "$_LAST_STDOUT" | grep -q "fake gemini"; then
+  fail "8: codex 401 does not fall back to gemini" "gemini stdout appeared"
+else
+  pass "8: codex 401 does not fall back to gemini"
+fi
+
+# ── Test 9: codex other error → no fallback, non-zero ────────────────────────
+run_wrapper --codex-stub "$STUB_CODEX_OTHER" --gemini-stub "$STUB_GEMINI_SUCCESS" -- review myfile.R
+if [ "$_LAST_EXIT" -ne 0 ]; then
+  pass "9: codex other error exits non-zero"
+else
+  fail "9: codex other error exits non-zero" "exit was $_LAST_EXIT"
+fi
+
+# ── Test 10: JSONL record emitted for every case ─────────────────────────────
+# Check success case
+run_wrapper --codex-stub "$STUB_CODEX_SUCCESS" -- review myfile.R
+jsonl=$(last_jsonl)
+if printf '%s' "$jsonl" | grep -q '"primary_provider"'; then
+  pass "10: JSONL record emitted for success case"
+else
+  fail "10: JSONL record emitted for success case" "jsonl was: $jsonl"
+fi
+
+# Check 429 case
+run_wrapper --codex-stub "$STUB_CODEX_429" --gemini-stub "$STUB_GEMINI_SUCCESS" -- review myfile.R
+jsonl=$(last_jsonl)
+if printf '%s' "$jsonl" | grep -q '"primary_provider"'; then
+  pass "11: JSONL record emitted for 429+fallback case"
+else
+  fail "11: JSONL record emitted for 429+fallback case" "jsonl was: $jsonl"
+fi
+
+# ── Test 12: fallback_used=false in JSONL for success case ───────────────────
+run_wrapper --codex-stub "$STUB_CODEX_SUCCESS" -- review myfile.R
+jsonl=$(last_jsonl)
+if printf '%s' "$jsonl" | grep -q '"fallback_used":false'; then
+  pass "12: fallback_used=false in JSONL for success"
+else
+  fail "12: fallback_used=false in JSONL for success" "jsonl: $jsonl"
+fi
+
+# ── Test 13: fallback_used=true in JSONL for 429+gemini-success case ─────────
+run_wrapper --codex-stub "$STUB_CODEX_429" --gemini-stub "$STUB_GEMINI_SUCCESS" -- review myfile.R
+jsonl=$(last_jsonl)
+if printf '%s' "$jsonl" | grep -q '"fallback_used":true'; then
+  pass "13: fallback_used=true in JSONL for 429+fallback"
+else
+  fail "13: fallback_used=true in JSONL for 429+fallback" "jsonl: $jsonl"
+fi
+
+# ── Test 14: gemini absent → clear error, no crash, non-zero exit ────────────
+# (no --gemini-stub = gemini not on PATH)
+run_wrapper --codex-stub "$STUB_CODEX_429" -- review myfile.R
+if [ "$_LAST_EXIT" -ne 0 ]; then
+  pass "14: 429+gemini absent exits non-zero"
+else
+  fail "14: 429+gemini absent exits non-zero" "exit was $_LAST_EXIT"
+fi
+
+if printf '%s' "$_LAST_STDERR" | grep -qiE "not found|gemini"; then
+  pass "15: 429+gemini absent: clear error message"
+else
+  fail "15: 429+gemini absent: clear error message" "stderr: $_LAST_STDERR"
+fi
+
+# ── Test 16: codex absent → clear error, exit 127 ────────────────────────────
+# (no --codex-stub = codex not on PATH)
+run_wrapper -- review myfile.R
+if [ "$_LAST_EXIT" -eq 127 ]; then
+  pass "16: codex absent exits 127"
+else
+  fail "16: codex absent exits 127" "exit was $_LAST_EXIT"
+fi
+
+# ── Test 17: secret args redacted in JSONL ───────────────────────────────────
+run_wrapper --codex-stub "$STUB_CODEX_SUCCESS" -- review --api-key SECRET_VALUE myfile.R
+jsonl=$(last_jsonl)
+if printf '%s' "$jsonl" | grep -q "SECRET_VALUE"; then
+  fail "17: secret arg not redacted in JSONL" "SECRET_VALUE appears in jsonl: $jsonl"
+else
+  pass "17: secret arg redacted in JSONL"
+fi
+
+# ── Test 18: duration_sec present and looks numeric ──────────────────────────
+run_wrapper --codex-stub "$STUB_CODEX_SUCCESS" -- review myfile.R
+jsonl=$(last_jsonl)
+if printf '%s' "$jsonl" | grep -qE '"duration_sec":[0-9]+'; then
+  pass "18: duration_sec present and numeric in JSONL"
+else
+  fail "18: duration_sec present and numeric in JSONL" "jsonl: $jsonl"
+fi
+
+# ── Test 19: JSONL append-only (two runs → two lines) ────────────────────────
+# Use a single, shared log dir for this test; stub codex success twice
+shared_bindir=$(mktemp -d "${TMPROOT}/bin_shared_XXXXXX")
+shared_logdir="${TMPROOT}/shared_logs"
+mkdir -p "$shared_logdir"
+cp "$STUB_CODEX_SUCCESS" "${shared_bindir}/codex"
+chmod +x "${shared_bindir}/codex"
+
+(
+  export PATH="${shared_bindir}:/usr/bin:/bin"
+  export FALLBACK_LOG_DIR="$shared_logdir"
+  unset CODEX_BIN GEMINI_BIN
+  "$WRAPPER" review myfile.R >/dev/null 2>&1 || true
+  "$WRAPPER" review myfile.R >/dev/null 2>&1 || true
+) || true
+
+date_part=$(date -u +%Y-%m-%d)
+shared_logfile="${shared_logdir}/${date_part}.jsonl"
+if [ -f "$shared_logfile" ]; then
+  line_count=$(wc -l < "$shared_logfile" | tr -d ' ')
+  if [ "$line_count" -ge 2 ]; then
+    pass "19: JSONL append-only: two runs produce two lines"
+  else
+    fail "19: JSONL append-only" "expected ≥2 lines, got $line_count"
+  fi
+else
+  fail "19: JSONL append-only" "log file not created"
+fi
+
+# ── Test 20: final_provider=codex in success JSONL ───────────────────────────
+run_wrapper --codex-stub "$STUB_CODEX_SUCCESS" -- review myfile.R
+jsonl=$(last_jsonl)
+if printf '%s' "$jsonl" | grep -q '"final_provider":"codex"'; then
+  pass "20: final_provider=codex in success JSONL"
+else
+  fail "20: final_provider=codex in success JSONL" "jsonl: $jsonl"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `.claude/scripts/codex_with_fallback.sh`: a shell wrapper around the codex CLI that auto-falls back to gemini on HTTP 429 (rate-limit) errors, and emits structured JSON telemetry for each invocation.
- Adds `tests/codex_fallback/test_codex_fallback.sh`: 20-test suite using stub binaries covering all specified cases.
- Does NOT wire the wrapper into any live roborev path (Phase 2 follow-up).

## Design choice: shell script (not Python)

Both `codex` (`/usr/local/bin/codex`) and `gemini` (`/usr/local/bin/gemini`) are
already bash wrappers over `npx @openai/codex` and `npx @google/gemini-cli`
respectively. The roborev binary invokes them as subprocess commands. A shell
wrapper is the natural interception point: it receives the same args, captures
stdout/stderr/exit code, classifies the error, and either relays the result or
retries with gemini.

## File inventory found

| File | Relevance |
|---|---|
| `/usr/local/bin/codex` | `#!/bin/bash; exec npx -y @openai/codex "$@"` |
| `/usr/local/bin/gemini` | `#!/bin/bash; exec npx -y @google/gemini-cli "$@"` |
| `.claude/scripts/session_end_refine.sh:134` | Calls `roborev --agent codex` |
| `.claude/scripts/roborev_agent_health.sh` | Existing bulk-throttle logic (config-file swap, not per-invocation) |
| No existing 429/per-invocation retry logic found | — |

## Wrapper behaviour

- `success` → relay stdout, exit 0, emit JSONL
- `rate_limit_429` → retry once with gemini; on gemini success: relay gemini stdout, exit 0; on gemini fail: exit gemini's code
- `auth_failed` → fail immediately (no silent fallback), emit JSONL
- `provider_error` / `other` → fail immediately, emit JSONL
- gemini absent from PATH → clear error + install hint, no crash, exit non-zero

## Telemetry

One JSON line per invocation at `~/.claude/logs/codex_fallback/YYYY-MM-DD.jsonl`:

```json
{"ts":"2026-05-30T18:00:00Z","invocation_id":"...","primary_provider":"codex",
 "primary_exit":1,"primary_classification":"rate_limit_429","fallback_used":true,
 "fallback_provider":"gemini","fallback_exit":0,"final_provider":"gemini",
 "duration_sec":4,"args_redacted":["review","<file>"]}
```

## Test results (20/20 passing)

```
PASS: 1: codex success exits 0
PASS: 2: codex success stdout relayed
PASS: 3: 429+gemini success exits 0
PASS: 4: 429+gemini success stdout from gemini
PASS: 5: 429+gemini fail exits non-zero
PASS: 6: codex 401 exits non-zero
PASS: 7: codex 401 stderr mentions auth
PASS: 8: codex 401 does not fall back to gemini
PASS: 9: codex other error exits non-zero
PASS: 10: JSONL record emitted for success case
PASS: 11: JSONL record emitted for 429+fallback case
PASS: 12: fallback_used=false in JSONL for success
PASS: 13: fallback_used=true in JSONL for 429+fallback
PASS: 14: 429+gemini absent exits non-zero
PASS: 15: 429+gemini absent: clear error message
PASS: 16: codex absent exits 127
PASS: 17: secret arg redacted in JSONL
PASS: 18: duration_sec present and numeric in JSONL
PASS: 19: JSONL append-only: two runs produce two lines
PASS: 20: final_provider=codex in success JSONL

Results: 20 passed, 0 failed
```

## Follow-up

File an issue to swap `codex` → `codex_with_fallback` in `session_end_refine.sh`
and any equivalent roborev invocation sites, once Phase 2 telemetry consumes
the JSON records.

Note: gemini-cli install hint for users who need it: `npm install -g @google/gemini-cli`

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
