### PR TITLE
fix(#381): background telemetry export in session_stop.sh

### DIFF
--- a/.claude/hooks/session_stop.sh
+++ b/.claude/hooks/session_stop.sh
@@ -107,10 +107,16 @@ if [ -f "$_bd_db" ]; then
 fi
 
 # ── Telemetry data export + deploy (Calibration + Sessions tabs) ────
-# Auto-runs export_and_deploy_data.sh (was orphaned — header claimed it ran here).
+# Background the export so /bye returns instantly. Output to dated log
+# for post-hoc inspection. See llm#381.
 EXPORT_SCRIPT="$CLAUDE_DIR/scripts/export_and_deploy_data.sh"
+EXPORT_LOG_DIR="$CLAUDE_DIR/logs"
+EXPORT_LOG="$EXPORT_LOG_DIR/export_and_deploy.$(date +%Y%m%d).log"
 if [ -x "$EXPORT_SCRIPT" ]; then
-  timeout 180 "$EXPORT_SCRIPT" 2>&1 | tail -3 || true
+  mkdir -p "$EXPORT_LOG_DIR"
+  nohup timeout 180 "$EXPORT_SCRIPT" > "$EXPORT_LOG" 2>&1 &
+  disown
+  echo "TELEMETRY: export backgrounded (log: $EXPORT_LOG)"
 fi
 
 # --- Prediction calibration: remind about unresolved predictions ---


### PR DESCRIPTION
## Summary

- Telemetry export in `session_stop.sh` previously ran synchronously, blocking `/bye` for up to 180 s on slow networks or large payloads.
- Now runs via `nohup … &` + `disown` so `/bye` returns immediately.
- Export output is captured in `$CLAUDE_DIR/logs/export_and_deploy.YYYYMMDD.log` for post-hoc inspection.

## Changes

- `.claude/hooks/session_stop.sh` lines 109-114 only — no other files touched.
- `bash -n` syntax check passes.

## Test plan

- [ ] Syntax: `bash -n .claude/hooks/session_stop.sh` exits 0 (verified in worktree).
- [ ] Diff is limited to the telemetry block (verified via `git diff`).
- [ ] Manual: trigger a session stop and confirm `/bye` returns before the export script finishes; check the dated log file appears in `~/.claude/logs/`.
- [ ] The export script itself (`export_and_deploy_data.sh`) is NOT modified.

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
