### PR TITLE
fix(#433): strip surrounding quotes in env-file loaders (4 scripts)

### DIFF
--- a/.claude/scripts/cc-worktree.sh
+++ b/.claude/scripts/cc-worktree.sh
@@ -77,6 +77,9 @@ if [ "$VALIDATE_CONFIG" = "1" ]; then
         # Trim whitespace
         CONF_NAME="${CONF_NAME## }"; CONF_NAME="${CONF_NAME%% }"
         CONF_PATH="${CONF_PATH## }"; CONF_PATH="${CONF_PATH%% }"
+        # Strip one layer of surrounding quotes (handles KEY="value" style env files)
+        CONF_PATH="${CONF_PATH#\"}"; CONF_PATH="${CONF_PATH%\"}"
+        CONF_PATH="${CONF_PATH#\'}"; CONF_PATH="${CONF_PATH%\'}"
         if [ -d "$CONF_PATH/.git" ] || [ -f "$CONF_PATH/.git" ]; then
             printf 'OK     %-25s %s\n' "$CONF_NAME" "$CONF_PATH"
         else
@@ -118,6 +121,9 @@ if [ -r "$PROJECTS_CONF" ]; then
         esac
         CONF_NAME="${CONF_NAME## }"; CONF_NAME="${CONF_NAME%% }"
         CONF_PATH="${CONF_PATH## }"; CONF_PATH="${CONF_PATH%% }"
+        # Strip one layer of surrounding quotes (handles KEY="value" style env files)
+        CONF_PATH="${CONF_PATH#\"}"; CONF_PATH="${CONF_PATH%\"}"
+        CONF_PATH="${CONF_PATH#\'}"; CONF_PATH="${CONF_PATH%\'}"
         if [ "$CONF_NAME" = "$PROJECT_NAME" ]; then
             if [ -d "$CONF_PATH/.git" ] || [ -f "$CONF_PATH/.git" ]; then
                 PROJECT_PATH="$CONF_PATH"

--- a/bin/config_digest_cron.sh
+++ b/bin/config_digest_cron.sh
@@ -79,6 +79,9 @@ if [ -f "${ENV_FILE}" ]; then
   while IFS='=' read -r key val; do
     [[ "${key}" =~ ^[[:space:]]*# ]] && continue
     [[ -z "${key}" ]] && continue
+    # Strip one layer of surrounding quotes (handles KEY="value" style env files)
+    val="${val#\"}"; val="${val%\"}"
+    val="${val#\'}"; val="${val%\'}"
     export "${key}=${val}"
   done < "${ENV_FILE}"
   set +a

--- a/bin/kb_digest_daily_cron.sh
+++ b/bin/kb_digest_daily_cron.sh
@@ -89,6 +89,9 @@ if [ -f "${ENV_FILE}" ]; then
   while IFS='=' read -r key val; do
     [[ "${key}" =~ ^[[:space:]]*# ]] && continue
     [[ -z "${key}" ]] && continue
+    # Strip one layer of surrounding quotes (handles KEY="value" style env files)
+    val="${val#\"}"; val="${val%\"}"
+    val="${val#\'}"; val="${val%\'}"
     export "${key}=${val}"
   done < "${ENV_FILE}"
   set +a

--- a/bin/roborev_daily_cron.sh
+++ b/bin/roborev_daily_cron.sh
@@ -87,6 +87,9 @@ if [ -f "${ENV_FILE}" ]; then
   while IFS='=' read -r key val; do
     [[ "${key}" =~ ^[[:space:]]*# ]] && continue
     [[ -z "${key}" ]] && continue
+    # Strip one layer of surrounding quotes (handles KEY="value" style env files)
+    val="${val#\"}"; val="${val%\"}"
+    val="${val#\'}"; val="${val%\'}"
     export "${key}=${val}"
   done < "${ENV_FILE}"
   set +a


### PR DESCRIPTION
## Summary

- Fixes #433: env-file loader in 4 scripts silently preserved literal quote characters when parsing `KEY="value"` lines, corrupting credentials on export
- Applies Option A from the issue: strip one layer of surrounding double/single quotes from `val` (or `CONF_PATH`) after the existing skip-blank/skip-comment checks, before `export`
- No change to behaviour for plain `KEY=value` lines (unquoted values pass through unchanged)

## Files patched

| File | Variable | Loop purpose |
|---|---|---|
| `bin/roborev_daily_cron.sh` | `key`/`val` | Load `~/.claude/env/roborev_email.env` credentials |
| `bin/kb_digest_daily_cron.sh` | `key`/`val` | Load `~/.claude/env/kb_digest.env` credentials |
| `bin/config_digest_cron.sh` | `key`/`val` | Load `~/.claude/env/roborev_email.env` credentials |
| `.claude/scripts/cc-worktree.sh` | `CONF_NAME`/`CONF_PATH` | Parse `projects.conf` (both Tier 1 and `--validate-config` loops) |

The comment `# Strip one layer of surrounding quotes (handles KEY="value" style env files)` and the two quote-stripping lines are byte-identical across all credential loops.

## Test plan

- [x] `bash -n` passes on all 4 patched files
- [x] Smoke test: `FOO="hello"` → `FOO=hello` (len=5), `BAR=plain` → unchanged, `BAZ='single'` → `BAZ=single`
- [ ] Integration: set `GMAIL_APP_PASSWORD="secret"` in `~/.claude/env/roborev_email.env` and confirm `${#GMAIL_APP_PASSWORD}=6` (not 8) after sourcing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
