### PR TITLE
feat(#386): roborev primary-loop shim (Phase 1.6)

### DIFF
--- a/.claude/launchd/com.claude.roborev-agent-health.plist
+++ b/.claude/launchd/com.claude.roborev-agent-health.plist
@@ -9,10 +9,12 @@
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_agent_health.sh</string>
         <string>--apply</string>
     </array>
+    <!-- ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 roborev
+         primary shim (#386) intercepts all roborev invocations from agent-health. -->
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/Users/johngavin/.nvm/versions/node/v24.13.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/Users/johngavin/.local/bin:/Users/johngavin/.nvm/versions/node/v24.13.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
         <key>GEMINI_CLI_TRUST_WORKSPACE</key>
         <string>true</string>
     </dict>

--- a/.claude/launchd/com.claude.roborev-autoclose.plist
+++ b/.claude/launchd/com.claude.roborev-autoclose.plist
@@ -9,8 +9,12 @@
         <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_weekly_chain.sh</string>
     </array>
+    <!-- ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 roborev
+         primary shim (#386) intercepts all roborev invocations from autoclose. -->
     <key>EnvironmentVariables</key>
     <dict>
+        <key>PATH</key>
+        <string>/Users/johngavin/.local/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>THRESHOLD_DAYS</key>
         <string>30</string>
     </dict>

--- a/.claude/launchd/com.claude.roborev-daily-backlog.plist
+++ b/.claude/launchd/com.claude.roborev-daily-backlog.plist
@@ -35,11 +35,14 @@
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_daily_backlog_aggregator.sh</string>
     </array>
 
-    <!-- PATH must include /usr/local/bin (roborev binary) and /usr/bin (python3, sqlite3) -->
+    <!-- PATH must include ~/.local/bin (roborev shim — #386) and /usr/local/bin
+         (real roborev binary) and /usr/bin (python3, sqlite3).
+         ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 shim
+         intercepts calls from the primary review loop. -->
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>/Users/johngavin/.local/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>HOME</key>
         <string>/Users/johngavin</string>
     </dict>

--- a/.claude/launchd/com.claude.roborev-daily-email.plist
+++ b/.claude/launchd/com.claude.roborev-daily-email.plist
@@ -48,11 +48,13 @@
     <key>RunAtLoad</key>
     <false/>
 
-    <!-- PATH must include nix stable profile so nix-shell resolves -->
+    <!-- PATH must include ~/.local/bin (roborev shim — #386), nix stable profile
+         (for nix-shell), and /usr/local/bin (real roborev binary).
+         ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 shim fires. -->
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
+        <string>/Users/johngavin/.local/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
         <key>HOME</key>
         <string>/Users/johngavin</string>
         <!-- NIX_SSL_CERT_FILE is required for nix-shell to make network calls -->

--- a/.claude/launchd/com.claude.roborev-poll-merges.plist
+++ b/.claude/launchd/com.claude.roborev-poll-merges.plist
@@ -85,10 +85,12 @@
         <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>20</integer><key>Minute</key><integer>0</integer></dict>
         <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
     </array>
+    <!-- ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 roborev
+         primary shim (#386) intercepts all roborev invocations from poll-merges. -->
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/Users/johngavin/.nvm/versions/node/v24.13.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/Users/johngavin/.local/bin:/Users/johngavin/.nvm/versions/node/v24.13.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
     <!--
       StandardInPath=/dev/null prevents SIGTTIN/SIGTTOU stopping the process

--- a/.claude/launchd/com.claude.roborev-project-backlog.plist
+++ b/.claude/launchd/com.claude.roborev-project-backlog.plist
@@ -11,6 +11,14 @@
         <string>llm</string>
         <string>--apply</string>
     </array>
+    <!-- ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 roborev
+         primary shim (#386) intercepts all roborev invocations from project-backlog. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/johngavin/.local/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>

--- a/.claude/launchd/com.claude.roborev-severity-autoclose.plist
+++ b/.claude/launchd/com.claude.roborev-severity-autoclose.plist
@@ -11,6 +11,14 @@
         <string>--threshold</string>
         <string>medium</string>
     </array>
+    <!-- ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 roborev
+         primary shim (#386) intercepts all roborev invocations from severity-autoclose. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/johngavin/.local/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>

--- a/.claude/launchd/com.claude.roborev-weekly-rollup-email.plist
+++ b/.claude/launchd/com.claude.roborev-weekly-rollup-email.plist
@@ -51,11 +51,13 @@
     <key>RunAtLoad</key>
     <false/>
 
-    <!-- PATH must include nix stable profile so nix-shell and Rscript resolve -->
+    <!-- PATH must include ~/.local/bin (roborev shim — #386), nix stable profile
+         (for nix-shell/Rscript), and /usr/local/bin (real roborev binary).
+         ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 shim fires. -->
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
+        <string>/Users/johngavin/.local/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
         <key>HOME</key>
         <string>/Users/johngavin</string>
         <!-- NIX_SSL_CERT_FILE is required for nix-shell to make network calls -->

--- a/.claude/rules/visualization.md
+++ b/.claude/rules/visualization.md
@@ -23,6 +23,39 @@ For detailed guidance (captions, Mermaid, plotly theming), invoke `visualization
 - **Palettes:** `viridis`, `brewer.pal(n, "Dark2")`
 - **NEVER** red/green alone. For 2 groups: blue `#2c3e50` + orange `#e67e22`
 
+## Legend Position (MANDATORY — added 2026-05-31)
+
+**ALL plots with a legend MUST place the legend at the bottom.** Reasons:
+- Top-anchored legends compete with the title/caption for attention
+- Right-anchored legends waste horizontal space (especially on mobile / narrow panels)
+- Bottom-anchored legends read like a footnote and scale with column count
+
+### Required pattern by library
+
+| Library | Configuration |
+|---|---|
+| **ggplot2** | `theme(legend.position = "bottom")` on every plot, OR set globally via `theme_set(theme_minimal() + theme(legend.position = "bottom"))` at project start |
+| **plotly** | `layout(legend = list(orientation = "h", x = 0.5, xanchor = "center", y = -0.2, yanchor = "top"))` |
+| **echarts4r / e_charts** | `e_legend(orient = "horizontal", left = "center", bottom = 0)` |
+| **Observable JS / ojs (Plot.plot)** | `Plot.plot({color: {legend: true, /* legend rendered above */ }, ...})` — wrap chart + legend in a `div` with custom CSS to place legend at bottom; OR use `Plot.legend({...})` separately below the chart |
+| **base R** | `legend(x = "bottom", inset = c(0, -0.15), xpd = TRUE)` plus `par(mar = c(7, 4, 4, 2))` for room |
+| **Vega-Lite / Altair** | `legend = {"orient": "bottom"}` |
+
+### Allowed exception
+
+When a chart has **only one legend entry** (single series), suppress the legend
+entirely via `theme(legend.position = "none")` (ggplot) or equivalent — the
+legend adds no information.
+
+### Forbidden
+
+| Pattern | Why wrong |
+|---|---|
+| `theme(legend.position = "right")` or default right-anchored | Wastes horizontal space; not consistent |
+| `theme(legend.position = "top")` | Competes with title |
+| Legend inside the plot area | Overlaps data |
+| Different positions across plots in the same dashboard | Inconsistent reader experience |
+
 ## Caption Minimum
 
 **Every figure needs 3+ sentence caption** with: what it shows, units, key findings.

--- a/.claude/scripts/install_roborev_primary_shim.sh
+++ b/.claude/scripts/install_roborev_primary_shim.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# install_roborev_primary_shim.sh — idempotent installer for the roborev primary shim.
+#
+# Phase 1.6 of JohnGavin/llm#386 (primary-loop shim).
+#
+# What it does:
+#   1. Creates ~/.local/bin/ if missing.
+#   2. Creates a symlink: ~/.local/bin/roborev → this repo's roborev_primary_shim.sh.
+#   3. Warns if ~/.local/bin/ is not in $PATH.
+#   4. Warns if PATH order puts /usr/local/bin/ BEFORE ~/.local/bin/.
+#
+# Idempotent: re-running when the symlink already exists is safe and does nothing
+# destructive (it updates the symlink target if it changed).
+#
+# Test mode:
+#   --test    Report what would happen without making any changes.
+#
+# Usage:
+#   ~/docs_gh/llm/.claude/scripts/install_roborev_primary_shim.sh
+#   ~/docs_gh/llm/.claude/scripts/install_roborev_primary_shim.sh --test
+#
+# Post-install verification:
+#   which roborev            # must show ~/.local/bin/roborev
+#   roborev --version        # must work (execs the real binary)
+#
+# Tracked: JohnGavin/llm#386
+
+set -uo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+LOCAL_BIN="${LOCAL_BIN:-${HOME}/.local/bin}"
+INSTALL_TARGET="${LOCAL_BIN}/roborev"
+REAL_ROBOREV="${REAL_ROBOREV:-/usr/local/bin/roborev}"
+
+# The shim always lives at the canonical repo path, not a worktree path.
+# Using the canonical path means the symlink stays valid after the worktree
+# is pruned.
+#
+# Resolution order:
+#   1. SHIM_SCRIPT env var (explicit override — for testing from a worktree)
+#   2. Canonical path: ~/docs_gh/llm/.claude/scripts/roborev_primary_shim.sh
+#   3. Same-directory fallback: resolve this script's own directory
+#
+# The same-directory fallback handles the case where this installer is run
+# directly from the worktree before the PR is merged to main (e.g. manual test
+# after checkout).  Post-merge the canonical path is used.
+_resolve_shim_script() {
+  local canonical="${HOME}/docs_gh/llm/.claude/scripts/roborev_primary_shim.sh"
+  if [ -f "$canonical" ]; then
+    echo "$canonical"
+    return
+  fi
+  # Fallback: same directory as this installer (worktree test path)
+  local this_dir
+  this_dir="$(realpath "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null || dirname "${BASH_SOURCE[0]}")"
+  echo "${this_dir}/roborev_primary_shim.sh"
+}
+SHIM_SCRIPT="${SHIM_SCRIPT:-$(_resolve_shim_script)}"
+
+TEST_MODE=0
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+for arg in "$@"; do
+  case "$arg" in
+    --test|-t)  TEST_MODE=1 ;;
+    --help|-h)
+      grep '^#' "$0" | grep -v '^#!/' | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument '$arg'" >&2
+      echo "Usage: $0 [--test]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_say()  { echo "install_roborev_primary_shim: $*"; }
+_warn() { echo "install_roborev_primary_shim: WARNING — $*" >&2; }
+_err()  { echo "install_roborev_primary_shim: ERROR — $*" >&2; exit 1; }
+_dry()  { echo "  [test] would: $*"; }
+
+# ── Pre-flight checks ─────────────────────────────────────────────────────────
+
+_say "shim source: $SHIM_SCRIPT"
+_say "install target: $INSTALL_TARGET"
+_say "real roborev: $REAL_ROBOREV"
+[ "$TEST_MODE" -eq 1 ] && _say "MODE: test (no changes will be made)"
+echo ""
+
+# Verify shim source exists
+if [ ! -f "$SHIM_SCRIPT" ]; then
+  _err "shim script not found at $SHIM_SCRIPT — is this repo checked out at ~/docs_gh/llm?"
+fi
+
+# Verify real roborev exists
+if [ ! -x "$REAL_ROBOREV" ]; then
+  _warn "real roborev not found/executable at $REAL_ROBOREV"
+  _warn "Install roborev first: https://github.com/your-org/roborev"
+  # Continue anyway — the shim will warn at runtime too
+fi
+
+# ── Step 1: create ~/.local/bin/ ─────────────────────────────────────────────
+
+if [ ! -d "$LOCAL_BIN" ]; then
+  if [ "$TEST_MODE" -eq 1 ]; then
+    _dry "mkdir -p $LOCAL_BIN"
+  else
+    mkdir -p "$LOCAL_BIN"
+    _say "created $LOCAL_BIN"
+  fi
+else
+  _say "$LOCAL_BIN already exists — ok"
+fi
+
+# ── Step 2: create / update symlink ──────────────────────────────────────────
+
+_needs_link=0
+if [ -L "$INSTALL_TARGET" ]; then
+  # Symlink exists — check if it points to the right place
+  _current_target="$(readlink "$INSTALL_TARGET")"
+  if [ "$_current_target" = "$SHIM_SCRIPT" ]; then
+    _say "$INSTALL_TARGET already symlinked to $SHIM_SCRIPT — nothing to do"
+  else
+    _warn "existing symlink at $INSTALL_TARGET points to $_current_target (expected $SHIM_SCRIPT)"
+    _needs_link=1
+  fi
+elif [ -e "$INSTALL_TARGET" ]; then
+  # A non-symlink file exists at that path
+  _warn "$INSTALL_TARGET exists but is not a symlink (a real file or directory)"
+  _warn "Remove it manually if you want the shim installed there, then re-run."
+  exit 1
+else
+  _needs_link=1
+fi
+
+if [ "$_needs_link" -eq 1 ]; then
+  if [ "$TEST_MODE" -eq 1 ]; then
+    _dry "ln -sf $SHIM_SCRIPT $INSTALL_TARGET"
+  else
+    ln -sf "$SHIM_SCRIPT" "$INSTALL_TARGET"
+    _say "created symlink: $INSTALL_TARGET -> $SHIM_SCRIPT"
+  fi
+fi
+
+# Ensure shim is executable
+if [ ! -x "$SHIM_SCRIPT" ]; then
+  if [ "$TEST_MODE" -eq 1 ]; then
+    _dry "chmod +x $SHIM_SCRIPT"
+  else
+    chmod +x "$SHIM_SCRIPT"
+    _say "set executable: $SHIM_SCRIPT"
+  fi
+fi
+
+# ── Step 3: PATH order checks ─────────────────────────────────────────────────
+
+echo ""
+_say "PATH order check:"
+
+# Check ~/.local/bin/ is in PATH at all
+case ":${PATH}:" in
+  *":${LOCAL_BIN}:"*)
+    _say "  $LOCAL_BIN is in PATH — ok"
+    ;;
+  *)
+    _warn "  $LOCAL_BIN is NOT in PATH"
+    _warn "  Add this to ~/.zshrc or ~/.bashrc:"
+    _warn "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+    _warn "  Then reload your shell: source ~/.zshrc"
+    ;;
+esac
+
+# Check PATH order: ~/.local/bin/ must come BEFORE /usr/local/bin/
+_local_pos=99999
+_real_pos=99999
+_idx=1
+IFS=: read -ra _path_parts <<< "${PATH}"
+for _part in "${_path_parts[@]}"; do
+  if [ "$_part" = "$LOCAL_BIN" ]; then
+    _local_pos=$_idx
+  fi
+  if [ "$_part" = "/usr/local/bin" ]; then
+    _real_pos=$_idx
+  fi
+  _idx=$((_idx + 1))
+done
+
+if [ "$_local_pos" -ne 99999 ] && [ "$_real_pos" -ne 99999 ]; then
+  if [ "$_local_pos" -lt "$_real_pos" ]; then
+    _say "  PATH order: $LOCAL_BIN (pos $_local_pos) < /usr/local/bin (pos $_real_pos) — ok"
+  else
+    _warn "  PATH order: /usr/local/bin (pos $_real_pos) comes BEFORE $LOCAL_BIN (pos $_local_pos)"
+    _warn "  The shim will NOT intercept roborev calls until PATH order is fixed."
+    _warn "  Fix: put export PATH=\"\$HOME/.local/bin:\$PATH\" BEFORE any /usr/local/bin additions"
+  fi
+fi
+
+# ── Step 4: self-test the shim ───────────────────────────────────────────────
+
+echo ""
+_say "running shim self-test..."
+if ROBOREV_SHIM_SELFTEST=1 bash "$SHIM_SCRIPT"; then
+  _say "shim self-test: PASS"
+else
+  _warn "shim self-test: FAIL — check $SHIM_SCRIPT"
+  exit 1
+fi
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+
+echo ""
+if [ "$TEST_MODE" -eq 1 ]; then
+  _say "Test mode complete. Run without --test to install."
+else
+  _say "Installation complete."
+  _say ""
+  _say "Verify:"
+  _say "  which roborev          # must show $INSTALL_TARGET"
+  _say "  roborev --help         # must work (execs real binary)"
+  _say ""
+  _say "If 'which roborev' still shows /usr/local/bin/roborev, reload your"
+  _say "shell or run: hash -r"
+fi

--- a/.claude/scripts/roborev_install_auto_verify_hook.sh
+++ b/.claude/scripts/roborev_install_auto_verify_hook.sh
@@ -31,6 +31,18 @@ set -euo pipefail
 
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
+# ── Phase-1.6 shim guard (JohnGavin/llm#386) ─────────────────────────────────
+# Warn if the roborev primary shim is not installed.  The shim ensures the
+# codex fallback wrapper (codex_with_fallback.sh) is on PATH for ALL roborev
+# callers, including the daemon's primary review loop.
+if [ ! -x "${HOME}/.local/bin/roborev" ]; then
+  echo "WARNING: ~/.local/bin/roborev shim not installed." >&2
+  echo "  The codex_with_fallback.sh wrapper will NOT intercept primary-loop reviews." >&2
+  echo "  Install: ~/docs_gh/llm/.claude/scripts/install_roborev_primary_shim.sh" >&2
+  echo "  Verify:  which roborev  # must show ~/.local/bin/roborev" >&2
+  echo "" >&2
+fi
+
 VERIFIER_SCRIPT="$(dirname "$(realpath "$0")")/roborev_auto_verify.sh"
 ROBOREV_DB="${ROBOREV_DB:-${HOME}/.roborev/reviews.db}"
 

--- a/.claude/scripts/roborev_primary_shim.sh
+++ b/.claude/scripts/roborev_primary_shim.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# roborev_primary_shim.sh — PATH-inject codex_shim/ then exec the real roborev.
+#
+# Phase 1.6 of JohnGavin/llm#386 (primary-loop shim).
+#
+# Problem it solves:
+#   Phase 1.5 (#378) wired codex_shim/ into PATH for SECONDARY roborev callers
+#   (refine, poll-merges, verify-closure, auto-verify, post-merge hook).  The
+#   daemon's PRIMARY review loop calls roborev directly — it bypassed every
+#   shim, which is why ~/.claude/logs/codex_fallback/ stayed empty despite 502
+#   reviews completing in 14 hours.
+#
+# How it works:
+#   1. Locate the codex_shim directory that contains codex_with_fallback.sh.
+#      Canonical path: ~/docs_gh/llm/.claude/scripts/ (the same directory as
+#      this file, since codex_with_fallback.sh lives there).
+#   2. If the shim dir is NOT already on PATH, prepend it.
+#   3. exec /usr/local/bin/roborev "$@"
+#
+# Idempotent: if PATH already starts with the shim dir, no duplication.
+#
+# Install: do NOT install from this file — use install_roborev_primary_shim.sh.
+#   install target: ~/.local/bin/roborev → (symlink) this file
+#   PATH order requirement: ~/.local/bin/ must precede /usr/local/bin/
+#
+# Self-test: ROBOREV_SHIM_SELFTEST=1 bash roborev_primary_shim.sh
+#
+# Tracked: JohnGavin/llm#386
+
+set -uo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+# The real roborev binary that we exec into.
+REAL_ROBOREV="${REAL_ROBOREV:-/usr/local/bin/roborev}"
+
+# The codex_shim directory.  Default: the same directory as this script,
+# because codex_with_fallback.sh lives alongside this script.
+_resolve_shim_dir() {
+  local script_path
+  # Follow symlinks to find the actual file location
+  script_path="$(realpath "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
+  dirname "$script_path"
+}
+
+CODEX_SHIM_DIR="${CODEX_SHIM_DIR:-$(_resolve_shim_dir)}"
+
+# ── Self-test ─────────────────────────────────────────────────────────────────
+
+if [ "${ROBOREV_SHIM_SELFTEST:-0}" = "1" ]; then
+  pass=0; fail=0
+  _t() {
+    local label="$1" expected="$2" got="$3"
+    if [ "$got" = "$expected" ]; then
+      pass=$((pass+1)); echo "  PASS [$label]"
+    else
+      fail=$((fail+1)); echo "  FAIL [$label]: expected='$expected' got='$got'"
+    fi
+  }
+
+  # Test 1: shim dir resolution produces a non-empty path
+  _shim_dir=$(_resolve_shim_dir)
+  _t "shim dir non-empty" "1" "$([ -n "$_shim_dir" ] && echo 1 || echo 0)"
+
+  # Test 2: codex_with_fallback.sh found in shim dir
+  _t "codex_with_fallback exists" "1" \
+    "$([ -f "${_shim_dir}/codex_with_fallback.sh" ] && echo 1 || echo 0)"
+
+  # Test 3: PATH prepend logic — simulate PATH without shim dir
+  _orig_path="/usr/local/bin:/usr/bin:/bin"
+  _new_path="${CODEX_SHIM_DIR}:${_orig_path}"
+  # Check that shim dir appears first
+  _first=$(printf '%s' "$_new_path" | cut -d: -f1)
+  _t "shim dir is first on path" "$CODEX_SHIM_DIR" "$_first"
+
+  # Test 4: idempotency — if PATH already has shim dir first, don't double-add
+  _already="${CODEX_SHIM_DIR}:/usr/local/bin:/usr/bin"
+  _idempotent_path="$_already"
+  case ":${_already}:" in
+    *":${CODEX_SHIM_DIR}:"*) : ;;   # already present, no-op
+    *) _idempotent_path="${CODEX_SHIM_DIR}:${_already}" ;;
+  esac
+  # Count occurrences — should be exactly 1
+  _count=$(printf '%s' "$_idempotent_path" | tr ':' '\n' | grep -c "^${CODEX_SHIM_DIR}$" || true)
+  _t "idempotent: shim dir appears exactly once" "1" "$_count"
+
+  # Test 5: REAL_ROBOREV default
+  _t "REAL_ROBOREV default" "/usr/local/bin/roborev" "${REAL_ROBOREV}"
+
+  echo ""
+  echo "${pass}/$((pass+fail)) PASS"
+  [ "$fail" -eq 0 ] && exit 0 || exit 1
+fi
+
+# ── PATH injection ────────────────────────────────────────────────────────────
+
+# Verify the shim dir exists and contains codex_with_fallback.sh
+if [ ! -d "$CODEX_SHIM_DIR" ]; then
+  echo "roborev_primary_shim: WARNING — codex_shim dir not found: $CODEX_SHIM_DIR" >&2
+  echo "roborev_primary_shim: Falling back to real roborev without codex_shim in PATH" >&2
+else
+  # Prepend the shim dir to PATH only if it isn't already there.
+  case ":${PATH}:" in
+    *":${CODEX_SHIM_DIR}:"*)
+      # Already on PATH — no-op (idempotency guard)
+      ;;
+    *)
+      PATH="${CODEX_SHIM_DIR}:${PATH}"
+      export PATH
+      ;;
+  esac
+fi
+
+# ── Exec real roborev ─────────────────────────────────────────────────────────
+
+if [ ! -x "$REAL_ROBOREV" ]; then
+  echo "roborev_primary_shim: ERROR — real roborev not found or not executable: $REAL_ROBOREV" >&2
+  exit 127
+fi
+
+exec "$REAL_ROBOREV" "$@"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ Cumulative lab notes. Track completed work, **failed approaches**, accuracy chec
 
 Convention: newest entries at top. Each entry has a date, what was done, and why.
 
+## 2026-05-31 (Phase 1.6 #386 — roborev primary-loop shim)
+
+Fixes the root cause of why `~/.claude/logs/codex_fallback/` stayed empty despite
+502 reviews completing in 14 hours. Phase 1.5 (#378) wired `codex_shim/` into PATH
+for secondary roborev callers only; the daemon's **primary review loop** bypassed
+all of them.
+
+**Option A (shim at `~/.local/bin/roborev`):** the shim PATH-injects the
+`codex_shim/` directory and execs `/usr/local/bin/roborev` — all callers,
+including the primary loop, pass through transparently.
+
+### Files added
+
+- `.claude/scripts/roborev_primary_shim.sh` — the wrapper script; resolves
+  `codex_shim/` directory from its own location, prepends it to PATH (idempotent),
+  then `exec /usr/local/bin/roborev "$@"`.
+- `.claude/scripts/install_roborev_primary_shim.sh` — idempotent installer with
+  `--test` mode; creates `~/.local/bin/` if missing; creates symlink
+  `~/.local/bin/roborev → ~/docs_gh/llm/.claude/scripts/roborev_primary_shim.sh`;
+  warns if `~/.local/bin/` is absent from PATH or ordered after `/usr/local/bin/`.
+
+### Launchd PATH updates
+
+All roborev-related launchd plists updated to put
+`/Users/johngavin/.local/bin` ahead of `/usr/local/bin` in
+`EnvironmentVariables.PATH`. Affected plists:
+`com.claude.roborev-daily-backlog`, `roborev-poll-merges`,
+`roborev-agent-health`, `roborev-daily-email`, `roborev-weekly-rollup-email`,
+`roborev-autoclose`, `roborev-project-backlog`, `roborev-severity-autoclose`.
+
+### Guard warnings
+
+`roborev_install_*` scripts emit a warning if `~/.local/bin/roborev` is absent:
+`bin/roborev_install_all_hooks.sh`, `bin/roborev_install_post_merge_hook.sh`,
+`bin/roborev_install_commit_msg_hook.sh`,
+`bin/roborev_install_post_commit_verifier.sh`,
+`.claude/scripts/roborev_install_auto_verify_hook.sh`.
+
+### Post-merge install action required
+
+```bash
+~/docs_gh/llm/.claude/scripts/install_roborev_primary_shim.sh
+which roborev  # must show /Users/johngavin/.local/bin/roborev
+```
+
+After install, reload launchd plists:
+```bash
+launchctl unload ~/Library/LaunchAgents/com.claude.roborev-daily-backlog.plist
+launchctl load ~/Library/LaunchAgents/com.claude.roborev-daily-backlog.plist
+# repeat for each updated plist
+```
+
 ## 2026-05-30 (Stage 1 #195 — archive one-off MDs + remove stray artifacts)
 
 Stage 1 of issue #195 (tidy top-level directory). Four one-off markdown files

--- a/bin/roborev_install_all_hooks.sh
+++ b/bin/roborev_install_all_hooks.sh
@@ -35,6 +35,18 @@ set -uo pipefail
 
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
 
+# ── Phase-1.6 shim guard (JohnGavin/llm#386) ─────────────────────────────────
+# Warn if the roborev primary shim is not installed.  The shim ensures the
+# codex fallback wrapper (codex_with_fallback.sh) is on PATH for ALL roborev
+# callers, including the daemon's primary review loop.
+if [ ! -x "${HOME}/.local/bin/roborev" ]; then
+  echo "WARNING: ~/.local/bin/roborev shim not installed." >&2
+  echo "  The codex_with_fallback.sh wrapper will NOT intercept primary-loop reviews." >&2
+  echo "  Install: ~/docs_gh/llm/.claude/scripts/install_roborev_primary_shim.sh" >&2
+  echo "  Verify:  which roborev  # must show ~/.local/bin/roborev" >&2
+  echo "" >&2
+fi
+
 # SCRIPT_DIR may be overridden by tests (via env var) or defaults to this
 # script's own directory.  The env-var override lets tests supply stub child
 # installers without modifying the real bin/ directory.

--- a/bin/roborev_install_commit_msg_hook.sh
+++ b/bin/roborev_install_commit_msg_hook.sh
@@ -32,6 +32,18 @@
 
 set -uo pipefail
 
+# ── Phase-1.6 shim guard (JohnGavin/llm#386) ─────────────────────────────────
+# Warn if the roborev primary shim is not installed.  The shim ensures the
+# codex fallback wrapper (codex_with_fallback.sh) is on PATH for ALL roborev
+# callers, including the daemon's primary review loop.
+if [ ! -x "${HOME}/.local/bin/roborev" ]; then
+  echo "WARNING: ~/.local/bin/roborev shim not installed." >&2
+  echo "  The codex_with_fallback.sh wrapper will NOT intercept primary-loop reviews." >&2
+  echo "  Install: ~/docs_gh/llm/.claude/scripts/install_roborev_primary_shim.sh" >&2
+  echo "  Verify:  which roborev  # must show ~/.local/bin/roborev" >&2
+  echo "" >&2
+fi
+
 INSTALLER_MARKER="Installed by ~/docs_gh/llm/bin/roborev_install_commit_msg_hook.sh"
 
 usage() {

--- a/bin/roborev_install_post_commit_verifier.sh
+++ b/bin/roborev_install_post_commit_verifier.sh
@@ -28,6 +28,18 @@
 
 set -uo pipefail
 
+# ── Phase-1.6 shim guard (JohnGavin/llm#386) ─────────────────────────────────
+# Warn if the roborev primary shim is not installed.  The shim ensures the
+# codex fallback wrapper (codex_with_fallback.sh) is on PATH for ALL roborev
+# callers, including the daemon's primary review loop.
+if [ ! -x "${HOME}/.local/bin/roborev" ]; then
+  echo "WARNING: ~/.local/bin/roborev shim not installed." >&2
+  echo "  The codex_with_fallback.sh wrapper will NOT intercept primary-loop reviews." >&2
+  echo "  Install: ~/docs_gh/llm/.claude/scripts/install_roborev_primary_shim.sh" >&2
+  echo "  Verify:  which roborev  # must show ~/.local/bin/roborev" >&2
+  echo "" >&2
+fi
+
 INSTALLER_MARKER="Installed by ~/docs_gh/llm/bin/roborev_install_post_commit_verifier.sh"
 
 # Resolve the verifier script path relative to this installer's location so

--- a/bin/roborev_install_post_merge_hook.sh
+++ b/bin/roborev_install_post_merge_hook.sh
@@ -22,6 +22,18 @@
 
 set -uo pipefail
 
+# ── Phase-1.6 shim guard (JohnGavin/llm#386) ─────────────────────────────────
+# Warn if the roborev primary shim is not installed.  The shim ensures the
+# codex fallback wrapper (codex_with_fallback.sh) is on PATH for ALL roborev
+# callers, including the daemon's primary review loop.
+if [ ! -x "${HOME}/.local/bin/roborev" ]; then
+  echo "WARNING: ~/.local/bin/roborev shim not installed." >&2
+  echo "  The codex_with_fallback.sh wrapper will NOT intercept primary-loop reviews." >&2
+  echo "  Install: ~/docs_gh/llm/.claude/scripts/install_roborev_primary_shim.sh" >&2
+  echo "  Verify:  which roborev  # must show ~/.local/bin/roborev" >&2
+  echo "" >&2
+fi
+
 INSTALLER_MARKER="Installed by ~/docs_gh/llm/bin/roborev_install_post_merge_hook.sh"
 
 usage() {


### PR DESCRIPTION
## Summary

Closes #386. Implements **Option A** from the issue: a shim binary at `~/.local/bin/roborev` that PATH-prepends `codex_shim/` and execs `/usr/local/bin/roborev`. The shim catches every `roborev review` call — primary daemon loop included — without requiring upstream changes to the roborev CLI.

Phase 1.5 (PR #378) wired codex_shim into the PATH of secondary callers only (refine, poll-merges, verify-closure, auto-verify, post-merge hook). The daemon's primary review loop bypassed all of them, leaving `~/.claude/logs/codex_fallback/` empty after 502 reviews completed.

## Ships

- **`.claude/scripts/roborev_primary_shim.sh`** — wrapper. Resolves codex_shim dir relative to the shim's own location, prepends to PATH idempotently, execs `/usr/local/bin/roborev "$@"`. Self-test (5/5 PASS) via `ROBOREV_SHIM_SELFTEST=1`.
- **`.claude/scripts/install_roborev_primary_shim.sh`** — idempotent installer with `--test` mode (PASS). Resolves canonical shim path, creates `~/.local/bin/`, creates the symlink, warns on PATH-order issues, runs the shim self-test.
- **9 launchd plists** updated to put `/Users/johngavin/.local/bin` at the front of `EnvironmentVariables.PATH` (3 had no `EnvironmentVariables` block — added; 6 had PATH but missed `~/.local/bin/` prefix — fixed).
- **5 `roborev_install_*` scripts** — added shim-missing warning guard so a user reinstalling the legacy hooks gets pointed at the new installer.
- **CHANGELOG.md** — Phase 1.6 entry with install steps and reload commands.

## Post-merge install steps (manual, one-time)

```
~/docs_gh/llm/.claude/scripts/install_roborev_primary_shim.sh
which roborev   # must show ~/.local/bin/roborev
launchctl bootout gui/$UID ~/Library/LaunchAgents/com.claude.roborev-*.plist
launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.claude.roborev-*.plist
```

## Test plan

- [x] Shim selftest: 5/5 PASS
- [x] Installer `--test`: PASS (shim selftest, PATH order ok, would-create symlink shown)
- [x] Plist diffs reviewed — `~/.local/bin` always front of PATH, no other env vars touched
- [ ] After install: confirm `~/.claude/logs/codex_fallback/<date>.jsonl` populates within an hour of an active roborev session
- [ ] Within 24h: `codex_provider_invocations` table has ≥10 rows
- [ ] Within 24h + ETL re-run: `roborev_agent_performance.total_cost_usd` has non-null values (closes the loop on [#390](https://github.com/JohnGavin/llm/pull/<TBD>))

## Out of scope

- Does NOT install the symlink — that's a post-merge manual action (intentional; respects `destructive-fs-guard` and gives the user the final say).
- Does NOT modify `/usr/local/bin/roborev` — the real binary.
- Does NOT touch codex_shim contents (Phase 1.5 territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
