### PR TITLE
fix(#303): local-side guard for T-lang closure-rebuild marker

### DIFF
--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -1124,6 +1124,23 @@ PYEOF
 }
 phase_roborev_backlog || true
 
+# ── Phase 14a: T-lang flake.nix closure-rebuild advisory ─────────────────────
+# Warns if any T-lang R project under ~/docs_gh/ is missing the closure-rebuild
+# shellHook marker. `t update` strips this block; without it, R compiled packages
+# segfault on dyn.load (nix-nested-shell-isolation rule). NON-BLOCKING.
+# See JohnGavin/llm#303 and .claude/scripts/check_tlang_flake_closure_rebuild.sh
+_tlang_check_script="$CLAUDE_DIR/scripts/check_tlang_flake_closure_rebuild.sh"
+if [ -x "$_tlang_check_script" ]; then
+  _tlang_missing=$(timeout 5 bash "$_tlang_check_script" --quiet 2>/dev/null) || true
+  if [ -n "$_tlang_missing" ]; then
+    echo ""
+    echo "WARN: T-lang closure-rebuild marker missing in these projects:"
+    echo "$_tlang_missing"
+    echo "  Fix: cd <project> && bash default.post.sh"
+    echo "  See: .claude/scripts/check_tlang_flake_closure_rebuild.sh"
+  fi
+fi
+
 # ── Phase 14: Record session-start SHA (for session-end refine) ───────────────
 # Writes HEAD SHA to ~/.claude/.session_start_sha_<project> so that
 # session_end_refine.sh can bound a roborev refine to commits from this session.

--- a/.claude/rules/t-lang-r-package.md
+++ b/.claude/rules/t-lang-r-package.md
@@ -67,6 +67,35 @@ grep -q "Closure-rebuild" flake.nix || {
 Upstream fix tracked in llm#303. When T-lang bakes the closure-rebuild into
 its template, `default.post.sh` is no longer needed for this purpose.
 
+## Periodic Detection — Automated Session Check
+
+`~/.claude/scripts/check_tlang_flake_closure_rebuild.sh` scans all T-lang R
+projects under `~/docs_gh/` and reports which ones are missing the
+`Closure-rebuild` marker.
+
+```bash
+# Check all projects, verbose:
+bash ~/.claude/scripts/check_tlang_flake_closure_rebuild.sh
+
+# Check all projects, only show MISSING:
+bash ~/.claude/scripts/check_tlang_flake_closure_rebuild.sh --quiet
+
+# Self-test (fixture-based, 5 cases):
+CLAUDE_HOOK_SELFTEST=1 bash ~/.claude/scripts/check_tlang_flake_closure_rebuild.sh
+```
+
+Session init (Phase 14a) runs the check automatically in `--quiet` mode with
+a 5-second timeout. It emits a non-blocking WARN line if any project is missing
+the marker. This ensures a stripped shellHook is surfaced at the start of the
+next session — before any R work begins.
+
+Output per project:
+- `OK      <path>` — marker present; no action needed
+- `MISSING <path>` — run `cd <path> && bash default.post.sh` immediately
+- `SKIP    <path>` — has `flake.nix` but no T-lang signature; ignored
+
+See llm#303 (local-side guard) and `nix-nested-shell-isolation` rule.
+
 ## Detailed Guides
 
 See `~/docs_gh/llm/knowledge/t-lang/wiki/` for:

--- a/.claude/scripts/check_tlang_flake_closure_rebuild.sh
+++ b/.claude/scripts/check_tlang_flake_closure_rebuild.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# check_tlang_flake_closure_rebuild.sh
+#
+# Detects T-lang R projects under ~/docs_gh/ (or --projects-dir) whose
+# flake.nix is missing the closure-rebuild shellHook marker.
+#
+# The closure-rebuild block is mandated by the nix-nested-shell-isolation rule
+# and re-applied after every `t update` via default.post.sh. When stripped,
+# R compiled packages segfault on dyn.load. See JohnGavin/llm#303.
+#
+# Exit codes:
+#   0 — all T-lang projects have the marker (or no T-lang projects found)
+#   1 — at least one T-lang project is MISSING the marker
+#
+# Usage:
+#   check_tlang_flake_closure_rebuild.sh [--quiet] [--projects-dir <dir>]
+#   CLAUDE_HOOK_SELFTEST=1 check_tlang_flake_closure_rebuild.sh
+#
+# Output (one line per matched project):
+#   OK      <project-path>
+#   MISSING <project-path>
+#   SKIP    <project-path>   (has flake.nix but no T-lang signature)
+#
+# With --quiet: only MISSING lines are shown.
+
+set -euo pipefail
+
+# ── Parse arguments ────────────────────────────────────────────────────────────
+QUIET=0
+PROJECTS_DIR="${HOME}/docs_gh"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quiet)          QUIET=1; shift ;;
+    --projects-dir)   PROJECTS_DIR="$2"; shift 2 ;;
+    --projects-dir=*) PROJECTS_DIR="${1#--projects-dir=}"; shift ;;
+    *)                shift ;;
+  esac
+done
+
+# ── Self-test mode ─────────────────────────────────────────────────────────────
+if [[ "${CLAUDE_HOOK_SELFTEST:-0}" == "1" ]]; then
+  TMP_DIR=$(mktemp -d /tmp/tlang_test_XXXXXX)
+  trap 'rm -rf "$TMP_DIR"' EXIT
+
+  # Case A: T-lang project WITH the Closure-rebuild marker → should emit OK
+  mkdir -p "$TMP_DIR/proj_ok"
+  cat > "$TMP_DIR/proj_ok/tproject.toml" <<'TOML'
+[project]
+name = "proj_ok"
+TOML
+  cat > "$TMP_DIR/proj_ok/flake.nix" <<'NIX'
+{
+  inputs.t-lang.url = "github:b-rodrigues/tlang/v0.51.2";
+  outputs = { self, t-lang }: {
+    devShells.default = {
+      shellHook = ''
+        # Closure-rebuild: discard inherited R_LIBS_SITE
+        R_LIBS_SITE=""
+        export R_LIBS_SITE
+      '';
+    };
+  };
+}
+NIX
+
+  # Case B: T-lang project WITHOUT the marker → should emit MISSING
+  mkdir -p "$TMP_DIR/proj_missing"
+  cat > "$TMP_DIR/proj_missing/tproject.toml" <<'TOML'
+[project]
+name = "proj_missing"
+TOML
+  cat > "$TMP_DIR/proj_missing/flake.nix" <<'NIX'
+{
+  inputs.t-lang.url = "github:b-rodrigues/tlang/v0.51.2";
+  outputs = { self, t-lang }: {
+    devShells.default = {
+      shellHook = ''
+        echo "no closure rebuild here"
+      '';
+    };
+  };
+}
+NIX
+
+  # Case C: Directory with flake.nix but NO T-lang signature → should emit SKIP
+  mkdir -p "$TMP_DIR/proj_notlang"
+  cat > "$TMP_DIR/proj_notlang/flake.nix" <<'NIX'
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  outputs = { self, nixpkgs }: {};
+}
+NIX
+
+  # Run the check on our fixture dir (suppress QUIET for self-test output)
+  SELFTEST_OUT=$(CLAUDE_HOOK_SELFTEST=0 QUIET=0 bash "$0" --projects-dir "$TMP_DIR" 2>&1 || true)
+
+  PASS=0
+  FAIL=0
+
+  check_line() {
+    local pattern="$1" label="$2"
+    if echo "$SELFTEST_OUT" | grep -qE "$pattern"; then
+      echo "PASS: $label"
+      PASS=$((PASS + 1))
+    else
+      echo "FAIL: $label"
+      echo "  Expected pattern: $pattern"
+      echo "  Got output:"
+      echo "$SELFTEST_OUT" | sed 's/^/    /'
+      FAIL=$((FAIL + 1))
+    fi
+  }
+
+  # Case A: proj_ok must be reported as OK
+  check_line "^OK[[:space:]].*proj_ok" "proj_ok reported as OK"
+
+  # Case B: proj_missing must be reported as MISSING
+  check_line "^MISSING[[:space:]].*proj_missing" "proj_missing reported as MISSING"
+
+  # Case C: proj_notlang must be SKIP or absent (not OK/MISSING)
+  if echo "$SELFTEST_OUT" | grep -qE "^(OK|MISSING)[[:space:]].*proj_notlang"; then
+    echo "FAIL: proj_notlang should be SKIP or absent, not OK/MISSING"
+    FAIL=$((FAIL + 1))
+  else
+    echo "PASS: proj_notlang not reported as OK/MISSING (correct — no T-lang signature)"
+    PASS=$((PASS + 1))
+  fi
+
+  # Exit code: script must exit 1 when MISSING exists
+  # Use a subshell with explicit exit-code capture; avoid set -e propagation
+  EXIT_CODE=0
+  (CLAUDE_HOOK_SELFTEST=0 bash "$0" --projects-dir "$TMP_DIR" >/dev/null 2>&1) || EXIT_CODE=$?
+  if [[ "$EXIT_CODE" -eq 1 ]]; then
+    echo "PASS: script exits 1 when MISSING found"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: expected exit 1, got $EXIT_CODE"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # Exit code: script must exit 0 when all OK (only OK project present)
+  ONLY_OK_DIR=$(mktemp -d /tmp/tlang_ok_only_XXXXXX)
+  mkdir -p "$ONLY_OK_DIR/just_ok"
+  cp "$TMP_DIR/proj_ok/tproject.toml" "$ONLY_OK_DIR/just_ok/tproject.toml"
+  cp "$TMP_DIR/proj_ok/flake.nix"    "$ONLY_OK_DIR/just_ok/flake.nix"
+  EXIT_CODE_OK=0
+  (CLAUDE_HOOK_SELFTEST=0 bash "$0" --projects-dir "$ONLY_OK_DIR" >/dev/null 2>&1) || EXIT_CODE_OK=$?
+  rm -rf "$ONLY_OK_DIR"
+  if [[ "$EXIT_CODE_OK" -eq 0 ]]; then
+    echo "PASS: script exits 0 when all T-lang projects have the marker"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: expected exit 0, got $EXIT_CODE_OK"
+    FAIL=$((FAIL + 1))
+  fi
+
+  TOTAL=$((PASS + FAIL))
+  echo ""
+  echo "${PASS}/${TOTAL} PASS"
+  [[ "$FAIL" -eq 0 ]] && exit 0 || exit 1
+fi
+
+# ── Main detection logic ───────────────────────────────────────────────────────
+# The closure-rebuild marker is a comment inserted by default.post.sh.
+# We look for the literal string "Closure-rebuild" (case-sensitive) which
+# appears as a comment in the shellHook block added by default.post.sh.
+MARKER="Closure-rebuild"
+
+# T-lang signature: presence of tproject.toml alongside flake.nix
+# (the canonical T-lang project indicator).
+# Secondary check: flake.nix references tlang or t-lang in inputs.
+is_tlang_project() {
+  local dir="$1"
+  local flake="$dir/flake.nix"
+
+  # Must have a tproject.toml
+  [[ -f "$dir/tproject.toml" ]] || return 1
+
+  # Must have flake.nix
+  [[ -f "$flake" ]] || return 1
+
+  # flake.nix must reference t-lang or tlang in inputs (defensive double-check)
+  grep -qE '(t-lang|tlang)\.' "$flake" 2>/dev/null || return 1
+
+  return 0
+}
+
+has_marker() {
+  local flake="$1"
+  grep -q "$MARKER" "$flake" 2>/dev/null
+}
+
+# Expand ~ manually in case caller passed a literal tilde path
+PROJECTS_DIR="${PROJECTS_DIR/#\~/$HOME}"
+
+if [[ ! -d "$PROJECTS_DIR" ]]; then
+  echo "ERROR: projects dir not found: $PROJECTS_DIR" >&2
+  exit 1
+fi
+
+EXIT_CODE=0
+
+# Scan one level deep under PROJECTS_DIR
+for candidate in "$PROJECTS_DIR"/*/; do
+  [[ -d "$candidate" ]] || continue
+
+  # Strip trailing slash for cleaner output
+  project="${candidate%/}"
+
+  flake="$project/flake.nix"
+
+  # No flake.nix → not a nix project at all; skip silently
+  [[ -f "$flake" ]] || continue
+
+  if ! is_tlang_project "$project"; then
+    # Has flake.nix but no T-lang signature
+    [[ "$QUIET" -eq 0 ]] && echo "SKIP    $project"
+    continue
+  fi
+
+  if has_marker "$flake"; then
+    [[ "$QUIET" -eq 0 ]] && echo "OK      $project"
+  else
+    echo "MISSING $project"
+    EXIT_CODE=1
+  fi
+done
+
+exit "$EXIT_CODE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,28 @@ launchctl unload ~/Library/LaunchAgents/com.claude.roborev-daily-backlog.plist
 launchctl load ~/Library/LaunchAgents/com.claude.roborev-daily-backlog.plist
 # repeat for each updated plist
 ```
+## 2026-05-31 (#303 — local-side guard for T-lang closure-rebuild marker)
+
+Ships the detection half of issue #303. `t update` regenerates `flake.nix`
+wholesale and strips the closure-rebuild shellHook (the nix-nested-shell-isolation
+fix). Without it, R compiled packages segfault on dyn.load at the next
+`nix develop` entry.
+
+- `.claude/scripts/check_tlang_flake_closure_rebuild.sh` — new detection script.
+  Scans `~/docs_gh/*/` for T-lang R projects (tproject.toml + tlang input) and
+  reports OK / MISSING / SKIP per project. Self-test mode (5/5 PASS):
+  `CLAUDE_HOOK_SELFTEST=1 bash check_tlang_flake_closure_rebuild.sh`.
+- `session_init.sh` Phase 14a — advisory check wired in; runs with 5-second
+  timeout in --quiet mode; emits WARN if any MISSING but does NOT block startup.
+- `.claude/rules/t-lang-r-package.md` — new "Periodic Detection" section
+  documenting the script, its output codes, and the session-init integration.
+
+Upstream OCaml template fix remains tracked in llm#303 / b-rodrigues/tlang.
+Until the template is updated, `default.post.sh` is the per-project fallback
+and the new session-init check ensures a missing marker is caught at session start.
+
+Real-world scan result: `historical` OK (marker present); no MISSING projects
+currently. `llama.cpp` correctly SKIP (has flake.nix, no T-lang signature).
 
 ## 2026-05-30 (Stage 1 #195 — archive one-off MDs + remove stray artifacts)
 


### PR DESCRIPTION
## Summary

Closes the local-side scope of #303. Adds an automated session-start detector that warns when any T-lang R project under `~/docs_gh/` has lost the closure-rebuild marker from `flake.nix` (the nix-nested-shell-isolation fix from `historical#211`).

Upstream T-lang template fix (b-rodrigues/tlang) remains the proper solution and is tracked separately. This PR makes the **local detection automatic** so a missing marker can't reach production without a session-start warning.

## Ships

- **`.claude/scripts/check_tlang_flake_closure_rebuild.sh`** — detects T-lang R projects (tproject.toml + tlang ref in flake.nix), checks each for the `Closure-rebuild` marker. Exit 0 = all OK, exit 1 = any MISSING. Flags: `--quiet`, `--projects-dir`. Self-test 5/5 PASS.
- **`.claude/hooks/session_init.sh`** — new Phase 14a advisory check (5s timeout, non-blocking warning).
- **`.claude/rules/t-lang-r-package.md`** — section documenting the new check and self-test invocation.
- **CHANGELOG.md** — top entry.

## Real-world scan

```
OK     /Users/johngavin/docs_gh/historical
SKIP   /Users/johngavin/docs_gh/llama.cpp
exit 0
```

No MISSING projects right now — but the next `t update` in any T-lang R repo will get caught.

## Test plan

- [x] Selftest 5/5 PASS (OK / MISSING / SKIP / exit-code cases)
- [x] Real-world scan exit 0
- [x] session_init phase non-blocking (5s timeout)
- [ ] Post-merge: verify the WARN fires in a fresh session if a T-lang project loses the marker (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
