### PR TITLE
feat(#444): enrich config-digest email

### DIFF
--- a/.claude/scripts/config_change_digest.R
+++ b/.claude/scripts/config_change_digest.R
@@ -23,7 +23,7 @@
 #
 # Output: a structured markdown file consumed by send_config_digest_email.R.
 #
-# Tracked in llm#297.
+# Tracked in llm#297, enriched in llm#444.
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -77,6 +77,22 @@ find_repo_root <- function() {
 }
 
 REPO_ROOT <- find_repo_root()
+
+# ── Repo slug and link helpers ────────────────────────────────────────────────
+
+REPO_SLUG <- "JohnGavin/llm"
+
+link_hash <- function(short_hash) {
+  # Render a 7-char commit hash as a markdown hyperlink.
+  sprintf("[`%s`](https://github.com/%s/commit/%s)", short_hash, REPO_SLUG, short_hash)
+}
+
+linkify_issues <- function(text) {
+  # Replace #NNN references with markdown issue links.
+  gsub("#([0-9]+)",
+       sprintf("[#\\1](https://github.com/%s/issues/\\1)", REPO_SLUG),
+       text, perl = TRUE)
+}
 
 # ── Category definitions ──────────────────────────────────────────────────────
 
@@ -145,7 +161,8 @@ compute_category_stats <- function(cat_def, since) {
     return(list(
       name = cat_def$name, path = path,
       n_commits = 0L, n_added = 0L, n_deleted = 0L,
-      files_changed = character(0), commits = list()
+      files_changed = character(0), commits = list(),
+      file_stats = list(), top_files = list()
     ))
   }
 
@@ -157,6 +174,8 @@ compute_category_stats <- function(cat_def, since) {
   files_changed <- character(0)
   total_added <- 0L
   total_deleted <- 0L
+  # Per-file accumulator: named list of list(added=N, deleted=N)
+  file_stats <- list()
 
   for (line in lines) {
     if (startsWith(line, "COMMIT:")) {
@@ -183,6 +202,32 @@ compute_category_stats <- function(cat_def, since) {
       if (!is.na(added))   total_added   <- total_added   + added
       if (!is.na(deleted)) total_deleted <- total_deleted + deleted
       files_changed <- unique(c(files_changed, file_path))
+      # Accumulate per-file stats
+      if (!is.null(file_stats[[file_path]])) {
+        file_stats[[file_path]]$added   <- file_stats[[file_path]]$added   + if (!is.na(added))   added   else 0L
+        file_stats[[file_path]]$deleted <- file_stats[[file_path]]$deleted + if (!is.na(deleted)) deleted else 0L
+      } else {
+        file_stats[[file_path]] <- list(
+          added   = if (!is.na(added))   added   else 0L,
+          deleted = if (!is.na(deleted)) deleted else 0L
+        )
+      }
+    }
+  }
+
+  # Compute top_files: top 3 by (added + deleted), sorted descending
+  top_files <- list()
+  if (length(file_stats) > 0L) {
+    totals <- sapply(file_stats, function(fs) fs$added + fs$deleted)
+    ord    <- order(totals, decreasing = TRUE)
+    top_n  <- min(3L, length(ord))
+    for (j in seq_len(top_n)) {
+      fp <- names(file_stats)[ord[j]]
+      top_files[[j]] <- list(
+        path    = fp,
+        added   = file_stats[[fp]]$added,
+        deleted = file_stats[[fp]]$deleted
+      )
     }
   }
 
@@ -193,15 +238,55 @@ compute_category_stats <- function(cat_def, since) {
     n_added       = total_added,
     n_deleted     = total_deleted,
     files_changed = files_changed,
-    commits       = commits
+    commits       = commits,
+    file_stats    = file_stats,
+    top_files     = top_files
   )
+}
+
+# ── Filetype subtotals ────────────────────────────────────────────────────────
+
+compute_filetype_stats <- function(cat_stats) {
+  # Walk all categories and re-bucket file_stats by extension.
+  # Returns a list sorted by total (added+deleted) desc, each entry:
+  #   list(ext=".R", n_files=N, added=N, deleted=N)
+  ext_map <- list()  # keyed by extension string
+
+  for (s in cat_stats) {
+    if (length(s$file_stats) == 0L) next
+    for (fp in names(s$file_stats)) {
+      ext <- tools::file_ext(fp)
+      if (!nzchar(ext)) ext <- "(no ext)"
+      ext_key <- paste0(".", ext)
+      fs  <- s$file_stats[[fp]]
+      if (!is.null(ext_map[[ext_key]])) {
+        ext_map[[ext_key]]$n_files <- ext_map[[ext_key]]$n_files + 1L
+        ext_map[[ext_key]]$added   <- ext_map[[ext_key]]$added   + fs$added
+        ext_map[[ext_key]]$deleted <- ext_map[[ext_key]]$deleted + fs$deleted
+      } else {
+        ext_map[[ext_key]] <- list(
+          ext     = ext_key,
+          n_files = 1L,
+          added   = fs$added,
+          deleted = fs$deleted
+        )
+      }
+    }
+  }
+
+  if (length(ext_map) == 0L) return(list())
+
+  totals <- sapply(ext_map, function(e) e$added + e$deleted)
+  ord    <- order(totals, decreasing = TRUE)
+  ext_map[ord]
 }
 
 # ── Theme clustering ──────────────────────────────────────────────────────────
 
 cluster_themes <- function(commit_lines, top_n = 5L) {
   # commit_lines: "hash|subject" format from git_log_commits()
-  if (length(commit_lines) == 0L) return(list())
+  # Returns: list with $top (top_n themes) and $all_counts (named int vector, sorted desc)
+  if (length(commit_lines) == 0L) return(list(top = list(), all_counts = integer(0)))
 
   parsed <- lapply(commit_lines, function(l) {
     parts   <- strsplit(l, "\x1f", fixed = TRUE)[[1L]]
@@ -227,10 +312,15 @@ cluster_themes <- function(commit_lines, top_n = 5L) {
     themes[[k]]$n       <- themes[[k]]$n + 1L
   }
 
-  # Sort by count descending; return top N
-  counts <- sapply(themes, function(t) t$n)
+  # Sort by count descending
+  counts        <- sapply(themes, function(t) t$n)
   themes_sorted <- themes[order(counts, decreasing = TRUE)]
-  head(themes_sorted, top_n)
+  counts_sorted <- counts[order(counts, decreasing = TRUE)]
+
+  # all_counts: named integer vector for breakdown QA marker
+  all_counts <- setNames(as.integer(counts_sorted), names(themes_sorted))
+
+  list(top = head(themes_sorted, top_n), all_counts = all_counts)
 }
 
 # ── Lessons-learnt extraction ─────────────────────────────────────────────────
@@ -309,12 +399,29 @@ extract_lessons <- function(since, changelog_path = NULL) {
     }
   }
 
-  lessons
+  # Compute type breakdown (named int vector, sorted desc) for QA marker
+  if (length(lessons) > 0L) {
+    type_vec  <- sapply(lessons, function(l) toupper(l$type))
+    type_tbl  <- sort(table(type_vec), decreasing = TRUE)
+    lessons_breakdown <- setNames(as.integer(type_tbl), names(type_tbl))
+  } else {
+    lessons_breakdown <- integer(0)
+  }
+
+  # Return list with $lessons (records) and $breakdown (named int vector)
+  list(lessons = lessons, breakdown = lessons_breakdown)
 }
 
 # ── Markdown rendering ────────────────────────────────────────────────────────
 
-render_markdown <- function(cat_stats, themes, lessons, since, generated_at) {
+render_markdown <- function(cat_stats, themes_result, lessons_result, since, generated_at) {
+  # themes_result: list(top=..., all_counts=...)  from cluster_themes()
+  # lessons_result: list(lessons=..., breakdown=...) from extract_lessons()
+  themes          <- themes_result$top
+  themes_counts   <- themes_result$all_counts
+  lessons         <- lessons_result$lessons
+  lessons_brkdown <- lessons_result$breakdown
+
   lines <- character(0)
   emit  <- function(...) lines <<- c(lines, sprintf(...))
 
@@ -322,14 +429,28 @@ render_markdown <- function(cat_stats, themes, lessons, since, generated_at) {
   emit("")
   emit("**Window:** since `%s` | **Generated:** `%s` UTC", since, generated_at)
   emit("")
+
+  # ── Enhancement 1: Filetype subtotals line ─────────────────────────────────
+  ft_stats <- compute_filetype_stats(cat_stats)
+  if (length(ft_stats) > 0L) {
+    top3_ft <- head(ft_stats, 3L)
+    others  <- max(0L, length(ft_stats) - 3L)
+    ft_parts <- sapply(top3_ft, function(ft) {
+      sprintf("%d `%s` (+%d -%d)", ft$n_files, ft$ext, ft$added, ft$deleted)
+    })
+    others_str <- if (others > 0L) sprintf(", +%d others", others) else ""
+    emit("**By filetype:** %s%s", paste(ft_parts, collapse = " · "), others_str)
+    emit("")
+  }
+
   emit("---")
   emit("")
 
-  # ── Section 1: Category summary table ──────────────────────────────────────
+  # ── Section 1: Category summary table (with Top files column) ──────────────
   emit("## Changes by Category")
   emit("")
-  emit("| Category | Files changed | Lines added | Lines deleted |")
-  emit("|----------|:-------------:|:-----------:|:-------------:|")
+  emit("| Category | Files changed | Lines added | Lines deleted | Top files |")
+  emit("|----------|:-------------:|:-----------:|:-------------:|-----------|")
 
   total_files   <- 0L
   total_added   <- 0L
@@ -341,11 +462,26 @@ render_markdown <- function(cat_stats, themes, lessons, since, generated_at) {
     total_added   <- total_added   + s$n_added
     total_deleted <- total_deleted + s$n_deleted
     if (n_files == 0L && s$n_added == 0L && s$n_deleted == 0L) next
-    emit("| %s | %d | +%d | -%d |",
-         s$name, n_files, s$n_added, s$n_deleted)
+
+    # ── Enhancement 5: Top-3 files drilldown ─────────────────────────────────
+    if (length(s$top_files) > 0L) {
+      file_parts <- sapply(s$top_files, function(tf) {
+        bn  <- basename(tf$path)
+        url <- sprintf("https://github.com/%s/blob/main/%s", REPO_SLUG, tf$path)
+        sprintf("[`%s`](%s) (+%d -%d)", bn, url, tf$added, tf$deleted)
+      })
+      n_extra    <- max(0L, n_files - length(s$top_files))
+      others_str <- if (n_extra > 0L) sprintf(" · +%d others", n_extra) else ""
+      top_files_cell <- paste0(paste(file_parts, collapse = " · "), others_str)
+    } else {
+      top_files_cell <- "—"
+    }
+
+    emit("| %s | %d | +%d | -%d | %s |",
+         s$name, n_files, s$n_added, s$n_deleted, top_files_cell)
   }
 
-  emit("| **Total** | **%d** | **+%d** | **-%d** |",
+  emit("| **Total** | **%d** | **+%d** | **-%d** | |",
        total_files, total_added, total_deleted)
   emit("")
 
@@ -362,7 +498,8 @@ render_markdown <- function(cat_stats, themes, lessons, since, generated_at) {
       emit("")
       for (c in head(t$commits, 3L)) {
         short_hash <- substr(c$hash, 1L, 7L)
-        emit("- `%s` %s", short_hash, c$subject)
+        # ── Enhancement 4: Embedded links ─────────────────────────────────────
+        emit("- %s %s", link_hash(short_hash), linkify_issues(c$subject))
       }
       if (t$n > 3L) emit("- _(+%d more)_", t$n - 3L)
       emit("")
@@ -386,7 +523,9 @@ render_markdown <- function(cat_stats, themes, lessons, since, generated_at) {
       emit("### From fix/revert commits")
       emit("")
       for (l in fix_lessons) {
-        emit("- **[%s]** `%s` %s", toupper(l$type), l$hash, l$subject)
+        # ── Enhancement 4: Embedded links ───────────────────────────────────
+        hash_part <- if (nzchar(l$hash)) sprintf(" %s", link_hash(l$hash)) else ""
+        emit("- **[%s]**%s %s", toupper(l$type), hash_part, linkify_issues(l$subject))
       }
       emit("")
     }
@@ -394,7 +533,7 @@ render_markdown <- function(cat_stats, themes, lessons, since, generated_at) {
       emit("### From CHANGELOG (failed approaches)")
       emit("")
       for (l in cl_lessons) {
-        emit("- %s", l$subject)
+        emit("- %s", linkify_issues(l$subject))
       }
       emit("")
     }
@@ -402,13 +541,31 @@ render_markdown <- function(cat_stats, themes, lessons, since, generated_at) {
 
   emit("---")
   emit("")
+
+  # ── QA markers ────────────────────────────────────────────────────────────
   emit("<!-- QA:config_digest_generated=%s -->"  , generated_at)
   emit("<!-- QA:config_digest_since=%s -->"       , since)
   emit("<!-- QA:config_digest_total_files=%d -->" , total_files)
   emit("<!-- QA:config_digest_total_added=%d -->" , total_added)
   emit("<!-- QA:config_digest_total_deleted=%d -->", total_deleted)
-  emit("<!-- QA:config_digest_n_themes=%d -->"    , length(themes))
+  emit("<!-- QA:config_digest_n_themes=%d -->"    , length(themes_counts))
   emit("<!-- QA:config_digest_n_lessons=%d -->"   , length(lessons))
+
+  # ── Enhancement 2+3: Breakdown QA markers ─────────────────────────────────
+  if (length(themes_counts) > 0L) {
+    top3_t  <- head(themes_counts, 3L)
+    others  <- max(0L, length(themes_counts) - 3L)
+    parts   <- paste(names(top3_t), top3_t, sep = ":")
+    if (others > 0L) parts <- c(parts, sprintf("+%d", others))
+    emit("<!-- QA:config_digest_themes_breakdown=%s -->", paste(parts, collapse = ","))
+  }
+  if (length(lessons_brkdown) > 0L) {
+    top3_l  <- head(lessons_brkdown, 3L)
+    others  <- max(0L, length(lessons_brkdown) - 3L)
+    parts   <- paste(names(top3_l), top3_l, sep = ":")
+    if (others > 0L) parts <- c(parts, sprintf("+%d", others))
+    emit("<!-- QA:config_digest_lessons_breakdown=%s -->", paste(parts, collapse = ","))
+  }
 
   paste(lines, collapse = "\n")
 }
@@ -427,22 +584,24 @@ main <- function() {
   cat_stats <- lapply(CATEGORIES, compute_category_stats, since = since)
 
   # Theme clustering (all commits in window, not scoped to category)
-  commit_lines <- git_log_commits(since)
-  themes <- cluster_themes(commit_lines, top_n = 5L)
+  commit_lines   <- git_log_commits(since)
+  themes_result  <- cluster_themes(commit_lines, top_n = 5L)
 
   # Lessons learnt
-  lessons <- extract_lessons(since)
+  lessons_result <- extract_lessons(since)
 
   # Render
-  digest <- render_markdown(cat_stats, themes, lessons, since, generated_at)
+  digest <- render_markdown(cat_stats, themes_result, lessons_result, since, generated_at)
 
   # Summary to stderr for callers
   total_files   <- sum(sapply(cat_stats, function(s) length(s$files_changed)))
   total_added   <- sum(sapply(cat_stats, function(s) s$n_added))
   total_deleted <- sum(sapply(cat_stats, function(s) s$n_deleted))
+  n_themes  <- length(themes_result$all_counts)
+  n_lessons <- length(lessons_result$lessons)
   message(sprintf(
     "config_change_digest.R: %d files changed | +%d/-%d lines | %d themes | %d lessons",
-    total_files, total_added, total_deleted, length(themes), length(lessons)
+    total_files, total_added, total_deleted, n_themes, n_lessons
   ))
 
   if (dry_run) {

--- a/.claude/scripts/send_config_digest_email.R
+++ b/.claude/scripts/send_config_digest_email.R
@@ -98,13 +98,15 @@ qa_val <- function(key, text) {
   sub(sprintf("<!-- QA:%s=", key), "", sub(" -->$", "", m))
 }
 
-generated_at  <- qa_val("config_digest_generated", digest_md)
-since_label   <- qa_val("config_digest_since",     digest_md)
-total_files   <- qa_val("config_digest_total_files",   digest_md)
-total_added   <- qa_val("config_digest_total_added",   digest_md)
-total_deleted <- qa_val("config_digest_total_deleted", digest_md)
-n_themes      <- qa_val("config_digest_n_themes",  digest_md)
-n_lessons     <- qa_val("config_digest_n_lessons", digest_md)
+generated_at       <- qa_val("config_digest_generated", digest_md)
+since_label        <- qa_val("config_digest_since",     digest_md)
+total_files        <- qa_val("config_digest_total_files",   digest_md)
+total_added        <- qa_val("config_digest_total_added",   digest_md)
+total_deleted      <- qa_val("config_digest_total_deleted", digest_md)
+n_themes           <- qa_val("config_digest_n_themes",  digest_md)
+n_lessons          <- qa_val("config_digest_n_lessons", digest_md)
+themes_breakdown   <- qa_val("config_digest_themes_breakdown",  digest_md)
+lessons_breakdown  <- qa_val("config_digest_lessons_breakdown", digest_md)
 
 if (is.na(generated_at)) generated_at <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
 if (is.na(since_label))  since_label  <- config_digest_since
@@ -174,6 +176,16 @@ htmlify <- function(txt) {
 }
 
 inline_code_html <- function(txt) {
+  # First: convert markdown links [label](url) to HTML anchors.
+  # Must run before htmlify() has escaped the text, because htmlify converts
+  # & < > — but [ ] ( ) are safe.  We run inline_code_html AFTER htmlify(),
+  # so at this point & < > are already &amp; &lt; &gt;.
+  # The link label may itself contain `code` backticks — handle that below.
+  txt <- gsub(
+    "\\[([^]]+)\\]\\(([^)]+)\\)",
+    sprintf('<a href="\\2" style="color:%s;">\\1</a>', accent_blue),
+    txt, perl = TRUE
+  )
   # Replace `code` spans with styled <code> elements
   gsub("`([^`]+)`",
        sprintf('<code style="background:%s; color:%s; padding:1px 3px; border-radius:3px;">\\1</code>',
@@ -243,14 +255,50 @@ wrap_tables <- function(html_lines) {
   paste(result, collapse = "\n")
 }
 
+# ── Breakdown subtitle helper ──────────────────────────────────────────────────
+# Parses "KEY:N,KEY:N,+M" QA breakdown strings into an HTML sub-label.
+# e.g. "chore:7,fix:5,feat:3,+2" -> "(chore 7 · fix 5 · feat 3 · +2 others)"
+
+format_breakdown_html <- function(breakdown_str) {
+  if (is.na(breakdown_str) || !nzchar(breakdown_str)) return("")
+  parts <- strsplit(breakdown_str, ",", fixed = TRUE)[[1L]]
+  labels <- character(length(parts))
+  for (i in seq_along(parts)) {
+    p <- parts[[i]]
+    if (grepl("^\\+[0-9]+$", p)) {
+      # "+N" tail entry
+      labels[i] <- paste0(p, " others")
+    } else if (grepl(":", p, fixed = TRUE)) {
+      kv <- strsplit(p, ":", fixed = TRUE)[[1L]]
+      key <- if (length(kv) >= 1L) kv[[1L]] else ""
+      val <- if (length(kv) >= 2L) kv[[2L]] else ""
+      labels[i] <- paste(key, val)
+    } else {
+      labels[i] <- p
+    }
+  }
+  inner <- paste(labels, collapse = " · ")
+  sprintf('<br><span style="font-size:11px; color:#aaa;">(%s)</span>', inner)
+}
+
 # ── Headline summary table (two-column Metric | Value) ─────────────────────────
+
+# Build value cells with optional breakdown sub-labels (Enhancements 2 & 3)
+themes_value_html  <- paste0(
+  if (!is.na(n_themes)) n_themes else "—",
+  format_breakdown_html(themes_breakdown)
+)
+lessons_value_html <- paste0(
+  if (!is.na(n_lessons)) n_lessons else "—",
+  format_breakdown_html(lessons_breakdown)
+)
 
 headline_rows <- list(
   c("Files changed",   if (!is.na(total_files))   total_files   else "—"),
   c("Lines added",     if (!is.na(total_added))    paste0("+", total_added) else "—"),
   c("Lines deleted",   if (!is.na(total_deleted))  paste0("-", total_deleted) else "—"),
-  c("Themes clustered",if (!is.na(n_themes))       n_themes      else "—"),
-  c("Lessons found",   if (!is.na(n_lessons))      n_lessons     else "—")
+  list("Themes clustered", themes_value_html),
+  list("Lessons found",    lessons_value_html)
 )
 
 headline_html <- sprintf(


### PR DESCRIPTION
## Summary

- **Enhancement 1 — Filetype subtotals:** New `compute_filetype_stats()` aggregates per-extension totals across all category stats; a `**By filetype:** N .R (+X -Y) · ...` line is emitted in the digest header.
- **Enhancement 2 — Themes clustered breakdown:** `cluster_themes()` now returns `list(top=, all_counts=)`; the markdown includes `<!-- QA:config_digest_themes_breakdown=... -->` and the email shows an HTML sub-label `(theme1 N · theme2 N · ...)`.
- **Enhancement 3 — Lessons found breakdown:** `extract_lessons()` now returns `list(lessons=, breakdown=)`; the markdown includes `<!-- QA:config_digest_lessons_breakdown=... -->` and the email shows an HTML sub-label.
- **Enhancement 4 — Embedded links:** `link_hash(short_hash)` and `linkify_issues(text)` helpers applied in Themes Today and Lessons sections; `inline_code_html()` extended to convert markdown `[label](url)` to `<a href>` anchors before code-span conversion.
- **Enhancement 5 — Top-3 files drilldown:** Fifth column "Top files" added to Changes by Category table; each file linked to `https://github.com/JohnGavin/llm/blob/main/<path>` using basename as label; `compute_category_stats()` retains per-file numstat and computes `top_files` list.

Closes #444

## Test plan

- [x] Dry-run verified: `config_change_digest.R --since=... --dry-run` produces correct output at `/tmp/digest_test.md`
- [x] Filetype line present on line 5: `**By filetype:** 5 .sh (+971 -26) · 2 .R (+404 -4) · ...`
- [x] Top-files column present with clickable GitHub blob links
- [x] Linked commit hashes (`[7ac0b1c](https://github.com/JohnGavin/llm/commit/7ac0b1c)`) in Themes Today
- [x] Linked issue refs (`[#439](https://github.com/JohnGavin/llm/issues/439)`) in Themes and Lessons
- [x] QA markers `config_digest_themes_breakdown` and `config_digest_lessons_breakdown` present
- [x] Both R scripts parse with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
