### PR TITLE
feat(#379): roborev DB review → fix-commit link enrichment

### DIFF
--- a/.claude/scripts/roborev_metrics_etl.R
+++ b/.claude/scripts/roborev_metrics_etl.R
@@ -506,6 +506,9 @@ build_review_lifecycle <- function(jobs, reviews, markers) {
     closed_at                    = as.POSIXct(character()),
     close_reason                 = character(),
     autoclose_threshold_at_close = character(),
+    fix_commit_sha               = character(),
+    fix_commit_at                = as.POSIXct(character()),
+    fix_method                   = character(),
     stringsAsFactors             = FALSE
   )
 
@@ -602,6 +605,9 @@ build_review_lifecycle <- function(jobs, reviews, markers) {
     closed_at                    = closed_at,
     close_reason                 = close_reason,
     autoclose_threshold_at_close = NA_character_,   # Slice 2
+    fix_commit_sha               = NA_character_,   # Slice 3 (#379): populated by enrich_fix_commit_links()
+    fix_commit_at                = as.POSIXct(NA_real_, origin = "1970-01-01"),   # Slice 3 (#379)
+    fix_method                   = NA_character_,   # Slice 3 (#379)
     stringsAsFactors             = FALSE
   )
 }
@@ -1445,10 +1451,317 @@ coalesce_int <- function(x, default = 0L) {
   x
 }
 
+# ── find_fix_commit_for_review (#379) ─────────────────────────────────────
+#
+# Heuristic chain to link a closed review to the commit that fixed it.
+#
+# Returns a named list with:
+#   fix_commit_sha : character(1) or NA
+#   fix_commit_at  : POSIXct(1) or NA
+#   fix_method     : one of "commit_reference" / "pr_close" / "manual" /
+#                    "autoclose_severity" / "unknown"
+#
+# Priority order:
+#   1. explicit commit reference in git log grep
+#   2. PR close via gh (skipped if gh unavailable — network call)
+#   3. time-proximity (commit within 6h before closure)
+#   4. autoclose (close_reason indicates automated close, no human fix commit)
+#   5. fallthrough: unknown
+#
+# Args:
+#   review_id    integer(1)  — reviews.id
+#   repo_path    character(1) — local filesystem path for git log (may not exist)
+#   closed_at    POSIXct(1)  — parsed closure timestamp
+#   close_reason character(1) — from derive_close_reason()
+#   closer_actor character(1) — git author name (best-effort; NA if unknown)
+#
+# All git calls are wrapped in tryCatch — a git failure never aborts the ETL.
+
+find_fix_commit_for_review <- function(review_id, repo_path, closed_at,
+                                        close_reason, closer_actor = NA_character_) {
+  empty_result <- list(
+    fix_commit_sha = NA_character_,
+    fix_commit_at  = as.POSIXct(NA_real_, origin = "1970-01-01"),
+    fix_method     = "unknown"
+  )
+
+  # Heuristic 4 first (cheap — no git needed): autoclose patterns do not
+  # correspond to a human fix commit.
+  if (!is.na(close_reason)) {
+    if (grepl("^(clean-verdict|severity-|autoclose)", close_reason, perl = TRUE)) {
+      return(list(
+        fix_commit_sha = NA_character_,
+        fix_commit_at  = as.POSIXct(NA_real_, origin = "1970-01-01"),
+        fix_method     = "autoclose_severity"
+      ))
+    }
+  }
+
+  # Require a valid repo path and closed_at timestamp for git-based heuristics
+  if (is.na(closed_at) || !is.character(repo_path) || !nzchar(repo_path) ||
+      !file.exists(repo_path)) {
+    return(empty_result)
+  }
+
+  # Format timestamps for git --since / --until
+  fmt_git <- function(ts) format(ts, "%Y-%m-%dT%H:%M:%S", tz = "UTC")
+  since_1d <- fmt_git(closed_at - 86400L)   # 1 day before closure
+  until_1d <- fmt_git(closed_at + 86400L)   # 1 day after closure
+  since_6h <- fmt_git(closed_at - 21600L)   # 6h before closure
+
+  # ── Heuristic 1: explicit commit reference ──────────────────────────────
+  # grep pattern: "roborev" followed by optional chars then the review_id.
+  # Use ERE (--extended-regexp) so {0,8} works.
+  # system2() on macOS passes args through /bin/sh which interprets unquoted
+  # parentheses as subshell syntax. Use system() with shQuote() on the grep
+  # value so the pattern is single-quoted when the shell sees it.
+  grep_pattern <- sprintf("roborev.{0,8}#?%d[^0-9]", review_id)
+
+  ref_sha <- tryCatch({
+    cmd <- paste(
+      "git", "-C", shQuote(repo_path),
+      "log",
+      "--extended-regexp",
+      "--regexp-ignore-case",
+      paste0("--since=", shQuote(since_1d)),
+      paste0("--until=", shQuote(until_1d)),
+      paste0("--grep=", shQuote(grep_pattern)),
+      "--format=%H#%ai",     # %ai = "2026-05-30 22:35:36 +0100"
+      "--no-merges",
+      "2>/dev/null"
+    )
+    raw <- system(cmd, intern = TRUE)
+    if (length(raw) > 0L && nzchar(raw[[1L]])) raw[[1L]] else NA_character_
+  }, error = function(e) NA_character_,
+     warning = function(w) NA_character_)
+
+  if (!is.na(ref_sha) && grepl("^[0-9a-f]{7}", ref_sha, perl = TRUE) && grepl("#", ref_sha, fixed = TRUE)) {
+    parts   <- strsplit(ref_sha, "#")[[1L]]
+    sha     <- parts[[1L]]
+    ts_raw  <- if (length(parts) >= 2L) parts[[2L]] else NA_character_
+    # %ai format: "2026-05-30 22:35:36 +0100" — parse with tz offset
+    fix_at  <- tryCatch(
+      as.POSIXct(trimws(ts_raw), tz = "UTC", format = "%Y-%m-%d %H:%M:%S %z"),
+      error = function(e) as.POSIXct(NA_real_, origin = "1970-01-01")
+    )
+    return(list(
+      fix_commit_sha = sha,
+      fix_commit_at  = fix_at,
+      fix_method     = "commit_reference"
+    ))
+  }
+
+  # ── Heuristic 2: PR close via gh CLI ───────────────────────────────────
+  # Only attempt if gh is available; skip silently otherwise.
+  gh_available <- tryCatch(
+    { system("gh --version > /dev/null 2>&1"); TRUE },
+    error   = function(e) FALSE,
+    warning = function(w) FALSE
+  )
+
+  if (isTRUE(gh_available)) {
+    # Derive github repo slug from root_path by checking remote URL
+    remote_slug <- tryCatch({
+      cmd_remote <- paste("git -C", shQuote(repo_path), "remote get-url origin 2>/dev/null")
+      url_raw <- system(cmd_remote, intern = TRUE)
+      if (length(url_raw) < 1L) NA_character_
+      else {
+        url <- trimws(url_raw[[1L]])
+        # Parse "git@github.com:Org/Repo.git" or "https://github.com/Org/Repo.git"
+        m <- regmatches(url, regexec("github\\.com[:/]([^/]+/[^/\\.]+)", url))[[1L]]
+        if (length(m) >= 2L) m[[2L]] else NA_character_
+      }
+    }, error = function(e) NA_character_)
+
+    if (!is.na(remote_slug)) {
+      pr_sha <- tryCatch({
+        # Search for closed PRs whose body/title mentions the review ID
+        search_q <- sprintf(
+          "roborev %d repo:%s merged:%s..%s",
+          review_id, remote_slug,
+          format(closed_at - 86400L, "%Y-%m-%d", tz = "UTC"),
+          format(closed_at + 86400L, "%Y-%m-%d", tz = "UTC")
+        )
+        cmd_gh <- paste(
+          "gh pr list",
+          "--repo", shQuote(remote_slug),
+          "--search", shQuote(search_q),
+          "--state closed",
+          "--json mergeCommit,mergedAt",
+          "--limit 1",
+          "2>/dev/null"
+        )
+        raw_pr <- system(cmd_gh, intern = TRUE)
+        if (length(raw_pr) == 0L) {
+          NA_character_
+        } else {
+          pr_json <- paste(raw_pr, collapse = "\n")
+          parsed  <- tryCatch(
+            jsonlite::fromJSON(pr_json, simplifyVector = TRUE),
+            error = function(e) list()
+          )
+          if (is.data.frame(parsed) && nrow(parsed) > 0L) {
+            mc <- parsed$mergeCommit[[1L]]
+            if (!is.null(mc) && !is.null(mc$oid)) mc$oid else NA_character_
+          } else {
+            NA_character_
+          }
+        }
+      }, error = function(e) NA_character_,
+         warning = function(w) NA_character_)
+
+      if (!is.na(pr_sha) && nzchar(pr_sha)) {
+        return(list(
+          fix_commit_sha = pr_sha,
+          fix_commit_at  = as.POSIXct(NA_real_, origin = "1970-01-01"),
+          fix_method     = "pr_close"
+        ))
+      }
+    }
+  }
+
+  # ── Heuristic 3: time-proximity (low confidence) ────────────────────────
+  # git log within 6h before closure; prefer commits by closer_actor if known.
+  # Use %x01 (SOH) as field separator to avoid shell or author-name conflicts.
+  # Use system() with shQuote() for all path arguments (same reason as H1).
+  proximity_lines <- tryCatch({
+    cmd <- paste(
+      "git", "-C", shQuote(repo_path),
+      "log",
+      paste0("--since=", shQuote(since_6h)),
+      paste0("--until=", shQuote(fmt_git(closed_at))),
+      "--format=%H%x01%ai%x01%an",
+      "--no-merges",
+      "--max-count=20",
+      "2>/dev/null"
+    )
+    raw <- system(cmd, intern = TRUE)
+    if (length(raw) > 0L) raw else character(0L)
+  }, error = function(e) character(0L),
+     warning = function(w) character(0L))
+
+  if (length(proximity_lines) > 0L) {
+    # Parse SOH-delimited fields: SHA, date, author
+    parts_list <- strsplit(proximity_lines, "\x01", fixed = TRUE)
+    shas    <- vapply(parts_list, function(p) if (length(p) >= 1L) p[[1L]] else NA_character_, character(1L))
+    ts_raws <- vapply(parts_list, function(p) if (length(p) >= 2L) p[[2L]] else NA_character_, character(1L))
+    authors <- vapply(parts_list, function(p) if (length(p) >= 3L) p[[3L]] else NA_character_, character(1L))
+
+    # Filter to valid SHA entries
+    valid <- nzchar(shas) & grepl("^[0-9a-f]{40}$", shas, perl = TRUE)
+    shas    <- shas[valid]
+    ts_raws <- ts_raws[valid]
+    authors <- authors[valid]
+
+    if (length(shas) > 0L) {
+      # Prefer by closer_actor if available
+      chosen_idx <- if (!is.na(closer_actor) && nzchar(closer_actor)) {
+        actor_match <- which(authors == closer_actor)
+        if (length(actor_match) > 0L) actor_match[[1L]] else length(shas)
+      } else {
+        length(shas)  # most recent commit (last in reverse-chron order → end of vector)
+      }
+
+      fix_at <- tryCatch(
+        as.POSIXct(trimws(ts_raws[[chosen_idx]]), tz = "UTC", format = "%Y-%m-%d %H:%M:%S %z"),
+        error = function(e) as.POSIXct(NA_real_, origin = "1970-01-01")
+      )
+
+      return(list(
+        fix_commit_sha = shas[[chosen_idx]],
+        fix_commit_at  = fix_at,
+        fix_method     = "manual"
+      ))
+    }
+  }
+
+  empty_result
+}
+
+# ── Enrich lifecycle data frame with fix-commit links ────────────────────
+#
+# Applies find_fix_commit_for_review() row-by-row to closed reviews where
+# fix_commit_sha IS NULL.  Uses repo root_path from a repos lookup tibble.
+#
+# Args:
+#   lifecycle_df   data.frame from build_review_lifecycle()
+#   read_con       DuckDB connection with 'src' sqlite attachment
+#
+# Returns lifecycle_df with fix_commit_sha, fix_commit_at, fix_method columns
+# populated (where determinable) for newly-closed rows.
+
+enrich_fix_commit_links <- function(lifecycle_df, read_con) {
+  if (nrow(lifecycle_df) == 0L) return(lifecycle_df)
+
+  # Ensure fix-link columns exist (may be missing on first call)
+  if (!"fix_commit_sha" %in% names(lifecycle_df)) {
+    lifecycle_df$fix_commit_sha <- NA_character_
+    lifecycle_df$fix_commit_at  <- as.POSIXct(NA_real_, origin = "1970-01-01")
+    lifecycle_df$fix_method     <- NA_character_
+  }
+
+  # Load repo name → root_path mapping from SQLite
+  repos_map <- tryCatch(
+    dbGetQuery(read_con, "SELECT name, root_path FROM src.repos"),
+    error = function(e) {
+      log_msg("WARN: could not load repos for fix-link enrichment: ", conditionMessage(e))
+      data.frame(name = character(), root_path = character(), stringsAsFactors = FALSE)
+    }
+  )
+
+  # Rows needing enrichment: closed=1 and fix_commit_sha IS NA
+  # (In an upsert scenario, already-linked rows keep their fix_commit_sha.)
+  closed_rows  <- !is.na(lifecycle_df$closed_at)
+  needs_enrich <- closed_rows & is.na(lifecycle_df$fix_commit_sha)
+
+  if (!any(needs_enrich)) {
+    cat("roborev_metrics_etl.R: fix-link enrichment — all closed rows already linked, skipping\n")
+    return(lifecycle_df)
+  }
+
+  to_enrich <- which(needs_enrich)
+  cat(sprintf("roborev_metrics_etl.R: fix-link enrichment — processing %d closed reviews\n",
+              length(to_enrich)))
+
+  for (idx in to_enrich) {
+    row        <- lifecycle_df[idx, ]
+    repo_name  <- row$repo
+    root_path  <- repos_map$root_path[repos_map$name == repo_name]
+    root_path  <- if (length(root_path) > 0L && !is.na(root_path[[1L]])) root_path[[1L]] else NA_character_
+
+    result <- find_fix_commit_for_review(
+      review_id    = row$review_id,
+      repo_path    = root_path,
+      closed_at    = row$closed_at,
+      close_reason = row$close_reason,
+      closer_actor = NA_character_   # not stored in current reviews.db
+    )
+
+    lifecycle_df$fix_commit_sha[[idx]] <- result$fix_commit_sha
+    lifecycle_df$fix_commit_at[[idx]]  <- result$fix_commit_at
+    lifecycle_df$fix_method[[idx]]     <- result$fix_method
+  }
+
+  # Summary of fix_method distribution
+  method_tbl <- table(lifecycle_df$fix_method[!is.na(lifecycle_df$fix_method)])
+  cat("roborev_metrics_etl.R: fix-link enrichment complete — method distribution:\n")
+  for (nm in names(method_tbl)) {
+    cat(sprintf("  %s: %d\n", nm, method_tbl[[nm]]))
+  }
+
+  lifecycle_df
+}
+
 # ── Build tables ───────────────────────────────────────────────────────────
 
 daily_df     <- build_daily_metrics(jobs_raw, reviews_raw)
 lifecycle_df <- build_review_lifecycle(jobs_raw, reviews_raw, markers_raw)
+
+# Enrich lifecycle with fix-commit links (#379).
+# Uses git log heuristics on the local repo checkouts — graceful fallback if
+# repo path is absent or git is unavailable.  Only processes rows where
+# fix_commit_sha IS NA (batch guard prevents redundant re-scanning).
+lifecycle_df <- enrich_fix_commit_links(lifecycle_df, read_con)
 
 cat(sprintf("roborev_metrics_etl.R: built %d daily_metrics rows, %d lifecycle rows\n",
             nrow(daily_df), nrow(lifecycle_df)))
@@ -1487,6 +1800,16 @@ if (mode == "dry-run") {
   cat(sprintf("  roborev_daily_metrics:        %d rows (since %s)\n",
               nrow(daily_df), format(since, "%Y-%m-%d")))
   cat(sprintf("  roborev_review_lifecycle:     %d rows\n", nrow(lifecycle_df)))
+
+  # Fix-link column summary (#379)
+  if (nrow(lifecycle_df) > 0L && "fix_method" %in% names(lifecycle_df)) {
+    fix_tbl <- table(lifecycle_df$fix_method[!is.na(lifecycle_df$fix_method)])
+    cat("  fix-commit link distribution:\n")
+    for (nm in names(fix_tbl)) cat(sprintf("    %s: %d\n", nm, fix_tbl[[nm]]))
+    n_unlinked <- sum(is.na(lifecycle_df$fix_method) & !is.na(lifecycle_df$closed_at))
+    cat(sprintf("    (unclassified closed): %d\n", n_unlinked))
+  }
+
   cat(sprintf("  roborev_agent_performance:    %d rows\n", nrow(agent_perf_df)))
   cat(sprintf("  roborev_threshold_changes:    %d rows\n", nrow(threshold_df)))
   cat(sprintf("  roborev_cadence_efficacy:     %d rows\n", nrow(cadence_df)))

--- a/.claude/scripts/roborev_metrics_schema.sql
+++ b/.claude/scripts/roborev_metrics_schema.sql
@@ -32,6 +32,12 @@ CREATE TABLE IF NOT EXISTS roborev_daily_metrics (
 -- ── roborev_review_lifecycle ──────────────────────────────────────────────
 -- Per-review timeline. One row per review (keyed on review_id from reviews.id).
 -- PK: review_id
+-- ADDITIVE columns (llm#379, 2026-05-31) — safe; downstream uses SELECT by name:
+--   fix_commit_sha, fix_commit_at, fix_method
+-- fix_method vocabulary: manual | commit_reference | pr_close |
+--   autoclose_severity | unknown
+-- Unblocks llmtelemetry #146 Q4 (time-to-fix), Q9 (false-positive rate),
+-- Q14 (closing-the-loop funnel).
 CREATE TABLE IF NOT EXISTS roborev_review_lifecycle (
   review_id                    BIGINT    NOT NULL,
   job_id                       BIGINT    NOT NULL,
@@ -49,6 +55,9 @@ CREATE TABLE IF NOT EXISTS roborev_review_lifecycle (
   closed_at                    TIMESTAMP,
   close_reason                 VARCHAR,
   autoclose_threshold_at_close VARCHAR,
+  fix_commit_sha               VARCHAR,
+  fix_commit_at                TIMESTAMP,
+  fix_method                   VARCHAR,
   PRIMARY KEY (review_id)
 );
 
@@ -173,3 +182,13 @@ SELECT
   )                                                 AS verdict_chain
 FROM roborev_finding_lineage fl
 GROUP BY fl.finding_id;
+
+-- ── Migration: add fix-commit link columns to existing lifecycle tables ────
+-- llm#379 — additive ALTER TABLE for databases created before 2026-05-31.
+-- DuckDB: ALTER TABLE ... ADD COLUMN IF NOT EXISTS is idempotent.
+ALTER TABLE IF EXISTS roborev_review_lifecycle
+  ADD COLUMN IF NOT EXISTS fix_commit_sha VARCHAR;
+ALTER TABLE IF EXISTS roborev_review_lifecycle
+  ADD COLUMN IF NOT EXISTS fix_commit_at TIMESTAMP;
+ALTER TABLE IF EXISTS roborev_review_lifecycle
+  ADD COLUMN IF NOT EXISTS fix_method VARCHAR;

--- a/plans/379-investigation.md
+++ b/plans/379-investigation.md
@@ -1,0 +1,129 @@
+# Issue #379 — Investigation: roborev DB review → fix-commit link
+
+**Date:** 2026-05-31
+**Investigator:** fixer agent (sonnet)
+
+---
+
+## Source database schema (reviews.db)
+
+Tables relevant to this issue:
+
+| Table | Key columns | Notes |
+|---|---|---|
+| `repos` | `id`, `name`, `root_path` | 40+ repos; `root_path` is the local git checkout path |
+| `review_jobs` | `id`, `repo_id`, `commit_id`, `git_ref`, `branch`, `status`, `enqueued_at` | `commit_id` FK → `commits.id` |
+| `reviews` | `id`, `job_id`, `closed`, `verdict_bool`, `output`, `updated_at` | one per job; closed=1 with updated_at = close timestamp |
+| `commits` | `id`, `repo_id`, `sha`, `author`, `subject`, `timestamp` | 2,581 rows; the commit SHA that triggered the review job |
+| `closures` | `id`, `finding_id`, `closure_commit_sha`, `closure_type`, `closure_reason`, `created_at` | **0 rows currently** — this table exists but is unpopulated |
+| `responses` | `id`, `job_id`, `response` | used for `auto-closed:` markers |
+
+### Key finding: closures table exists but is empty
+
+The `closures` table already has `closure_commit_sha` — but it has 0 rows.
+Nothing populates it in the current codebase. This is not the right source
+for fix-commit links; we must derive them via heuristics.
+
+### Reviews scale
+
+- Total reviews: 5,035
+- Closed reviews: 3,945 (78.3%)
+- The `reviews.updated_at` field holds the closure timestamp (when closed=1)
+
+### Repos have `root_path`
+
+`repos.root_path` gives the local filesystem path for `git log` queries.
+This is the key enabler for heuristic 1 (explicit reference) and 3 (time-proximity).
+
+---
+
+## Target DuckDB schema (unified.duckdb)
+
+`roborev_review_lifecycle` has 16 columns, PK = `review_id`. Currently:
+- `commit_sha` is always NULL (comment: "Slice 2: join via commits table")
+- `autoclose_threshold_at_close` is always NULL (comment: "Slice 2")
+- `close_reason` is populated (5-value vocabulary)
+
+The new columns `fix_commit_sha`, `fix_commit_at`, `fix_method` are NOT
+currently in this table. Decision needed: extend or separate table.
+
+---
+
+## Design decision: EXTEND roborev_review_lifecycle vs new table
+
+**Decision: extend `roborev_review_lifecycle` with 3 new columns.**
+
+Rationale:
+1. `roborev_review_lifecycle` is the canonical per-review record; fix-commit
+   link is 1:1 with review, not 1:N → no separate table needed
+2. llmtelemetry #146 Q4/Q9/Q14 reference `roborev_review_lifecycle` directly;
+   adding columns there avoids a JOIN in every downstream query
+3. Precedent: `commit_sha` and `autoclose_threshold_at_close` are already
+   deferred NULLs in the same table (Slice 2 placeholders)
+4. `roborev_review_lifecycle` PK = `review_id`; INSERT OR REPLACE handles
+   backfill cleanly when re-running ETL
+
+The schema note says "SCHEMAS FROZEN — llmtelemetry#144 depends on these
+column names". Adding NEW columns is additive and safe for DuckDB (the
+downstream consumer uses SELECT by name, not position). We document this
+in the schema file comment.
+
+---
+
+## Heuristic chain
+
+### Heuristic 1: explicit commit reference
+
+Scan `git log --grep 'roborev.*<id>'` within ±1 day of `closed_at` in the
+repo's `root_path`. This is the strongest signal and almost zero false-
+positive rate.
+
+**Limitation:** requires the repo path to exist on this machine.
+Check `file.exists(root_path)` before running; skip gracefully if absent.
+
+### Heuristic 2: PR close
+
+`gh pr list --search` for PRs closed near `closed_at` that mention the
+review ID. Expensive (network) and low yield given the local-only workflow.
+**Included for completeness but not run in batch** — only when heuristic 1
+misses and `fix_method` would otherwise be `unknown`. Rate-limited with
+`tryCatch`.
+
+### Heuristic 3: time-proximity
+
+`git log --since <closed_at - 6h> --until <closed_at>` in the same repo.
+Commits by the same `closer_actor` within 6 hours before closure are
+candidates. Mark as `fix_method = "manual"` (low confidence).
+
+**Limitation:** `closer_actor` is not reliably stored in reviews.db. We
+use `reviews.updated_by_machine_id` or fall back to any commit by any
+author in the window.
+
+### Heuristic 4: autoclose
+
+When `close_reason LIKE 'severity-%'` or `close_reason = 'clean-verdict'`:
+the review was closed automatically, not by a human fix. Set
+`fix_method = "autoclose_severity"`, `fix_commit_sha = NULL`.
+
+### Heuristic 5: fallthrough
+
+`fix_method = "unknown"`, NULLs elsewhere.
+
+---
+
+## Batch guard
+
+Process only reviews where `fix_commit_sha IS NULL AND closed = 1`.
+This prevents redundant git-log scanning on already-linked reviews.
+
+---
+
+## Test fixture approach
+
+Mirror `test-roborev-etl-lifecycle.R` pattern:
+- Source a line range from the ETL script containing the new functions
+- Build a synthetic SQLite fixture with 3+ review cases
+- Assert correct classification per case
+
+`testthat::test_file()` parse-safe; actual R execution deferred to
+`devtools::test()` in the llm nix shell.

--- a/tests/testthat/test-roborev-fix-commit-link.R
+++ b/tests/testthat/test-roborev-fix-commit-link.R
@@ -1,0 +1,328 @@
+# Tests for find_fix_commit_for_review() and enrich_fix_commit_links().
+# Tracks llm#379.
+#
+# Tests verify:
+#   1. Autoclose heuristic (close_reason = "severity-*") → fix_method = autoclose_severity
+#   2. Explicit reference heuristic via git log grep → fix_method = commit_reference
+#   3. Time-proximity heuristic (commit within 6h before closure) → fix_method = manual
+#   4. Fallthrough: closed, no matching commit, not autoclose → fix_method = unknown
+#   5. Edge: review with unknown close_reason, no repo path → fix_method = unknown
+#   6. Boundary: fix_commit_sha IS NOT NA guard (batch idempotence)
+#
+# Strategy: source the ETL function block containing find_fix_commit_for_review
+# and enrich_fix_commit_links (pure functions with no I/O beyond sys calls).
+# git-dependent heuristics (1, 3) are exercised via a temporary git repo fixture.
+
+library(testthat)
+
+# ── Load ETL function block ─────────────────────────────────────────────────
+# Source lines covering the new functions.  We source the whole script in a
+# sandboxed environment to pick up helpers (coalesce_int, `%||%`, parse_ts, etc.).
+#
+# Because the script has top-level I/O (arg parsing, DB reads), we fake the
+# commandArgs output and redirect the graceful_exit() calls.
+
+etl_script <- file.path(pkgload::pkg_path(),
+                         ".claude", "scripts", "roborev_metrics_etl.R")
+
+skip_if_not(file.exists(etl_script), "ETL script not found at expected path")
+
+# Parse-only check (always run, even if duckdb absent)
+test_that("ETL script parses without error (syntax check)", {
+  expect_silent(parse(etl_script))
+})
+
+# ── Minimal fixture helpers ─────────────────────────────────────────────────
+
+# Build a minimal lifecycle_df row matching the build_review_lifecycle schema
+make_lifecycle_row <- function(review_id, closed_at, close_reason,
+                                fix_commit_sha = NA_character_) {
+  data.frame(
+    review_id                    = as.integer(review_id),
+    job_id                       = as.integer(review_id),
+    repo                         = "llm",
+    agent                        = "claude-code",
+    model                        = NA_character_,
+    branch                       = "main",
+    commit_sha                   = NA_character_,
+    created_at                   = as.POSIXct("2026-05-27 10:00:00", tz = "UTC"),
+    started_at                   = as.POSIXct("2026-05-27 10:00:01", tz = "UTC"),
+    finished_at                  = as.POSIXct("2026-05-27 10:00:10", tz = "UTC"),
+    duration_s                   = 9.0,
+    verdict                      = "F",
+    severity_max                 = "High",
+    closed_at                    = as.POSIXct(closed_at, tz = "UTC"),
+    close_reason                 = close_reason,
+    autoclose_threshold_at_close = NA_character_,
+    fix_commit_sha               = fix_commit_sha,
+    fix_commit_at                = as.POSIXct(NA_real_, origin = "1970-01-01"),
+    fix_method                   = NA_character_,
+    stringsAsFactors             = FALSE
+  )
+}
+
+# ── Load the functions needed for testing ──────────────────────────────────
+#
+# We source only the pure-function block to avoid triggering I/O.
+# find_fix_commit_for_review and enrich_fix_commit_links are defined after
+# coalesce_int (the last helper before the Slice 3 block).
+
+all_lines <- readLines(etl_script)
+
+# Find line numbers for the two target functions.
+# Anchor on the unique comment that precedes each function definition.
+fn_start_pattern  <- "^# .* find_fix_commit_for_review \\(#379\\)"
+enrich_end_pattern <- "^\\}"  # closing brace of enrich_fix_commit_links
+
+fn_start_line  <- grep(fn_start_pattern, all_lines)[[1L]]
+
+# Also need coalesce_int and %||% helpers; source from their first occurrence.
+coalesce_line <- grep("^coalesce_int <- function", all_lines)[[1L]]
+pipe_line     <- grep("^`%||%` <-", all_lines)[[1L]]
+helper_start  <- min(coalesce_line, pipe_line)
+
+# Find end of enrich_fix_commit_links: the first bare "}" after
+# "enrich_fix_commit_links <- function" definition.
+enrich_fn_line  <- grep("^enrich_fix_commit_links <- function", all_lines)[[1L]]
+# The function ends at the first bare "}" that occurs on its own line after
+# the function opens, at depth 0. Walk forward to find it.
+depth        <- 0L
+enrich_end_line <- enrich_fn_line
+for (li in enrich_fn_line:length(all_lines)) {
+  opens   <- nchar(gsub("[^{]", "", all_lines[[li]]))
+  closes  <- nchar(gsub("[^}]", "", all_lines[[li]]))
+  depth   <- depth + opens - closes
+  if (li > enrich_fn_line && depth == 0L) {
+    enrich_end_line <- li
+    break
+  }
+}
+
+fn_block <- all_lines[helper_start:enrich_end_line]
+
+# Evaluate in the test environment
+fn_env <- new.env(parent = globalenv())
+eval(parse(text = paste(fn_block, collapse = "\n")), envir = fn_env)
+
+find_fix_commit_for_review  <- fn_env$find_fix_commit_for_review
+enrich_fix_commit_links      <- fn_env$enrich_fix_commit_links
+
+skip_if(is.null(find_fix_commit_for_review),
+        "find_fix_commit_for_review not found in ETL script — line offsets may need updating")
+
+# ── Test 1: autoclose heuristic ────────────────────────────────────────────
+
+test_that("find_fix_commit: autoclose close_reason → autoclose_severity, NULL sha", {
+  closed_at <- as.POSIXct("2026-05-27 18:00:00", tz = "UTC")
+
+  for (cr in c("severity-medium", "severity-low", "clean-verdict", "severity-high")) {
+    result <- find_fix_commit_for_review(
+      review_id    = 42L,
+      repo_path    = "/nonexistent/path",
+      closed_at    = closed_at,
+      close_reason = cr,
+      closer_actor = NA_character_
+    )
+    expect_equal(result$fix_method, "autoclose_severity",
+                 info = sprintf("close_reason='%s' should yield autoclose_severity", cr))
+    expect_true(is.na(result$fix_commit_sha),
+                info = sprintf("fix_commit_sha must be NA for autoclose (close_reason='%s')", cr))
+  }
+})
+
+# ── Test 2: no repo path → unknown ─────────────────────────────────────────
+
+test_that("find_fix_commit: non-existent repo path → unknown", {
+  result <- find_fix_commit_for_review(
+    review_id    = 99L,
+    repo_path    = "/this/path/does/not/exist",
+    closed_at    = as.POSIXct("2026-05-27 18:00:00", tz = "UTC"),
+    close_reason = "manual",
+    closer_actor = NA_character_
+  )
+  expect_equal(result$fix_method, "unknown")
+  expect_true(is.na(result$fix_commit_sha))
+})
+
+# ── Test 3: explicit commit reference via git grep ─────────────────────────
+
+test_that("find_fix_commit: commit with 'roborev #<id>' in message → commit_reference", {
+  skip_if_not(nzchar(Sys.which("git")), "git not available")
+
+  tmp_repo <- withr::local_tempdir()
+
+  # Initialise bare git repo with one commit referencing roborev #1234
+  system2("git", args = c("-C", tmp_repo, "init", "-q"))
+  system2("git", args = c("-C", tmp_repo, "config", "user.email", "test@test.com"))
+  system2("git", args = c("-C", tmp_repo, "config", "user.name", "Test"))
+
+  writeLines("hello", file.path(tmp_repo, "file.txt"))
+  system2("git", args = c("-C", tmp_repo, "add", "file.txt"))
+  system2("git", args = c(
+    "-C", tmp_repo,
+    "commit", "-m", "fix: address roborev review #1234 finding in R/foo.R",
+    "--date", "2026-05-27T17:30:00+00:00",
+    "--no-gpg-sign"
+  ))
+
+  # Get the commit SHA
+  sha_raw <- system2("git", args = c("-C", tmp_repo, "log", "--format=%H", "-1"),
+                     stdout = TRUE)
+  expected_sha <- trimws(sha_raw[[1L]])
+
+  closed_at <- as.POSIXct("2026-05-27 18:00:00", tz = "UTC")
+  result <- find_fix_commit_for_review(
+    review_id    = 1234L,
+    repo_path    = tmp_repo,
+    closed_at    = closed_at,
+    close_reason = "manual",
+    closer_actor = NA_character_
+  )
+
+  expect_equal(result$fix_method, "commit_reference",
+               info = "Should detect explicit roborev #1234 reference in commit message")
+  expect_equal(result$fix_commit_sha, expected_sha,
+               info = "SHA should match the commit that references roborev #1234")
+  expect_false(is.na(result$fix_commit_at),
+               info = "fix_commit_at must be non-NA when commit is found")
+})
+
+# ── Test 4: time-proximity heuristic ───────────────────────────────────────
+
+test_that("find_fix_commit: commit within 6h before closure → manual (time-proximity)", {
+  skip_if_not(nzchar(Sys.which("git")), "git not available")
+
+  tmp_repo <- withr::local_tempdir()
+  system2("git", args = c("-C", tmp_repo, "init", "-q"))
+  system2("git", args = c("-C", tmp_repo, "config", "user.email", "test@test.com"))
+  system2("git", args = c("-C", tmp_repo, "config", "user.name", "Test"))
+
+  # A commit 3 hours before closure (within 6h window) WITHOUT a roborev reference
+  writeLines("fix", file.path(tmp_repo, "fix.R"))
+  system2("git", args = c("-C", tmp_repo, "add", "fix.R"))
+  system2("git", args = c(
+    "-C", tmp_repo,
+    "commit", "-m", "refactor: general cleanup",
+    "--date", "2026-05-27T15:00:00+00:00",
+    "--no-gpg-sign"
+  ))
+
+  sha_raw <- system2("git", args = c("-C", tmp_repo, "log", "--format=%H", "-1"),
+                     stdout = TRUE)
+  expected_sha <- trimws(sha_raw[[1L]])
+
+  # closed_at = 18:00; commit at 15:00 → 3h gap, within 6h window
+  closed_at <- as.POSIXct("2026-05-27 18:00:00", tz = "UTC")
+  result <- find_fix_commit_for_review(
+    review_id    = 9999L,   # won't match the commit message
+    repo_path    = tmp_repo,
+    closed_at    = closed_at,
+    close_reason = "manual",
+    closer_actor = NA_character_
+  )
+
+  expect_equal(result$fix_method, "manual",
+               info = "Commit within 6h window with no explicit ref → manual")
+  expect_equal(result$fix_commit_sha, expected_sha,
+               info = "SHA should match the time-proximity commit")
+})
+
+# ── Test 5: fallthrough — closed, no commit anywhere near closure ──────────
+
+test_that("find_fix_commit: no commits in window → unknown", {
+  skip_if_not(nzchar(Sys.which("git")), "git not available")
+
+  tmp_repo <- withr::local_tempdir()
+  system2("git", args = c("-C", tmp_repo, "init", "-q"))
+  system2("git", args = c("-C", tmp_repo, "config", "user.email", "test@test.com"))
+  system2("git", args = c("-C", tmp_repo, "config", "user.name", "Test"))
+
+  # A commit OUTSIDE the 6-hour window (8 hours before closure)
+  writeLines("old", file.path(tmp_repo, "old.R"))
+  system2("git", args = c("-C", tmp_repo, "add", "old.R"))
+  system2("git", args = c(
+    "-C", tmp_repo,
+    "commit", "-m", "chore: old unrelated commit",
+    "--date", "2026-05-27T10:00:00+00:00",
+    "--no-gpg-sign"
+  ))
+
+  # closed_at = 18:00; only commit is at 10:00 → 8h gap, outside window
+  closed_at <- as.POSIXct("2026-05-27 18:00:00", tz = "UTC")
+  result <- find_fix_commit_for_review(
+    review_id    = 5555L,
+    repo_path    = tmp_repo,
+    closed_at    = closed_at,
+    close_reason = "manual",
+    closer_actor = NA_character_
+  )
+
+  expect_equal(result$fix_method, "unknown",
+               info = "No commits in window → unknown")
+  expect_true(is.na(result$fix_commit_sha),
+              info = "fix_commit_sha must be NA when unknown")
+})
+
+# ── Test 6: enrich_fix_commit_links batch guard ────────────────────────────
+
+test_that("enrich_fix_commit_links: already-linked rows are not re-processed", {
+  skip_if_not_installed("duckdb")
+
+  # Build a minimal SQLite fixture for the repos map lookup
+  tmp <- withr::local_tempdir()
+  db_path <- file.path(tmp, "reviews_fix.db")
+
+  con <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  DBI::dbExecute(con, "LOAD sqlite")
+  DBI::dbExecute(con, sprintf("ATTACH '%s' AS src (TYPE sqlite)", db_path))
+  DBI::dbExecute(con, "CREATE TABLE src.repos (id INTEGER PRIMARY KEY, name TEXT, root_path TEXT)")
+  DBI::dbExecute(con, "INSERT INTO src.repos VALUES (1, 'llm', '/nonexistent/llm')")
+
+  # Lifecycle with one row already linked (fix_commit_sha IS NOT NA)
+  already_linked <- make_lifecycle_row(
+    review_id      = 1L,
+    closed_at      = "2026-05-27 18:00:00",
+    close_reason   = "manual",
+    fix_commit_sha = "abc123def456abc123def456abc123def456abc1"
+  )
+  already_linked$fix_method <- "commit_reference"
+
+  # Enrich — already-linked row should be untouched
+  enriched <- enrich_fix_commit_links(already_linked, con)
+
+  expect_equal(enriched$fix_commit_sha[[1L]],
+               "abc123def456abc123def456abc123def456abc1",
+               info = "Already-linked sha must not change")
+  expect_equal(enriched$fix_method[[1L]], "commit_reference",
+               info = "Already-linked method must not change")
+})
+
+# ── Test 7: enrich adds fix_commit_sha column if absent ───────────────────
+
+test_that("enrich_fix_commit_links: adds fix_commit_sha column when missing", {
+  skip_if_not_installed("duckdb")
+
+  tmp <- withr::local_tempdir()
+  db_path <- file.path(tmp, "reviews_fix2.db")
+
+  con <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  DBI::dbExecute(con, "LOAD sqlite")
+  DBI::dbExecute(con, sprintf("ATTACH '%s' AS src (TYPE sqlite)", db_path))
+  DBI::dbExecute(con, "CREATE TABLE src.repos (id INTEGER PRIMARY KEY, name TEXT, root_path TEXT)")
+  DBI::dbExecute(con, "INSERT INTO src.repos VALUES (1, 'llm', '/nonexistent/path')")
+
+  # Lifecycle without fix-link columns (simulates pre-#379 build)
+  row_df <- make_lifecycle_row(1L, "2026-05-27 18:00:00", "manual")
+  row_df$fix_commit_sha <- NULL
+  row_df$fix_commit_at  <- NULL
+  row_df$fix_method     <- NULL
+
+  enriched <- enrich_fix_commit_links(row_df, con)
+
+  expect_true("fix_commit_sha" %in% names(enriched),
+              info = "fix_commit_sha column must be added by enrich()")
+  expect_true("fix_method"     %in% names(enriched),
+              info = "fix_method column must be added by enrich()")
+})


### PR DESCRIPTION
## Summary

Adds review→fix-commit link enrichment to `roborev_review_lifecycle` so
llmtelemetry #146 Q4/Q9/Q14 can ship.

### What this PR does

- **Schema** (`roborev_metrics_schema.sql`): extends `roborev_review_lifecycle`
  CREATE TABLE with 3 new columns (`fix_commit_sha VARCHAR`, `fix_commit_at
  TIMESTAMP`, `fix_method VARCHAR`). Adds idempotent `ALTER TABLE IF EXISTS …
  ADD COLUMN IF NOT EXISTS` migrations for pre-existing databases.
  fix_method vocabulary: `manual | commit_reference | pr_close | autoclose_severity | unknown`

- **ETL** (`roborev_metrics_etl.R`): adds two new functions:
  - `find_fix_commit_for_review()` — 5-heuristic chain (priority order):
    1. Autoclose detection (cheap; no git needed): `close_reason` matches severity/clean-verdict pattern → `autoclose_severity`
    2. Explicit commit reference: `git log --grep "roborev.*<id>"` within ±1 day → `commit_reference`
    3. PR close via `gh pr list --search` → `pr_close` (optional; skipped if `gh` unavailable)
    4. Time-proximity: commit within 6h before closure → `manual`
    5. Fallthrough → `unknown`
  - `enrich_fix_commit_links()` — batch guard (`IS NULL` check) + row-by-row enrichment
  Wired into build flow immediately after `build_review_lifecycle()`.
  Dry-run output now shows fix_method distribution.

- **Tests** (`tests/testthat/test-roborev-fix-commit-link.R`): 7 tests —
  autoclose classification, unknown path, explicit git grep match, time-proximity
  (inside and outside 6h window), batch guard idempotency, column-addition guard.
  ETL script parses cleanly (`Rscript -e 'parse(...)'`); full `devtools::test()`
  deferred to nix shell CI due to segfault risk in nested shells (#62).

- **Investigation doc** (`plans/379-investigation.md`): schema findings, design
  decision (extend vs new table), heuristic chain rationale.

### Smoke test results (since 2026-05-20, 675 closed reviews)

| fix_method | Count | % |
|---|---|---|
| autoclose_severity | 502 | 74.4% |
| unknown | 152 | 22.5% |
| manual | 16 | 2.4% |
| commit_reference | 5 | 0.7% |

### Constraints respected

- Live `~/.claude/logs/unified.duckdb` NOT modified (dry-run only)
- `roborev_agent_performance` derivation NOT touched (that's #380's territory)
- No `roborev close/comment` calls made

### Unblocks

- llmtelemetry #146 Q4 (time-to-fix histogram): `fix_commit_at - closed_at`
- llmtelemetry #146 Q9 (false-positive rate): `autoclose_severity` row fraction
- llmtelemetry #146 Q14 (closing-the-loop funnel): `fix_method` distribution

## Test plan

- [x] `Rscript -e 'parse("tests/testthat/test-roborev-fix-commit-link.R")'` — PASS
- [x] `Rscript -e 'parse(".claude/scripts/roborev_metrics_etl.R")'` — PASS  
- [x] Dry-run smoke test (since 2026-05-20, 675 closed reviews) — no shell errors, correct fix_method distribution
- [ ] `devtools::test()` inside llm nix shell — deferred; nested-shell segfault risk (#62)

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
