### PR TITLE
feat(#436): daily digest email of Stage 1 self-review findings

### DIFF
--- a/.claude/launchd/com.claude.stage1-findings-email.plist
+++ b/.claude/launchd/com.claude.stage1-findings-email.plist
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.claude.stage1-findings-email.plist
+     Daily Stage 1 self-review findings digest email.
+     Runs at 08:10 local time (after roborev-daily-email 08:00 and config-digest 08:05).
+
+     Install:
+       cp .claude/launchd/com.claude.stage1-findings-email.plist \
+          ~/Library/LaunchAgents/com.claude.stage1-findings-email.plist
+       launchctl load -w ~/Library/LaunchAgents/com.claude.stage1-findings-email.plist
+
+     Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.claude.stage1-findings-email.plist
+       rm ~/Library/LaunchAgents/com.claude.stage1-findings-email.plist
+
+     Manual dry-run:
+       EMAIL_DRY_RUN=1 bash ~/docs_gh/llm/bin/stage1_findings_daily_cron.sh
+
+     Credentials: ~/.claude/env/roborev_email.env (not committed; create manually)
+       GMAIL_USERNAME=you@gmail.com
+       GMAIL_APP_PASSWORD=<16-char app password>
+       REPORT_RECIPIENT=you@gmail.com
+
+     To send live (not dry-run), set EMAIL_DRY_RUN=0 in the env file.
+     The cron script defaults to EMAIL_DRY_RUN=1 — opt-out, not opt-in.
+
+     Tracked in llm#436.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.stage1-findings-email</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/stage1_findings_daily_cron.sh</string>
+    </array>
+
+    <!-- Daily at 08:10 local time (after roborev-daily-email 08:00 and config-digest 08:05) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>10</integer>
+    </dict>
+
+    <!-- Do NOT run immediately on launchctl load -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- PATH must include nix stable profile (for nix-shell) and homebrew.
+         NIX_SSL_CERT_FILE is required for nix-shell to make network calls. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/johngavin/.local/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+        <!-- NIX_SSL_CERT_FILE is required for nix-shell to make network calls -->
+        <key>NIX_SSL_CERT_FILE</key>
+        <string>/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/stage1_findings_email_launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/stage1_findings_email_launchd.log</string>
+
+    <!-- Retry once after 60 s if job exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+</dict>
+</plist>

--- a/.claude/scripts/send_stage1_findings_email.R
+++ b/.claude/scripts/send_stage1_findings_email.R
@@ -1,0 +1,313 @@
+#!/usr/bin/env Rscript
+# send_stage1_findings_email.R — Send daily Stage 1 self-review findings digest via Gmail.
+#
+# Reads self_review_findings_stage1 from unified.duckdb (last 24h).
+# If 0 rows: logs and exits 0 (no email sent — no noise on quiet days).
+# If >=1 rows: renders an HTML body grouped by finding_type x severity, sends via blastula.
+#
+# Required env vars:
+#   GMAIL_USERNAME       Gmail address (sender + credential lookup)
+#   GMAIL_APP_PASSWORD   Gmail app password
+#   REPORT_RECIPIENT     Recipient address (falls back to GMAIL_USERNAME)
+#
+# Optional env vars:
+#   UNIFIED_DUCKDB   Path to unified.duckdb (default ~/.claude/logs/unified.duckdb)
+#   EMAIL_DRY_RUN    Set to "1" to print body to stdout without sending
+#
+# Usage:
+#   Rscript .claude/scripts/send_stage1_findings_email.R
+#   EMAIL_DRY_RUN=1 Rscript .claude/scripts/send_stage1_findings_email.R
+#
+# Called from bin/stage1_findings_daily_cron.sh.
+# Tracked in llm#436.
+
+suppressPackageStartupMessages({
+  library(blastula)
+  library(DBI)
+  library(duckdb)
+  library(jsonlite)
+})
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+UNIFIED_DUCKDB <- Sys.getenv(
+  "UNIFIED_DUCKDB",
+  file.path(Sys.getenv("HOME"), ".claude", "logs", "unified.duckdb")
+)
+
+dry_run <- identical(Sys.getenv("EMAIL_DRY_RUN"), "1")
+report_date <- format(Sys.Date())
+
+# ── Connect to DuckDB (read-only) ─────────────────────────────────────────────
+
+if (!file.exists(UNIFIED_DUCKDB)) {
+  message(sprintf("send_stage1_findings_email.R: unified.duckdb not found at %s", UNIFIED_DUCKDB))
+  quit(status = 1L)
+}
+
+con <- DBI::dbConnect(duckdb::duckdb(), UNIFIED_DUCKDB, read_only = TRUE)
+on.exit(DBI::dbDisconnect(con), add = TRUE)
+
+# ── Query last 24h of findings ─────────────────────────────────────────────────
+
+findings <- tryCatch(
+  DBI::dbGetQuery(con, "
+    SELECT
+      finding_id,
+      finding_type,
+      session_id,
+      severity,
+      evidence,
+      detected_at
+    FROM self_review_findings_stage1
+    WHERE detected_at >= (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::TIMESTAMP - INTERVAL '24 hours'
+    ORDER BY severity, finding_type, detected_at DESC
+  "),
+  error = function(e) {
+    message("send_stage1_findings_email.R: query failed — ", conditionMessage(e))
+    quit(status = 1L)
+  }
+)
+
+n_findings <- nrow(findings)
+message(sprintf(
+  "send_stage1_findings_email.R: %d findings in last 24h (date=%s)",
+  n_findings, report_date
+))
+
+# ── Exit silently when no findings (no noise on quiet days) ───────────────────
+
+if (n_findings == 0L) {
+  message("send_stage1_findings_email.R: 0 findings — skipping email (quiet day)")
+  quit(status = 0L)
+}
+
+# ── Colour palette (dark-mode safe, matches send_roborev_email.R) ─────────────
+
+dark_bg       <- "#1a1a2e"
+dark_card     <- "#16213e"
+dark_row_alt  <- "#0f3460"
+dark_text     <- "#e8e8e8"
+dark_muted    <- "#a0a0a0"
+dark_border   <- "#2a2a4a"
+accent_green  <- "#00d26a"
+accent_blue   <- "#4fc3f7"
+accent_orange <- "#ff9800"
+accent_red    <- "#f08080"
+accent_purple <- "#bb86fc"
+
+severity_colour <- function(sev) {
+  switch(
+    tolower(sev %||% "unknown"),
+    critical = accent_red,
+    major    = accent_orange,
+    minor    = accent_blue,
+    info     = accent_green,
+    accent_blue
+  )
+}
+
+`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0 && !is.na(a[1])) a else b
+
+# ── Truncate evidence JSON to ~200 chars ──────────────────────────────────────
+
+truncate_evidence <- function(ev, max_chars = 200L) {
+  if (is.null(ev) || is.na(ev) || !nzchar(ev)) return("(no evidence)")
+  # Pretty-print the JSON key=value pairs as a compact string
+  parsed <- tryCatch(jsonlite::fromJSON(ev, simplifyVector = TRUE), error = function(e) NULL)
+  if (!is.null(parsed) && is.list(parsed)) {
+    flat <- paste(names(parsed), unlist(parsed), sep = "=", collapse = " | ")
+  } else {
+    flat <- ev
+  }
+  if (nchar(flat) > max_chars) {
+    flat <- paste0(substr(flat, 1L, max_chars), "...")
+  }
+  # HTML-escape special characters
+  flat <- gsub("&", "&amp;", flat, fixed = TRUE)
+  flat <- gsub("<", "&lt;",  flat, fixed = TRUE)
+  flat <- gsub(">", "&gt;",  flat, fixed = TRUE)
+  flat
+}
+
+# ── Group findings by finding_type then severity ───────────────────────────────
+
+build_group_table <- function(group_df) {
+  type_val <- group_df$finding_type[1]
+  sev_val  <- group_df$severity[1]
+  sev_col  <- severity_colour(sev_val)
+  n_rows   <- nrow(group_df)
+
+  header <- sprintf(
+    '<h4 style="color:%s; margin:16px 0 6px 0;">
+       %s &nbsp;<span style="color:%s; font-size:11px;">[%s]</span>
+       &nbsp;<span style="color:%s; font-size:11px;">(%d finding%s)</span>
+     </h4>',
+    sev_col,
+    htmltools_escape(type_val),
+    sev_col, htmltools_escape(sev_val),
+    dark_muted, n_rows, if (n_rows == 1L) "" else "s"
+  )
+
+  table_open <- sprintf(
+    '<table style="border-collapse:collapse; width:100%%; font-size:11px; margin-bottom:10px;">
+       <tr style="background-color:%s;">
+         <th style="padding:5px 8px; border:1px solid %s; color:white; text-align:left;">Finding ID</th>
+         <th style="padding:5px 8px; border:1px solid %s; color:white; text-align:left;">Session</th>
+         <th style="padding:5px 8px; border:1px solid %s; color:white; text-align:left;">Evidence</th>
+         <th style="padding:5px 8px; border:1px solid %s; color:white; text-align:left;">Detected</th>
+       </tr>',
+    dark_row_alt,
+    dark_border, dark_border, dark_border, dark_border
+  )
+
+  rows_html <- ""
+  for (i in seq_len(n_rows)) {
+    bg  <- if (i %% 2L == 0L) dark_row_alt else dark_card
+    row <- group_df[i, ]
+    session_short <- if (is.na(row$session_id) || !nzchar(row$session_id %||% "")) {
+      "(unknown)"
+    } else {
+      substr(row$session_id, 1L, 12L)
+    }
+    detected_str <- format(as.POSIXct(row$detected_at), "%Y-%m-%d %H:%M", tz = "UTC")
+    rows_html <- paste0(rows_html, sprintf(
+      '<tr style="background-color:%s;">
+         <td style="padding:4px 6px; border:1px solid %s; color:%s; font-size:10px;">%s</td>
+         <td style="padding:4px 6px; border:1px solid %s; color:%s; font-size:10px;">%s</td>
+         <td style="padding:4px 6px; border:1px solid %s; color:%s;">%s</td>
+         <td style="padding:4px 6px; border:1px solid %s; color:%s; white-space:nowrap;">%s</td>
+       </tr>',
+      bg,
+      dark_border, accent_blue, htmltools_escape(row$finding_id %||% ""),
+      dark_border, dark_muted,  session_short,
+      dark_border, dark_text,   truncate_evidence(row$evidence),
+      dark_border, dark_muted,  detected_str
+    ))
+  }
+
+  paste0(header, table_open, rows_html, "</table>")
+}
+
+# Minimal HTML escaping (htmltools not always available in nix env)
+htmltools_escape <- function(x) {
+  x <- as.character(x %||% "")
+  x <- gsub("&", "&amp;", x, fixed = TRUE)
+  x <- gsub("<", "&lt;",  x, fixed = TRUE)
+  x <- gsub(">", "&gt;",  x, fixed = TRUE)
+  x <- gsub('"', "&quot;", x, fixed = TRUE)
+  x
+}
+
+# Build sections grouped by (finding_type, severity)
+group_keys <- unique(findings[, c("finding_type", "severity"), drop = FALSE])
+# Sort: severity order critical > major > minor > info
+sev_order <- c(critical = 1L, major = 2L, minor = 3L, info = 4L)
+group_keys$sev_ord <- sev_order[tolower(group_keys$severity)]
+group_keys$sev_ord[is.na(group_keys$sev_ord)] <- 5L
+group_keys <- group_keys[order(group_keys$sev_ord, group_keys$finding_type), ]
+
+groups_html <- ""
+for (i in seq_len(nrow(group_keys))) {
+  mask <- findings$finding_type == group_keys$finding_type[i] &
+          findings$severity      == group_keys$severity[i]
+  groups_html <- paste0(groups_html, build_group_table(findings[mask, ]))
+}
+
+# ── Build email body ───────────────────────────────────────────────────────────
+
+subject_line <- sprintf(
+  "Stage 1 Self-Review Findings — %s (%d finding%s)",
+  report_date, n_findings, if (n_findings == 1L) "" else "s"
+)
+
+qa_markers <- sprintf(
+  "<!-- QA:report_date=%s --><!-- QA:n_findings=%d -->",
+  report_date, n_findings
+)
+
+email_body <- sprintf(
+  '<div style="background-color:%s; color:%s; padding:20px;
+               font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">
+<h2 style="color:%s; margin-bottom:4px;">Stage 1 Self-Review Findings &mdash; %s</h2>
+<p style="color:%s; font-size:11px; margin-top:0; margin-bottom:16px;">
+  %d finding%s in the last 24 hours &nbsp;|&nbsp; Generated: %s UTC
+</p>
+%s
+<p style="color:%s; font-size:10px; margin-top:20px;">
+  Source: %s &nbsp;|&nbsp; Table: self_review_findings_stage1
+</p>
+%s
+</div>',
+  dark_bg, dark_text,
+  accent_orange, report_date,
+  dark_muted,
+  n_findings, if (n_findings == 1L) "" else "s",
+  format(Sys.time(), "%Y-%m-%d %H:%M", tz = "UTC"),
+  groups_html,
+  dark_muted, UNIFIED_DUCKDB,
+  qa_markers
+)
+
+# ── Dry-run mode ───────────────────────────────────────────────────────────────
+
+if (dry_run) {
+  message("send_stage1_findings_email.R: EMAIL_DRY_RUN=1 — printing body to stdout")
+  cat(email_body, "\n")
+  message(sprintf(
+    "send_stage1_findings_email.R: dry-run complete (would send: %s)",
+    subject_line
+  ))
+  quit(status = 0L)
+}
+
+# ── Credentials ────────────────────────────────────────────────────────────────
+
+gmail_user <- Sys.getenv("GMAIL_USERNAME", "")
+gmail_pass <- Sys.getenv("GMAIL_APP_PASSWORD", "")
+
+if (!nzchar(gmail_user) || !nzchar(gmail_pass)) {
+  message("send_stage1_findings_email.R: GMAIL_USERNAME or GMAIL_APP_PASSWORD not set")
+  cat("\n--- Email body (credentials missing, not sent) ---\n")
+  cat(email_body, "\n")
+  quit(status = 1L)
+}
+
+report_to <- Sys.getenv("REPORT_RECIPIENT", "")
+if (!nzchar(report_to)) report_to <- gmail_user
+
+# ── Compose and send ───────────────────────────────────────────────────────────
+
+london_time <- format(Sys.time(), tz = "Europe/London", "%Y-%m-%d %H:%M")
+
+email <- compose_email(
+  body   = md(email_body),
+  footer = md(sprintf(
+    "<span style='color:%s;'>Sent: %s (London)</span>",
+    dark_muted, london_time
+  ))
+)
+
+smtp_creds <- creds_envvar(
+  user        = gmail_user,
+  pass_envvar = "GMAIL_APP_PASSWORD",
+  host        = "smtp.gmail.com",
+  port        = 465,
+  use_ssl     = TRUE
+)
+
+tryCatch({
+  smtp_send(
+    email       = email,
+    to          = report_to,
+    from        = gmail_user,
+    subject     = subject_line,
+    credentials = smtp_creds
+  )
+  message(sprintf("send_stage1_findings_email.R: email sent to %s", report_to))
+}, error = function(e) {
+  message("send_stage1_findings_email.R: SMTP send failed — ", conditionMessage(e))
+  cat("\n--- Email body (SMTP failed) ---\n")
+  cat(email_body, "\n")
+  quit(status = 1L)
+})

--- a/bin/stage1_findings_daily_cron.sh
+++ b/bin/stage1_findings_daily_cron.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# stage1_findings_daily_cron.sh — Daily Stage 1 self-review findings digest email.
+#
+# Steps:
+#   1. Send digest email of self_review_findings_stage1 (last 24h):
+#      Rscript .claude/scripts/send_stage1_findings_email.R
+#
+# No Step 2 (no JSON publishing for this digest — data stays in unified.duckdb).
+#
+# All R calls are wrapped in nix-shell per the nix-agent-shell-protocol rule.
+# EMAIL_DRY_RUN defaults to 1 — must be explicitly set to 0 to send live mail.
+#
+# Env vars sourced from ~/.claude/env/roborev_email.env if it exists:
+#   GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT
+#
+# Log: ~/.claude/logs/stage1_findings_email.log
+#
+# Install plist:
+#   cp .claude/launchd/com.claude.stage1-findings-email.plist \
+#      ~/Library/LaunchAgents/com.claude.stage1-findings-email.plist
+#   launchctl load -w ~/Library/LaunchAgents/com.claude.stage1-findings-email.plist
+#
+# Manual dry-run:
+#   EMAIL_DRY_RUN=1 bash bin/stage1_findings_daily_cron.sh
+#
+# Tracked in llm#436.
+
+set -uo pipefail
+
+# ── PATH (launchd runs with a bare PATH; must resolve nix-shell, Rscript) ────
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# ── Recursion guard ────────────────────────────────────────────────────────────
+: "${STAGE1_EMAIL_CRON_DEPTH:=0}"
+if (( STAGE1_EMAIL_CRON_DEPTH > 0 )); then
+  echo "[stage1_findings_daily_cron] ERROR: recursion detected (depth=${STAGE1_EMAIL_CRON_DEPTH}). Abort." >&2
+  exit 1
+fi
+export STAGE1_EMAIL_CRON_DEPTH=$(( STAGE1_EMAIL_CRON_DEPTH + 1 ))
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LLM_NIX="${REPO_ROOT}/default.nix"
+LOG_FILE="${HOME}/.claude/logs/stage1_findings_email.log"
+ENV_FILE="${HOME}/.claude/env/roborev_email.env"
+LOCK_FILE="${HOME}/.claude/logs/.stage1_findings_email.lock"
+
+# EMAIL_DRY_RUN defaults to 1 — opt-out, not opt-in (must set to "0" to send live)
+EMAIL_DRY_RUN="${EMAIL_DRY_RUN:-1}"
+export EMAIL_DRY_RUN
+
+# ── Logging ────────────────────────────────────────────────────────────────────
+mkdir -p "$(dirname "${LOG_FILE}")"
+
+log() {
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  printf '%s: %s\n' "${ts}" "$1" | tee -a "${LOG_FILE}"
+}
+
+log "=== stage1_findings_daily_cron.sh starting (EMAIL_DRY_RUN=${EMAIL_DRY_RUN}) ==="
+
+# ── Lock (prevent concurrent runs) ────────────────────────────────────────────
+if [ -f "${LOCK_FILE}" ]; then
+  existing_pid="$(cat "${LOCK_FILE}" 2>/dev/null || true)"
+  if [ -n "${existing_pid}" ] && kill -0 "${existing_pid}" 2>/dev/null; then
+    log "SKIP: another instance running (PID ${existing_pid})"
+    exit 0
+  fi
+fi
+printf '%d' "$$" > "${LOCK_FILE}"
+trap 'rm -f "${LOCK_FILE}"' EXIT
+
+# ── Load credentials from env file ────────────────────────────────────────────
+if [ -f "${ENV_FILE}" ]; then
+  log "Loading env from ${ENV_FILE}"
+  # shellcheck disable=SC1090
+  set -a
+  # Source only KEY=VALUE lines; skip comments and blanks
+  # Quote-stripping fix: handles KEY="value" and KEY='value' style env files
+  while IFS='=' read -r key val; do
+    [[ "${key}" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${key}" ]] && continue
+    # Strip one layer of surrounding quotes
+    val="${val#\"}"; val="${val%\"}"
+    val="${val#\'}"; val="${val%\'}"
+    export "${key}=${val}"
+  done < "${ENV_FILE}"
+  set +a
+else
+  log "INFO: ${ENV_FILE} not found — relying on existing environment"
+  log "  Create it with: GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT"
+fi
+
+# ── Verify nix shell is accessible ────────────────────────────────────────────
+if [ ! -f "${LLM_NIX}" ]; then
+  log "ERROR: nix file not found at ${LLM_NIX}"
+  exit 1
+fi
+
+if ! command -v nix-shell > /dev/null 2>&1; then
+  log "ERROR: nix-shell not on PATH (${PATH})"
+  exit 1
+fi
+
+# ── Step 1: Send Stage 1 findings digest email ────────────────────────────────
+log "Step 1: sending Stage 1 findings digest email (EMAIL_DRY_RUN=${EMAIL_DRY_RUN})..."
+EMAIL_SCRIPT="${REPO_ROOT}/.claude/scripts/send_stage1_findings_email.R"
+
+if [ ! -f "${EMAIL_SCRIPT}" ]; then
+  log "ERROR: send_stage1_findings_email.R not found at ${EMAIL_SCRIPT}"
+  exit 1
+fi
+
+nix-shell "${LLM_NIX}" --run "Rscript '${EMAIL_SCRIPT}'" >> "${LOG_FILE}" 2>&1
+STEP1_EXIT=$?
+
+if [ "${STEP1_EXIT}" -ne 0 ]; then
+  log "ERROR: send_stage1_findings_email.R failed (exit=${STEP1_EXIT})"
+  exit "${STEP1_EXIT}"
+fi
+log "Step 1 done (exit=${STEP1_EXIT})"
+
+log "=== stage1_findings_daily_cron.sh done ==="


### PR DESCRIPTION
## Summary

- New `send_stage1_findings_email.R`: queries `self_review_findings_stage1` in `unified.duckdb` for the last 24h, exits 0 silently on 0 rows (no noise on quiet days), renders dark-mode HTML grouped by `finding_type × severity` with truncated evidence, sends via blastula `creds_envvar` re-using the same SMTP pattern as `send_roborev_email.R`. `EMAIL_DRY_RUN=1` prints to stdout without sending.
- New `bin/stage1_findings_daily_cron.sh`: mirrors `roborev_daily_cron.sh` (PID lock, logging, nix-shell wrap, quote-stripping env loader); **no Step 2** (no JSON publishing); `EMAIL_DRY_RUN` defaults to `1` — must be explicitly set to `0` to send live mail.
- New `.claude/launchd/com.claude.stage1-findings-email.plist`: daily at 08:10 local (after roborev 08:00, config-digest 08:05); `PATH + HOME + NIX_SSL_CERT_FILE` env block per #432; `RunAtLoad=false`; `LowPriorityIO=true`.

## Test plan

- [x] `bash -n bin/stage1_findings_daily_cron.sh` — PASS
- [x] `plutil -lint .claude/launchd/com.claude.stage1-findings-email.plist` — PASS (OK)
- [x] `EMAIL_DRY_RUN=1 bash bin/stage1_findings_daily_cron.sh` — exit 0; 1 finding rendered in HTML with correct dark-mode styling; QA markers `<!-- QA:report_date=... --><!-- QA:n_findings=... -->` present
- [ ] Orchestrator to install plist into `~/Library/LaunchAgents/` post-merge (per issue)
- [ ] Set `EMAIL_DRY_RUN=0` in `~/.claude/env/roborev_email.env` to enable live sending

## Notes

- Re-uses `~/.claude/env/roborev_email.env` (GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT) — no new credential file needed
- Timestamp fix: DuckDB TIMESTAMP column requires explicit cast `(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::TIMESTAMP` to avoid TIMESTAMP WITH TIME ZONE type mismatch in the 24h filter
- Does not touch existing roborev or kb_digest pipelines

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
