### PR TITLE
ci: bump GH actions off Node 20 before Node 24 default (2026-06-02)

### DIFF
--- a/.github/workflows/quarto-publish.yaml
+++ b/.github/workflows/quarto-publish.yaml
@@ -37,7 +37,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/vignette-validation.yml
+++ b/.github/workflows/vignette-validation.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Check for vignettes
         id: check-vignettes
@@ -42,7 +42,7 @@ jobs:
 
       - name: Setup Cachix
         if: steps.check-vignettes.outputs.has_vignettes == 'true'
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v17
         with:
           name: rstats-on-nix
           extraPullNames: johngavin

--- a/.github/workflows/wiki-sync-check.yaml
+++ b/.github/workflows/wiki-sync-check.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
## Summary

Closes #281. Audited all three workflows for Node-20-based actions ahead of the 2026-06-02 GitHub Actions runner change that forces Node 24 as the default runtime (Node 20 removed September 2026).

### Findings — full action audit

| Action | File(s) | Was | Now | Why |
|---|---|---|---|---|
| `cachix/cachix-action` | `vignette-validation.yml` | `@v15` (Node 20) | **`@v17`** (Node 24) | **Required** — v15/v16 run on Node 20; v17 is the first Node 24 release (2025-03-18) |
| `actions/checkout` | all three workflows | `@v5` (Node 24) | **`@v6`** (Node 24) | Clean-up — v5 already uses Node 24 but v6 (v6.0.2) is the latest Node-24-compatible major |

### Actions already on Node 24 — no changes needed

| Action | Pinned to | Status |
|---|---|---|
| `actions/upload-pages-artifact` | `@v5` | Composite action; internally calls `upload-artifact@7.0.0` (Node 24) |
| `actions/deploy-pages` | `@v5` | Node 24 since v5.0.0 (2026-03-25) |
| `r-lib/actions/{setup-r,setup-pandoc,setup-r-dependencies}` | `@v2` (sliding) | Node 24 since v2.12.0 (2026-04-30); `@v2` tag slides forward |
| `quarto-dev/quarto-actions/setup` | `@v2` | Composite action — no Node.js runtime |
| `DeterminateSystems/nix-installer-action` | `@main` | Pinned to HEAD, always latest |

### Notes on checkout v6

`actions/checkout@v6.0.0` changed credential-persistence defaults (credentials are no longer persisted in git config by default). The three workflows in this repo do not perform authenticated git operations after checkout, so this change is safe:
- `quarto-publish.yaml` — reads + renders; deploy handled by `actions/deploy-pages`
- `vignette-validation.yml` — reads + validates only
- `wiki-sync-check.yaml` — reads + compares only

## Test plan

- [ ] Quarto Publish workflow runs clean on merge to main
- [ ] Vignette Validation workflow (reusable, invoked by callers) no longer emits Node 20 deprecation warnings for `cachix-action`
- [ ] Wiki Sync Check workflow runs clean

Refs #281

---
_Generated by [Claude Code](https://claude.ai/code/session_019EbwasoWym7UUbqdiGXMfc)_