### PR TITLE
feat(scripts): check_146_panel_data_watcher.sh — launchd watcher for llmtelemetry #146

### DIFF
--- a/.claude/scripts/check_146_panel_data_watcher.sh
+++ b/.claude/scripts/check_146_panel_data_watcher.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# check_146_panel_data_watcher.sh
+#
+# Polled by ~/Library/LaunchAgents/com.johngavin.check-146-panel-data.plist
+# every 30 minutes. Runs the llmtelemetry #146 panel-readiness check
+# (inst/scripts/check_146_panel_data.sh) and:
+#   - on NOT_READY: appends a line to the log
+#   - on READY:     posts a macOS notification, writes a marker, unloads itself
+#
+# Launchd has a bare PATH and won't resolve `nix-shell` without help. We export
+# a PATH led by /nix/var/nix/profiles/default/bin (the canonical nix profile
+# symlink that survives nix-store garbage collection), mirroring the fix from
+# JohnGavin/llm#235 → PR #289.
+#
+# Idempotent: if the READY marker exists, the script no-ops fast (defensive —
+# the plist should already be unloaded but we belt-and-braces it).
+
+set -uo pipefail
+
+# ── Launchd PATH fix (llm#235/#289 pattern) ───────────────────────────────────
+export PATH="/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+PROJECT="/Users/johngavin/docs_gh/llmtelemetry"
+SCRIPT="$PROJECT/inst/scripts/check_146_panel_data.sh"
+# The duckdb CLI lives in the GLOBAL dev shell, not the project shell.
+# llmtelemetry/default.nix lists `duckdb` as an R package only — no CLI binary.
+# Mirrors the launchd fix from JohnGavin/llm#235 → PR #289.
+NIX_DEV_SHELL="/Users/johngavin/docs_gh/llm/default.nix"
+LABEL="com.johngavin.check-146-panel-data"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG="$HOME/Library/Logs/check_146_panel_data.log"
+STATE_DIR="$HOME/.claude/state"
+MARKER="$STATE_DIR/146_panel_readiness_notified"
+
+mkdir -p "$STATE_DIR" "$(dirname "$LOG")"
+
+ts()  { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { echo "$(ts) $*" >> "$LOG"; }
+
+# ── Fast path: already flipped ────────────────────────────────────────────────
+if [ -f "$MARKER" ]; then
+  log "marker present; no further polling needed (plist should be unloaded)"
+  exit 0
+fi
+
+# ── Run the check ─────────────────────────────────────────────────────────────
+if ! command -v nix-shell >/dev/null 2>&1; then
+  log "FATAL: nix-shell not on PATH after fix ($PATH)"
+  exit 2
+fi
+if [ ! -f "$SCRIPT" ]; then
+  log "FATAL: check script not found at $SCRIPT"
+  exit 2
+fi
+
+# No `timeout` wrapper: macOS doesn't ship one and the nix profile lacks it.
+# The check script itself is bounded — duckdb queries are sub-second; the
+# slow leg is nix-shell entry (≤20 s cold, ~3 s warm). If anything genuinely
+# hangs, launchd will sigkill us after the StartInterval boundary.
+OUT=$(nix-shell "$NIX_DEV_SHELL" --run "bash '$SCRIPT' --quiet" 2>&1 \
+      | tail -n1)
+RC=$?
+
+log "iter rc=$RC out=\"$OUT\""
+
+# ── Branch on result ──────────────────────────────────────────────────────────
+case "$OUT" in
+  READY*)
+    log "FLIP detected: $OUT"
+    osascript -e "display notification \"$OUT\" with title \"llmtelemetry #146 panels READY\" subtitle \"Q1/Q11/Q20 cost ROI panels can ship\" sound name \"Glass\"" \
+      >> "$LOG" 2>&1 || log "WARN: osascript notification failed"
+    touch "$MARKER"
+    log "Unloading plist $PLIST"
+    launchctl unload "$PLIST" >> "$LOG" 2>&1 || log "WARN: launchctl unload failed"
+    exit 0
+    ;;
+  NOT_READY*)
+    # No state change; the periodic log line is enough.
+    exit 0
+    ;;
+  *)
+    log "WARN: unexpected output: \"$OUT\""
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
## Summary

Cross-project tooling: a polled launchd watcher that runs the [llmtelemetry#146](https://github.com/JohnGavin/llmtelemetry/issues/146) panel-readiness check every 30 min. Lives in `llm` because `llm` has cross-project authority and llmtelemetry does not own the launchd integration.

## Behaviour

| Result | Action |
|---|---|
| `READY*` | Post macOS notification (`osascript`), write marker, `launchctl unload` self |
| `NOT_READY*` | Log iteration, exit 0 |
| Other | Warn, exit 0 |

Fast no-op when the marker (`~/.claude/state/146_panel_readiness_notified`) exists — defensive belt-and-braces in case the plist failed to unload.

## Launchd PATH fix

launchd ships with a bare PATH that does not include the nix profile. Script exports `PATH=/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` — using the canonical nix profile symlink that survives nix-store GC. Mirrors the pattern from [llm#235 → PR #289](https://github.com/JohnGavin/llm/pull/289).

## Nix dev shell

The `duckdb` CLI lives in the global dev shell (`~/docs_gh/llm/default.nix`), NOT in `llmtelemetry/default.nix` (which lists duckdb as an R package only — no CLI binary). Watcher enters the global shell to run the check.

## Syntax check

`bash -n` exits 0.

## Out of scope (user does separately)

- Installing the launchd plist at `~/Library/LaunchAgents/com.johngavin.check-146-panel-data.plist` (not committed; user installs locally with the appropriate StartInterval / KeepAlive settings)

## Test plan

- [x] `bash -n` syntax check passes
- [ ] Invoke directly (no plist): `bash .claude/scripts/check_146_panel_data_watcher.sh`; expect log entry, no notification (NOT_READY case)
- [ ] Once llmtelemetry#146 panels actually flip to READY, confirm notification fires and plist unloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
