### PR TITLE
fix(#369): vignette uses library(llm) instead of source(here::here(...)) [supersedes #371]

### DIFF
--- a/vignettes/hover-popup-demo.qmd
+++ b/vignettes/hover-popup-demo.qmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
   warning   = FALSE,
   results   = "asis"
 )
-source(here::here("R", "hover_popup_helper.R"))
+library(llm)
 ```
 
 This vignette demonstrates the hover-popup standard introduced in
@@ -85,10 +85,10 @@ Include the shared partial at the top of every vignette that uses `tt()`:
 {{< include /_includes/hover-popups.qmd >}}
 ````
 
-In a knitr chunk with `results = "asis"`, source the helper and call `tt()`:
+In a knitr chunk with `results = "asis"`, load the package and call `tt()`:
 
 ```r
-source(here::here("R", "hover_popup_helper.R"))
+library(llm)
 cat(tt(
   "LLM",
   paste0(
@@ -116,7 +116,7 @@ introduced in Issue #246.
 
 ### Data sources
 
-- `R/hover_popup_helper.R`: the `tt()` function sourced directly at render time.
+- `llm::tt()`: the hover-popup helper exported from the `llm` package; loaded via `library(llm)` at render time.
 - `_includes/hover-popups.qmd`: the shared Tippy.js CSS + JS partial, included
   via Quarto's `{{< include >}}` directive.
 


### PR DESCRIPTION
Closes #369. Refs #363 (Stage 2 audit).

## What this PR does

Replaces `source(here::here("R", "hover_popup_helper.R"))` in `vignettes/hover-popup-demo.qmd` with `library(llm)` — `tt()` is already exported (`grep export\(tt\) NAMESPACE`). Three line-edits in the same file:

- Line 27 (executed setup chunk) — the actual fix.
- Line ~88-91 (documentation code-fence) — updated example to model the correct pattern.
- Line ~119 (Methodology / Data sources) — updated prose to say `llm::tt()` is loaded via `library(llm)`.

## Provenance — this PR supersedes #371

PR #371 was opened by the original #369 fixer but stayed on the harness branch (`worktree-agent-a2eab8e4e3b20d698`) which was forked off the orchestrator's session branch. The session branch had diverged from main (2 commits ahead, 5 behind), so PR #371 ballooned to 219 changed files / +24,615/-648 — drowning the actual 1-file vignette fix in unrelated session-branch divergence.

This PR cherry-picks the agent's commit `9982fd9` onto a fresh branch off `origin/main`. The diff is now the intended 1 file / +4/-4.

PR #371 will be closed as superseded.

## Verification (carried over from the original agent's run)

- `quarto render vignettes/hover-popup-demo.qmd --to html`: **PASS** (exit 0, 7 chunks, no warnings)
- `grep -c 'data-tippy-content' <rendered-html>`: **6** (all `tt()` calls rendered correctly)
- `library(llm); is.function(tt)`: **TRUE**
- `git grep -nE 'source\(here::here' -- 'vignettes/*.qmd'`: only this one file, no other vignettes affected.
