### PR TITLE
fix(#368): install send_roborev_email.R under inst/scripts/ + fail-loud test

### DIFF
--- a/inst/scripts/send_roborev_email.R
+++ b/inst/scripts/send_roborev_email.R
@@ -1,0 +1,1 @@
+../../.claude/scripts/send_roborev_email.R

--- a/tests/testthat/test-roborev-daily-email.R
+++ b/tests/testthat/test-roborev-daily-email.R
@@ -78,12 +78,12 @@ run_email_dry_run <- function(fixture, extra_env = character(0)) {
     json_path
   )
 
+  # Primary: installed package path (CI). Fallback: dev-time source tree.
   email_script <- system.file(
-    ".claude/scripts/send_roborev_email.R",
+    "scripts/send_roborev_email.R",
     package = "llm",
     mustWork = FALSE
   )
-  # Fallback: resolve from tests/ location
   if (!nzchar(email_script) || !file.exists(email_script)) {
     email_script <- normalizePath(
       file.path(dirname(dirname(testthat::test_path())),
@@ -91,7 +91,10 @@ run_email_dry_run <- function(fixture, extra_env = character(0)) {
       mustWork = FALSE
     )
   }
-  skip_if_not(file.exists(email_script), "send_roborev_email.R not found")
+  expect_true(
+    nzchar(email_script) && file.exists(email_script),
+    info = "send_roborev_email.R must be present (via system.file or dev-time fallback)"
+  )
 
   env_vars <- c(
     "EMAIL_DRY_RUN=1",
@@ -175,12 +178,23 @@ test_that("dry-run output contains outlier review IDs", {
 test_that("script exits non-zero when no JSON found in empty dir", {
   skip_if_not_installed("blastula")
 
-  email_script <- normalizePath(
-    file.path(dirname(dirname(testthat::test_path())),
-              ".claude", "scripts", "send_roborev_email.R"),
+  # Primary: installed package path (CI). Fallback: dev-time source tree.
+  email_script <- system.file(
+    "scripts/send_roborev_email.R",
+    package = "llm",
     mustWork = FALSE
   )
-  skip_if_not(file.exists(email_script), "send_roborev_email.R not found")
+  if (!nzchar(email_script) || !file.exists(email_script)) {
+    email_script <- normalizePath(
+      file.path(dirname(dirname(testthat::test_path())),
+                ".claude", "scripts", "send_roborev_email.R"),
+      mustWork = FALSE
+    )
+  }
+  expect_true(
+    nzchar(email_script) && file.exists(email_script),
+    info = "send_roborev_email.R must be present (via system.file or dev-time fallback)"
+  )
 
   empty_dir <- tempfile("roborev_empty_")
   dir.create(empty_dir)


### PR DESCRIPTION
## Summary

- **Option A (symlink):** Added `inst/scripts/send_roborev_email.R` as a relative symlink to `../../.claude/scripts/send_roborev_email.R`. After `R CMD INSTALL`, `system.file("scripts/send_roborev_email.R", package = "llm")` now resolves to the installed copy. Git tracks symlinks natively; `R CMD INSTALL` follows them.

- **Option B (fail-loud test):** Replaced both `skip_if_not(file.exists(email_script), ...)` call sites with `expect_true(nzchar(email_script) && file.exists(email_script), ...)`. The primary lookup uses `system.file("scripts/send_roborev_email.R", package = "llm")` (resolves in CI after install); the dev-time fallback via `testthat::test_path()` still works for `devtools::test()` before install.

## Test results

- `R CMD INSTALL --library=/tmp/llm_test_lib .` — DONE (no errors)
- `system.file("scripts/send_roborev_email.R", package = "llm")` resolves to `/tmp/llm_test_lib/llm/scripts/send_roborev_email.R` ✓
- `testthat::test_file("tests/testthat/test-roborev-daily-email.R")`: `[ FAIL 0 | WARN 0 | SKIP 10 | PASS 0 ]`
  - All 10 skips are `skip_if_not_installed("blastula")` or missing bash scripts — the `send_roborev_email.R not found` skip no longer appears.
  - No R CMD INSTALL failures from this change.

## Test plan

- [ ] Confirm `system.file("scripts/send_roborev_email.R", package = "llm")` returns non-empty string after install in CI
- [ ] Confirm no new SKIP for "send_roborev_email.R not found" in CI test run
- [ ] Confirm FAIL 0 in CI test run for this file

Closes #368
