### PR TITLE
fix(#424 follow-up): stable age-check via locked-file mtime

### DIFF
--- a/.claude/scripts/clean-stale-worktrees.sh
+++ b/.claude/scripts/clean-stale-worktrees.sh
@@ -136,7 +136,13 @@ evaluate_worktree() {
         # No parseable PID — fall through to age check (best-effort)
     fi
 
-    # Guard 5: Age check using stat -f '%m' (BSD/macOS mtime)
+    # Guard 5: Age check.
+    # PREFER the locked file's mtime over the meta-dir mtime — the meta-dir
+    # gets bumped by routine `git status` calls (including this script's own
+    # Guard 6 below), making the dir mtime worthless for distinguishing
+    # actually-stale worktrees from ones we just probed. The `locked` file
+    # only changes when the worktree is (un)locked, which is a meaningful
+    # signal of "last real activity". Fall back to dir mtime if no lock file.
     local GITDIR_FOR_WT="${GIT_COMMON_DIR}/worktrees/${WT_NAME}"
     if [ ! -d "$GITDIR_FOR_WT" ]; then
         printf 'SKIP no-gitdir-metadata'
@@ -144,7 +150,11 @@ evaluate_worktree() {
     fi
 
     local WT_MTIME
-    WT_MTIME=$(stat -f '%m' "$GITDIR_FOR_WT" 2>/dev/null || printf '0')
+    if [ -f "${GITDIR_FOR_WT}/locked" ]; then
+        WT_MTIME=$(stat -f '%m' "${GITDIR_FOR_WT}/locked" 2>/dev/null || printf '0')
+    else
+        WT_MTIME=$(stat -f '%m' "$GITDIR_FOR_WT" 2>/dev/null || printf '0')
+    fi
     local WT_AGE=$(( NOW - WT_MTIME ))
 
     if [ "$WT_AGE" -lt "$AGE_SEC" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ Cumulative lab notes. Track completed work, **failed approaches**, accuracy chec
 
 Convention: newest entries at top. Each entry has a date, what was done, and why.
 
+## 2026-06-02 (#424 follow-up — stable age-check via locked-file mtime)
+
+Bug discovered during the first live sweep: the age-check in `clean-stale-worktrees.sh`
+Guard 5 was using the meta-dir mtime (`.git/worktrees/agent-X/`), but that mtime gets
+bumped by routine `git status` calls — including the script's own Guard 6 probe.
+Net effect: running the script touched every worktree's meta-dir mtime, so a follow-up
+invocation minutes later saw every candidate as "too-recent" and skipped everything.
+The script was effectively self-defeating.
+
+Fix: prefer the `locked` file's mtime over the meta-dir mtime. The locked file only
+changes on actual (un)lock operations — a meaningful proxy for "last real activity".
+Falls back to dir mtime only when no lock file exists (e.g. an unlocked worktree).
+
+Evidence: with the original Guard 5, a live `--sweep --age=1d` removed 0 worktrees
+right after a dry-run reported 81 candidates. With the patched Guard 5, the same
+command removed 118 worktrees cleanly (historical 27, micromort 23, llm 51,
+llmtelemetry 17). Selftest 6/6 PASS across 3 consecutive runs.
+
 ## 2026-06-02 (#389 — commit_reference_rate trend tracker)
 
 Adds a leading-indicator pipeline for measuring adoption of the #359 commit-msg


### PR DESCRIPTION
## Summary

Follow-up to #425 / #424. Fixes the **self-defeating age-check bug** discovered during today's first real-world sweep.

## The bug

Guard 5 in `clean-stale-worktrees.sh` used the meta-dir mtime (`.git/worktrees/agent-X/`) to measure how stale a worktree is. But that mtime gets bumped by routine `git status` calls — including the script's own Guard 6 probe (the uncommitted-changes check). So:

- Run the dry-run → script calls `git status` on every candidate → every meta-dir mtime is now NOW
- Run the live sweep minutes later → all candidates appear "too-recent" (ages of 26-59 seconds) → 0 actual removals

Concretely today: `--sweep --age=1d` dry-run reported 81 candidates; the immediate live run removed 0. Script was self-defeating.

## The fix

Prefer the `locked` file's mtime over the meta-dir mtime. The `locked` file only changes when the worktree is actually (un)locked — a meaningful proxy for "last real activity" that routine git probing doesn't disturb. Falls back to dir mtime only when no lock file exists (e.g. unlocked worktrees).

```diff
-    local WT_MTIME
-    WT_MTIME=$(stat -f '%m' "$GITDIR_FOR_WT" 2>/dev/null || printf '0')
+    local WT_MTIME
+    if [ -f "${GITDIR_FOR_WT}/locked" ]; then
+        WT_MTIME=$(stat -f '%m' "${GITDIR_FOR_WT}/locked" 2>/dev/null || printf '0')
+    else
+        WT_MTIME=$(stat -f '%m' "$GITDIR_FOR_WT" 2>/dev/null || printf '0')
+    fi
```

## Evidence

With the patched Guard 5, the same `--sweep --age=1d` invocation that originally removed 0 worktrees now cleanly removes **118 worktrees** across 4 projects:

| Project | Removed | Skipped |
|---|---|---|
| historical | 27 | 20 |
| micromort | 23 | 5 |
| llm | 51 | 14 |
| llmtelemetry | 17 | 3 |
| premortem | 0 | 8 (no locked files — fallback path) |
| **Total** | **118** | **50** |

0 failures.

## Test plan

- [x] Selftest 6/6 PASS across **3 consecutive runs** (verified reliability — first single-run flake earlier was a transient `git worktree add` lock-file race that the patched logic now handles correctly)
- [x] Existing tests cover the no-locked-file fallback path (their fixtures don't create locked files; `git worktree add` doesn't either)
- [x] Real-world sweep removed 118 stale worktrees, 0 failures
- [ ] Post-merge: confirm the previously-stuck cleanup loop now works end-to-end on next run

## Related

- #424 — parent issue
- PR #425 — original implementation
- Part C (deferred follow-up to #424) — auto-GC at 14d in session_init Phase 7; this bug-fix is a prerequisite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
