### PR TITLE
feat(#376): credential tier split + incident-response skeleton

### DIFF
--- a/.claude/credential_tiers.toml.example
+++ b/.claude/credential_tiers.toml.example
@@ -1,0 +1,36 @@
+# credential_tiers.toml.example — Template for two-vault credential split.
+#
+# PURPOSE: Separates credentials into two tiers:
+#   auto — agent may use without prompting the user
+#   ask  — requires explicit human confirmation before each use
+#
+# SETUP:
+#   1. Copy this file to ~/.claude/credential_tiers.toml
+#   2. Edit the lists to match your actual .Renviron / environment variables
+#   3. The real file is gitignored — never commit it
+#
+# See JohnGavin/llm#376.
+
+# ── auto tier ────────────────────────────────────────────────────────────────
+# Credentials safe for automated/agent use: read-only or low-blast-radius.
+# Examples: read-only tokens, local DB paths, non-secret config.
+[auto]
+keys = [
+  "GITHUB_TOKEN_READ",
+  "ROBOREV_DB_PATH",
+  "NTFY_TOPIC",
+]
+
+# ── ask tier ─────────────────────────────────────────────────────────────────
+# Credentials requiring human confirmation: write-capable, billing-gated,
+# or high blast-radius (API keys that can spend money or modify prod).
+# Examples: LLM API keys, write-capable GitHub tokens, email credentials.
+[ask]
+keys = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GITHUB_TOKEN",
+  "GITHUB_TOKEN_WRITE",
+  "GMAIL_USERNAME",
+  "GMAIL_APP_PASSWORD",
+]

--- a/.claude/hooks/permission_request.sh
+++ b/.claude/hooks/permission_request.sh
@@ -7,6 +7,13 @@
 # Guard design: python3 temp file reads FULL command — no truncation, no grep -P.
 # Fixes: 120-char bypass, broken [\n] regex, BSD-grep grep -P (issue #181 Theme 1).
 # Additional: output redirect > / >>, find -delete / -exec auto-approve gaps.
+#
+# Credential tier check (JohnGavin/llm#376):
+#   Additive layer after the main guard. When a Bash command references an env-var
+#   that appears in the [ask] tier of ~/.claude/credential_tiers.toml, the hook
+#   emits a visible "ASK-VAULT CONFIRMATION REQUIRED" warning to stderr before
+#   falling through to the normal human-approval prompt.
+#   Uses .claude/scripts/credential_tier_lookup.sh — tolerates its absence.
 
 set -euo pipefail
 
@@ -331,6 +338,38 @@ if [ "$_tool" = "Bash" ]; then
   esac
   # Rscript REMOVED from auto-approve: can execute arbitrary fs/network/process ops.
   # Require human approval for every Rscript call (see Finding 2 in issue #181).
+fi
+
+# ── Credential tier check (additive, JohnGavin/llm#376) ───────────────
+# Scan the command for env-var patterns (Sys.getenv("VAR"), $VAR, ${VAR}).
+# For each candidate name, look it up via credential_tier_lookup.sh.
+# If any name is in the [ask] tier, emit a warning to stderr and continue
+# to the normal human-approval prompt below — this does NOT auto-deny.
+# Tolerates: missing lookup script, missing tier file, lookup errors.
+_TIER_LOOKUP_SCRIPT="$(dirname "$0")/../scripts/credential_tier_lookup.sh"
+if [ -f "$_TIER_LOOKUP_SCRIPT" ] && [ "$_guard" != "UNSAFE:"* ] 2>/dev/null; then
+  # Extract candidate var names from the action log (truncated to 200 chars by python).
+  # Patterns matched: Sys.getenv("VAR"), $VAR, ${VAR}
+  _cred_candidates=$(printf '%s' "$_action_log" | \
+    grep -oE 'Sys\.getenv\("([A-Z_][A-Z0-9_]*)"\)|\$\{?([A-Z_][A-Z0-9_]*)' | \
+    grep -oE '[A-Z_][A-Z0-9_]+' | sort -u || true)
+
+  _ask_vars=""
+  for _cvar in $_cred_candidates; do
+    _tier=$(bash "$_TIER_LOOKUP_SCRIPT" "$_cvar" 2>/dev/null || true)
+    if [ "$_tier" = "ask" ]; then
+      _ask_vars="${_ask_vars} ${_cvar}"
+    fi
+  done
+
+  if [ -n "$_ask_vars" ]; then
+    log "ASK-VAULT: ask-tier credentials referenced:${_ask_vars} -- action=$_action_log"
+    # Write a prominent warning to stderr (visible in the permission prompt UI)
+    printf '\n⚠️  ASK-VAULT CONFIRMATION REQUIRED\n' >&2
+    printf '   Ask-tier credential(s) referenced:%s\n' "$_ask_vars" >&2
+    printf '   These are in the [ask] tier of ~/.claude/credential_tiers.toml.\n' >&2
+    printf '   Confirm you intend to allow agent use of these credentials.\n\n' >&2
+  fi
 fi
 
 # ── Needs human approval: notify and fall through ─────────────────────

--- a/.claude/scripts/credential_tier_lookup.sh
+++ b/.claude/scripts/credential_tier_lookup.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# credential_tier_lookup.sh — Look up a credential env-var name in the two-vault tier file.
+#
+# Usage:
+#   credential_tier_lookup.sh <VAR_NAME>
+#
+# Output:
+#   Prints "auto"    (exit 0) if VAR_NAME is in the [auto] tier
+#   Prints "ask"     (exit 0) if VAR_NAME is in the [ask] tier
+#   Prints "unknown" (exit 1) if VAR_NAME is not found in any tier
+#
+# Tier file lookup order:
+#   1. $CREDENTIAL_TIERS_FILE env var (used in tests to inject a fixture file)
+#   2. ~/.claude/credential_tiers.toml
+#   3. Falls back to the .example file in the same directory as this script
+#      (development / first-run convenience — not a security fallback)
+#
+# Self-test:
+#   CLAUDE_HOOK_SELFTEST=1 bash credential_tier_lookup.sh
+#
+# See JohnGavin/llm#376.
+
+set -euo pipefail
+
+# ── Locate the tier file ─────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_TIER_FILE="$HOME/.claude/credential_tiers.toml"
+EXAMPLE_TIER_FILE="$SCRIPT_DIR/../credential_tiers.toml.example"
+
+if [ -n "${CREDENTIAL_TIERS_FILE:-}" ]; then
+  TIER_FILE="$CREDENTIAL_TIERS_FILE"
+elif [ -f "$DEFAULT_TIER_FILE" ]; then
+  TIER_FILE="$DEFAULT_TIER_FILE"
+elif [ -f "$EXAMPLE_TIER_FILE" ]; then
+  TIER_FILE="$EXAMPLE_TIER_FILE"
+else
+  # No tier file found — treat everything as unknown (do not block, let hook decide)
+  printf 'unknown\n'
+  exit 1
+fi
+
+# ── Self-test mode ───────────────────────────────────────────────────────────
+# Accept both CREDENTIAL_TIER_LOOKUP_SELFTEST and CLAUDE_HOOK_SELFTEST
+_SELFTEST="${CREDENTIAL_TIER_LOOKUP_SELFTEST:-${CLAUDE_HOOK_SELFTEST:-0}}"
+if [ "$_SELFTEST" = "1" ]; then
+  # Create a temporary fixture toml for self-test
+  _fixture=$(mktemp /tmp/cred_tier_fixture_XXXXXX.toml)
+  trap 'rm -f "$_fixture"' EXIT
+
+  cat > "$_fixture" << 'TOML_EOF'
+[auto]
+keys = ["GITHUB_TOKEN_READ", "ROBOREV_DB_PATH"]
+
+[ask]
+keys = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GITHUB_TOKEN_WRITE"]
+TOML_EOF
+
+  _pass=0
+  _fail=0
+  SCRIPT_PATH="$(realpath "$0")"
+
+  _run_lookup() {
+    local var="$1"
+    CREDENTIAL_TIER_LOOKUP_SELFTEST=0 \
+    CREDENTIAL_TIERS_FILE="$_fixture" \
+    bash "$SCRIPT_PATH" "$var" 2>/dev/null || true
+  }
+
+  _check_tier() {
+    local desc="$1" var="$2" expected="$3"
+    local got exit_code=0
+    got=$(CREDENTIAL_TIER_LOOKUP_SELFTEST=0 \
+          CREDENTIAL_TIERS_FILE="$_fixture" \
+          bash "$SCRIPT_PATH" "$var" 2>/dev/null) || exit_code=$?
+
+    if [ "$got" = "$expected" ]; then
+      printf '  PASS  [%s] → %s\n' "$desc" "$got"
+      _pass=$((_pass + 1))
+    else
+      printf '  FAIL  [%s] expected=%s got=%s\n' "$desc" "$expected" "$got"
+      _fail=$((_fail + 1))
+    fi
+  }
+
+  # Also test exit codes
+  _check_exit() {
+    local desc="$1" var="$2" expected_exit="$3"
+    local exit_code=0
+    CREDENTIAL_TIER_LOOKUP_SELFTEST=0 \
+    CREDENTIAL_TIERS_FILE="$_fixture" \
+    bash "$SCRIPT_PATH" "$var" > /dev/null 2>&1 || exit_code=$?
+    if [ "$exit_code" = "$expected_exit" ]; then
+      printf '  PASS  [%s exit=%s]\n' "$desc" "$exit_code"
+      _pass=$((_pass + 1))
+    else
+      printf '  FAIL  [%s] expected exit=%s got exit=%s\n' "$desc" "$expected_exit" "$exit_code"
+      _fail=$((_fail + 1))
+    fi
+  }
+
+  echo "=== credential_tier_lookup.sh self-test ==="
+
+  _check_tier  "auto key GITHUB_TOKEN_READ"    "GITHUB_TOKEN_READ"  "auto"
+  _check_tier  "auto key ROBOREV_DB_PATH"      "ROBOREV_DB_PATH"    "auto"
+  _check_tier  "ask key ANTHROPIC_API_KEY"     "ANTHROPIC_API_KEY"  "ask"
+  _check_tier  "ask key OPENAI_API_KEY"        "OPENAI_API_KEY"     "ask"
+  _check_tier  "ask key GITHUB_TOKEN_WRITE"    "GITHUB_TOKEN_WRITE" "ask"
+  _check_tier  "unknown key SOME_OTHER_VAR"    "SOME_OTHER_VAR"     "unknown"
+
+  _check_exit  "auto exits 0"    "GITHUB_TOKEN_READ"  "0"
+  _check_exit  "ask exits 0"     "ANTHROPIC_API_KEY"  "0"
+  _check_exit  "unknown exits 1" "SOME_OTHER_VAR"      "1"
+
+  echo "=== Results: $_pass passed, $_fail failed (9 total) ==="
+  [ "$_fail" -eq 0 ] && exit 0 || exit 1
+fi
+
+# ── Main lookup logic ────────────────────────────────────────────────────────
+VAR_NAME="${1:-}"
+if [ -z "$VAR_NAME" ]; then
+  printf 'Usage: %s <VAR_NAME>\n' "$(basename "$0")" >&2
+  exit 2
+fi
+
+# Parse the TOML file with pure shell.
+# The tier file uses a simple format: [section] headers and keys = [...] arrays.
+# We do NOT use a TOML parser — we match the exact structure produced by
+# credential_tiers.toml.example so the logic stays shell-portable.
+#
+# Strategy: scan lines for the current section header, then look for VAR_NAME
+# inside quoted strings on keys = [...] lines (possibly multi-line arrays).
+
+_current_section=""
+_in_array=0
+_found_tier=""
+
+while IFS= read -r line; do
+  # Strip leading/trailing whitespace
+  line="${line#"${line%%[! ]*}"}"
+  line="${line%"${line##*[! ]}"}"
+
+  # Skip blank lines and comments
+  case "$line" in
+    ""|\#*) continue ;;
+  esac
+
+  # Section header: [auto] or [ask]
+  if printf '%s' "$line" | grep -qE '^\[[a-zA-Z_]+\]$'; then
+    _current_section="${line#[}"
+    _current_section="${_current_section%]}"
+    _in_array=0
+    continue
+  fi
+
+  # Start of keys array: keys = [...]
+  if printf '%s' "$line" | grep -qE '^keys[[:space:]]*='; then
+    _in_array=1
+  fi
+
+  # Once we are in an array (or on the keys = line itself), scan for VAR_NAME
+  if [ "$_in_array" = "1" ]; then
+    # Check if VAR_NAME appears as a quoted string on this line
+    if printf '%s' "$line" | grep -qE "\"$VAR_NAME\""; then
+      _found_tier="$_current_section"
+      break
+    fi
+    # End of array on this line (closing ])
+    if printf '%s' "$line" | grep -q ']'; then
+      _in_array=0
+    fi
+  fi
+done < "$TIER_FILE"
+
+if [ -n "$_found_tier" ]; then
+  printf '%s\n' "$_found_tier"
+  exit 0
+else
+  printf 'unknown\n'
+  exit 1
+fi

--- a/.claude/scripts/incident_response.sh
+++ b/.claude/scripts/incident_response.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# incident_response.sh — Credential incident response SKELETON (DRY-RUN ONLY)
+#
+# PURPOSE
+#   Guides a human through the steps needed to revoke and rotate credentials
+#   after a suspected leak. This version prints rotation URLs and commands
+#   WITHOUT calling them — it is purely informational.
+#
+# STATUS: SKELETON — DRY-RUN ONLY
+#   Live credential revocation logic (API calls, automated rotation) is
+#   intentionally absent from this file and will be added in a follow-up PR.
+#   The only action this script takes is logging and printing instructions.
+#
+# SAFETY CONSTRAINTS (all enforced at runtime, not by convention):
+#   1. DRY_RUN is hard-coded to "true" — it can only be changed by editing
+#      this file (there is no --no-dry-run flag).
+#   2. Refuses to run if CLAUDE_AGENT=1 is set (human-only).
+#   3. Requires INCIDENT_CONFIRM="I AM ROTATING CREDENTIALS" — anything else
+#      aborts immediately.
+#   4. All invocations are logged to ~/.claude/logs/incident_response.log.
+#   5. macOS alert fires only with --alert flag (prevents alarm during tests).
+#
+# USAGE (human-only, from terminal — NOT from Claude Code):
+#   INCIDENT_CONFIRM="I AM ROTATING CREDENTIALS" bash incident_response.sh [--alert]
+#
+# TESTING (dry-run output only, no side effects):
+#   INCIDENT_CONFIRM="I AM ROTATING CREDENTIALS" bash incident_response.sh
+#
+# See JohnGavin/llm#376.
+
+set -euo pipefail
+
+# ── Hard-coded safety switches ───────────────────────────────────────────────
+# DRY_RUN can ONLY be set to false by editing this file.
+# There is no flag or env-var override — this is intentional.
+DRY_RUN=true
+readonly DRY_RUN
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+LOG_DIR="$HOME/.claude/logs"
+LOG_FILE="$LOG_DIR/incident_response.log"
+mkdir -p "$LOG_DIR"
+
+log() {
+  local level="$1"; shift
+  printf '%s [%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$level" "$*" | tee -a "$LOG_FILE"
+}
+
+log_only() {
+  local level="$1"; shift
+  printf '%s [%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$level" "$*" >> "$LOG_FILE"
+}
+
+# ── Parse flags ──────────────────────────────────────────────────────────────
+_ALERT=false
+for _arg in "$@"; do
+  case "$_arg" in
+    --alert) _ALERT=true ;;
+    *) printf 'Unknown flag: %s\n' "$_arg" >&2; exit 2 ;;
+  esac
+done
+
+# ── Log every invocation (before any checks) ─────────────────────────────────
+log_only "INVOKE" "invoked: user=${USER:-unknown} pid=$$ dry_run=$DRY_RUN agent=${CLAUDE_AGENT:-0} alert=$_ALERT"
+
+# ── Guard: agent context ─────────────────────────────────────────────────────
+if [ "${CLAUDE_AGENT:-0}" = "1" ]; then
+  log "ABORT" "CLAUDE_AGENT=1 detected — this script is human-only. Refusing to run."
+  exit 1
+fi
+
+# ── Guard: confirmation phrase ───────────────────────────────────────────────
+_REQUIRED_PHRASE="I AM ROTATING CREDENTIALS"
+_PROVIDED="${INCIDENT_CONFIRM:-}"
+
+if [ "$_PROVIDED" != "$_REQUIRED_PHRASE" ]; then
+  log "ABORT" "confirmation phrase missing or incorrect. Provide: INCIDENT_CONFIRM=\"$_REQUIRED_PHRASE\""
+  printf '\nTo run this script, set:\n' >&2
+  printf '  INCIDENT_CONFIRM="%s" bash %s\n\n' "$_REQUIRED_PHRASE" "$(basename "$0")" >&2
+  exit 1
+fi
+
+log "CONFIRMED" "phrase accepted, proceeding (dry_run=$DRY_RUN)"
+
+# ── Optional macOS alert ──────────────────────────────────────────────────────
+if [ "$_ALERT" = "true" ]; then
+  osascript -e 'display alert "CREDENTIAL INCIDENT RESPONSE" message "Running incident_response.sh — check terminal." as critical' 2>/dev/null || true
+fi
+
+# ── Dry-run banner ───────────────────────────────────────────────────────────
+printf '\n'
+printf '═══════════════════════════════════════════════════════════════════\n'
+printf '  INCIDENT RESPONSE — DRY-RUN MODE\n'
+printf '  No API calls, no revocations, no mutations.\n'
+printf '  Review the steps below and execute them manually.\n'
+printf '═══════════════════════════════════════════════════════════════════\n\n'
+
+# ── Step 1: GitHub token rotation ────────────────────────────────────────────
+printf '── Step 1: GitHub Personal Access Tokens ──────────────────────────\n'
+printf 'Revoke ALL active tokens:\n'
+printf '  URL: https://github.com/settings/tokens\n'
+printf '  Action: Identify tokens named GITHUB_TOKEN / GITHUB_TOKEN_READ / GITHUB_TOKEN_WRITE\n'
+printf '          Click "Delete" on each.\n'
+printf 'Create replacement tokens:\n'
+printf '  URL: https://github.com/settings/personal-access-tokens/new\n'
+printf '  Action: Create new tokens with minimum required scopes.\n'
+printf '          For read-only CI: contents:read, metadata:read\n'
+printf '          For write CI: contents:write, pull_requests:write\n'
+printf 'Update .Renviron:\n'
+printf '  GITHUB_TOKEN_READ=<new-read-token>\n'
+printf '  GITHUB_TOKEN_WRITE=<new-write-token>\n'
+printf '  GITHUB_TOKEN=<new-token>\n\n'
+
+log "DRY-RUN" "Step 1 printed (GitHub token rotation)"
+
+# ── Step 2: Anthropic API key rotation ───────────────────────────────────────
+printf '── Step 2: Anthropic API Key ───────────────────────────────────────\n'
+printf 'Revoke current key:\n'
+printf '  URL: https://console.anthropic.com/account/keys\n'
+printf '  Action: Locate active key(s), click "Revoke".\n'
+printf 'Create replacement key:\n'
+printf '  URL: https://console.anthropic.com/account/keys\n'
+printf '  Action: "Create Key", copy immediately (shown only once).\n'
+printf 'Update .Renviron:\n'
+printf '  ANTHROPIC_API_KEY=<new-key>\n\n'
+
+log "DRY-RUN" "Step 2 printed (Anthropic API key rotation)"
+
+# ── Step 3: OpenAI API key rotation ──────────────────────────────────────────
+printf '── Step 3: OpenAI API Key ──────────────────────────────────────────\n'
+printf 'Revoke current key:\n'
+printf '  URL: https://platform.openai.com/api-keys\n'
+printf '  Action: Locate active key(s), click "Revoke".\n'
+printf 'Create replacement key:\n'
+printf '  URL: https://platform.openai.com/api-keys\n'
+printf '  Action: "+ Create new secret key", copy immediately.\n'
+printf 'Update .Renviron:\n'
+printf '  OPENAI_API_KEY=<new-key>\n\n'
+
+log "DRY-RUN" "Step 3 printed (OpenAI API key rotation)"
+
+# ── Step 4: Gmail app password rotation ──────────────────────────────────────
+printf '── Step 4: Gmail App Password ──────────────────────────────────────\n'
+printf 'Revoke current app password:\n'
+printf '  URL: https://myaccount.google.com/apppasswords\n'
+printf '  Action: Delete the "Claude Code" or relevant app password.\n'
+printf 'Create replacement:\n'
+printf '  URL: https://myaccount.google.com/apppasswords\n'
+printf '  Action: Generate a new app password for "Mail" / "Other".\n'
+printf 'Update .Renviron:\n'
+printf '  GMAIL_APP_PASSWORD=<new-app-password>\n\n'
+
+log "DRY-RUN" "Step 4 printed (Gmail app password rotation)"
+
+# ── Step 5: Post-rotation verification ───────────────────────────────────────
+printf '── Step 5: Verification ────────────────────────────────────────────\n'
+printf 'After updating .Renviron, restart Claude Code and verify:\n'
+printf '  bash ~/.claude/scripts/credential_tier_lookup.sh ANTHROPIC_API_KEY\n'
+printf '  # Expected output: ask\n'
+printf 'Test that the new keys work:\n'
+printf '  gh auth status  # GitHub\n'
+printf '  Rscript -e '"'"'cat(nchar(Sys.getenv("ANTHROPIC_API_KEY")), "chars\n")'"'"'\n\n'
+
+log "DRY-RUN" "Step 5 printed (post-rotation verification)"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+printf '═══════════════════════════════════════════════════════════════════\n'
+printf '  DRY-RUN COMPLETE. No credentials were modified.\n'
+printf '  Log: %s\n' "$LOG_FILE"
+printf '═══════════════════════════════════════════════════════════════════\n\n'
+
+log "COMPLETE" "dry-run finished — 4 providers printed, no mutations"

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,7 @@ explorations/*
 # trusted-contributors.txt is NOT excluded — it is source-controlled.
 .claude/state/untrusted-comments.log
 .claude/state/untrusted-comment-pending
+
+# Credential tier file (real one lives at ~/.claude/credential_tiers.toml — JohnGavin/llm#376)
+# The .example template is tracked; the real file with actual key names is not.
+.claude/credential_tiers.toml


### PR DESCRIPTION
## Summary

Implements #376 Part A (credential tier split + permission_request hook extension) and **Part B in DRY-RUN-ONLY skeleton form** (incident response script that refuses to run destructively). Live revocation logic deferred to a follow-up PR — this PR ships the structure and the safety guards.

## Ships

### Part A — Two-vault credential split

- **`.claude/credential_tiers.toml.example`** — template (`[auto]` + `[ask]` sections). The real file lives at `~/.claude/credential_tiers.toml` (gitignored).
- **`.claude/scripts/credential_tier_lookup.sh`** — helper: takes env-var name, prints `auto` / `ask` / `unknown`, exits 0/0/1. Selftest 9/9 PASS.
- **`.claude/hooks/permission_request.sh`** — additive ask-tier check (no regressions; pre-existing 5 self-test failures unchanged from HEAD).
- **`.gitignore`** — entry for the real `credential_tiers.toml`.

### Part B — Incident response SKELETON

- **`.claude/scripts/incident_response.sh`** — DRY-RUN-only by hard-coded constant. Three independent guards:
  1. Refuses if `CLAUDE_AGENT=1` (human-only operation)
  2. Refuses without exact `INCIDENT_CONFIRM="I AM ROTATING CREDENTIALS"` env var
  3. Even with both guards satisfied, prints rotation URLs/commands; does NOT call them
  - Logs every invocation to `~/.claude/logs/incident_response.log`
  - `--alert` flag for macOS notification (optional)

## Test plan

- [x] `credential_tier_lookup.sh` selftest 9/9 PASS
- [x] `incident_response.sh` with wrong confirm phrase → exit 1
- [x] `incident_response.sh` with `CLAUDE_AGENT=1` → exit 1 (refuses agent context)
- [x] `incident_response.sh` with both guards satisfied → dry-run output, logged, nothing destructive
- [x] permission_request.sh: 23/28 PASS (5 pre-existing failures unchanged)
- [ ] Post-merge: copy `credential_tiers.toml.example` → `~/.claude/credential_tiers.toml`, classify real keys

## Follow-up

- Live revocation logic per provider (GitHub, Anthropic, OpenAI, …)
- Automated key rotation where API supports it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
