### PR TITLE
feat(#454): survival-analysis skill + survival-reporting rule (TTE foundation)

### DIFF
--- a/.claude/rules/survival-reporting.md
+++ b/.claude/rules/survival-reporting.md
@@ -1,0 +1,117 @@
+---
+name: survival-reporting
+description: "Mandatory reporting standards for every survival curve, hazard ratio, median survival, and log-rank result published in a vignette, dashboard, or report. Extends statistical-reporting."
+type: rule
+---
+# Rule: Survival Reporting
+
+## When This Applies
+
+Every survival curve, hazard ratio (HR), median survival estimate, or log-rank
+p-value that appears in a vignette, dashboard panel, report, or PR description.
+Applies to both interactive (Shiny/Quarto) and static outputs.
+
+Extends `statistical-reporting`. Where both rules apply, this rule is the more
+specific one — follow both.
+
+---
+
+## CRITICAL: Effect size with every p-value
+
+A log-rank p-value alone is uninterpretable. It answers "are the curves different?"
+not "how different, and in which direction?". The hazard ratio quantifies the effect.
+
+> Report HR + 95% CI + p-value together, always.
+
+---
+
+## Mandatory reporting table
+
+| When you report | Must include |
+|---|---|
+| A survival curve | KM with 95% CI band; at-risk table beneath; censoring tick marks on the curve |
+| A hazard ratio | HR + 95% CI + Wald p-value + reference category named explicitly + proportional-hazards check noted (Schoenfeld residuals via `cox.zph()`) |
+| Median survival | Median + 95% CI; write "not reached" (not NA, not blank) when the curve does not cross 0.5 |
+| Group comparison | Log-rank p-value AND HR + 95% CI — never p-value alone |
+| Multiple group comparisons | Adjust log-rank p-values with `p.adjust(ps, "holm")` before reporting |
+
+---
+
+## Minimum figure requirements for any published survival plot
+
+Every survival figure must have:
+
+1. **CI band** around the survival curve (not just the point estimate line)
+2. **At-risk table** immediately beneath the figure (use `risk.table = TRUE` in
+   `survminer::ggsurvplot()`)
+3. **Censoring tick marks** on the curve at each censored time point
+4. **Units** on the x-axis label (days, hours, etc.)
+5. **Caption** with dynamic values: n, events, median + CI
+
+```r
+# Compliant ggsurvplot call
+ggsurvplot(
+  fit,
+  data        = df,
+  conf.int    = TRUE,
+  conf.type   = "log-log",    # respects (0,1) boundaries
+  risk.table  = TRUE,
+  censor      = TRUE,         # tick marks
+  xlab        = "Days",
+  caption     = paste0(
+    "n = ", n_total, "; events = ", n_events,
+    "; median = ", median_surv, " days (95% CI ", ci_lo, "–", ci_hi, ")"
+  )
+)
+```
+
+---
+
+## Hazard ratio reporting format
+
+```
+HR = 1.4 (95% CI 1.1–1.9; p = 0.008; reference: llm repo)
+Proportional hazards: Schoenfeld residuals global p = 0.34 (assumption met)
+```
+
+If proportional hazards is violated (global Schoenfeld p < 0.05), state this
+explicitly and report the appropriate alternative (stratified Cox, time-interaction
+term, or parametric model).
+
+---
+
+## "Not reached" convention
+
+When a KM curve does not cross the 0.5 probability threshold, the median survival
+is undefined within the follow-up window. Report it as **"not reached"**, not as
+`NA`, `Inf`, or blank. Include the largest observed event time as context:
+
+> "Median time-to-close: not reached (largest observed: 142 days; 38% of items
+> still open at snapshot)"
+
+---
+
+## Forbidden patterns
+
+| Pattern | Why wrong | Fix |
+|---|---|---|
+| KM curve without at-risk table | Reader cannot judge n at each time point | Add `risk.table = TRUE` |
+| KM curve without CI band | Single line conceals uncertainty | Add `conf.int = TRUE` |
+| HR without CI | Effect size without precision is uninterpretable | Report HR + 95% CI |
+| "not significant" without effect size | Absence of evidence ≠ evidence of absence | Always report HR + CI |
+| Median = `NA` or blank when curve doesn't cross 0.5 | Ambiguous — is it missing or not reached? | Write "not reached" |
+| Log-rank p without HR | No effect size | Add HR from `coxph()` |
+| Unadjusted p-values for >2 group comparison | Multiple testing inflation | Use `p.adjust(ps, "holm")` |
+| Dropping censored rows before analysis | Biases all summary statistics downward | Include censored rows with `event = 0` |
+| Colour as sole arm differentiator | Fails accessibility (colour-blind users) | Use BOTH colour AND line type |
+
+---
+
+## Related
+
+- `statistical-reporting` — parent rule; effect size before p-value, numeric precision
+- `survival-analysis` skill — the workflow rule implements; step-by-step code
+- `narrative-evidence-block` — methodology block in vignettes must name survival data sources
+- `dynamic-prose-values` — n, events, median, CI in captions must be R expressions, not hardcoded
+- `accessibility` — 4.5:1 contrast for CI bands; line type + colour for arm differentiation
+- `dashboard-table-styling` — at-risk tables follow right-justify, width-auto rules

--- a/.claude/skills/survival-analysis/SKILL.md
+++ b/.claude/skills/survival-analysis/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: survival-analysis
+description: "Use when performing time-to-event analysis where censoring matters: PR merge time, issue close time, finding resolution, CI recovery. Triggers: survival analysis, KM curve, Kaplan-Meier, hazard ratio, censored data, time-to-event, TTE, coxph, flexsurv, ggsurvplot."
+metadata:
+  type: skill
+---
+# Survival Analysis
+
+## When to use this skill
+
+Use when the outcome is the **time until an event** and some observations may never
+experience that event (censored). The classic failure mode is analysing censored
+times as if they were fully observed — this biases every summary statistic downward.
+
+**Apply this skill when:**
+
+- Computing time-to-PR-merge, time-to-issue-close, time-to-finding-resolution
+- Comparing resolution rates across repos, agent types, or severity tiers
+- Asking "what fraction never resolve?" or "when does the median tail thin out?"
+- Fitting parametric models to describe hazard shape over time
+
+**Do NOT use when:**
+
+- Every observation experiences the event before the analysis window closes (no censoring)
+- The "time" variable is a fixed period (e.g. daily count, not a duration to event)
+- You only care about proportions, not timing
+
+---
+
+## Baseline-first workflow
+
+Mirror the `modeling-baselines` principle: always fit the simplest adequate model
+before reaching for complexity.
+
+### Step 1 — Kaplan-Meier (non-parametric baseline)
+
+KM makes no distributional assumptions. Always start here.
+
+```r
+library(survival)
+library(survminer)
+
+# Build the Surv object — event column is 1 = event occurred, 0 = censored
+surv_obj <- Surv(time = df$days_to_close, event = df$closed)
+
+# Overall KM curve
+km_fit <- survfit(surv_obj ~ 1, data = df)
+
+# Stratified KM
+km_strat <- survfit(surv_obj ~ repo, data = df)
+
+# Plot with CI band + at-risk table + censoring marks (all three are mandatory)
+ggsurvplot(
+  km_strat,
+  data        = df,
+  conf.int    = TRUE,
+  conf.type   = "log-log",   # log-log transformation respects (0,1) boundaries
+  risk.table  = TRUE,
+  censor      = TRUE,
+  palette     = PALETTE,     # use project palette — narrative-colour-persistence rule
+  xlab        = "Days",
+  ylab        = "Probability of remaining open",
+  legend.labs = levels(df$repo)
+)
+```
+
+`conf.type = "log-log"` is the default for `ggsurvplot` in recent survminer. Prefer
+it over `"plain"` because plain CIs can exceed (0, 1) near boundaries.
+
+### Step 2 — Cox proportional hazards (semi-parametric)
+
+Cox requires no shape assumption for the baseline hazard. It IS parametric in the
+covariate effects (linear log-hazard). Fit it before any fully parametric model.
+
+```r
+cox_fit <- coxph(
+  Surv(days_to_close, closed) ~ repo + severity + agent_type,
+  data = df,
+  ties = "efron"   # Efron is preferred for tied event times
+)
+
+summary(cox_fit)  # reports HR + CI + Wald test for each covariate
+
+# MANDATORY: test the proportional hazards assumption
+cox_zph_result <- cox.zph(cox_fit)
+print(cox_zph_result)       # global test + per-covariate test
+plot(cox_zph_result)        # Schoenfeld residuals — should be flat over time
+```
+
+If `cox.zph()` global p < 0.05, the proportional hazards assumption is violated.
+Options: stratify by the offending variable, add a time-interaction term, or switch
+to a parametric model.
+
+### Step 3 — Parametric models (when shape matters)
+
+Fit parametric models when you need to extrapolate beyond observed follow-up, or
+when the hazard shape itself is of interest.
+
+```r
+library(flexsurv)
+
+# Start with simplest: exponential (constant hazard)
+fit_exp  <- flexsurvreg(Surv(days_to_close, closed) ~ repo, data = df,
+                        dist = "exponential")
+
+# Weibull allows monotone increasing/decreasing hazard
+fit_wb   <- flexsurvreg(Surv(days_to_close, closed) ~ repo, data = df,
+                        dist = "weibull")
+
+# Gompertz allows accelerating hazard (common in biological/organisational processes)
+fit_gomp <- flexsurvreg(Surv(days_to_close, closed) ~ repo, data = df,
+                        dist = "gompertz")
+
+# Compare by AIC (lower = better fit penalised for complexity)
+AIC(fit_exp, fit_wb, fit_gomp)
+
+# Overlay parametric fits on KM curve to check visual agreement
+plot(km_fit)
+lines(fit_wb, col = "steelblue", lty = 2)
+```
+
+Pick the parametric distribution with the lowest AIC **and** a plausible hazard
+shape for your domain. For software events (issues, PRs), a Weibull with decreasing
+hazard (shape < 1) often fits — early-stage items close fast; long-running ones slow.
+
+---
+
+## Confidence intervals — three flavours
+
+| Type | What it covers | Recommended for |
+|------|---------------|-----------------|
+| **Pointwise** | S(t) at each time point separately | Dashboards, single-arm curves |
+| **Hall-Wellner band** | Entire curve simultaneously | Formal inference, regulatory |
+| **Equal-precision band** | Curve simultaneously, narrower near median | Publication figures |
+
+For dashboards: pointwise CIs (`conf.type = "log-log"` in `survfit`). For formal
+reporting where you claim anything about the whole curve shape, use simultaneous bands
+via `km.ci::km.ci()`.
+
+---
+
+## Group comparisons
+
+Log-rank test compares survival curves across groups. ALWAYS pair it with a hazard
+ratio.
+
+```r
+# Log-rank test
+survdiff(Surv(days_to_close, closed) ~ repo, data = df)
+
+# Hazard ratio (from Cox, one covariate)
+cox_single <- coxph(Surv(days_to_close, closed) ~ repo, data = df)
+exp(coef(cox_single))          # HR
+exp(confint(cox_single))       # 95% CI on HR
+```
+
+Report both: "Log-rank p = 0.02; HR for `llmtelemetry` vs `llm` = 1.4 (95% CI 1.1–1.9)".
+A log-rank p without an HR is uninterpretable for effect size.
+
+Multiple comparisons: if you compare > 2 groups, adjust log-rank p-values via
+`p.adjust(ps, "holm")` before reporting.
+
+---
+
+## Visual checks
+
+Every survival analysis requires at minimum:
+
+1. **KM curve with CI band and at-risk table** — see Step 1 above
+2. **Schoenfeld residuals** — confirms proportional hazards for any Cox model
+3. **Parametric overlay on KM** — confirms chosen distribution fits
+
+For the hazard function directly:
+
+```r
+library(muhaz)
+
+# Kernel-smoothed hazard estimate
+haz <- muhaz(df$days_to_close, df$closed)
+plot(haz)
+```
+
+---
+
+## Visual predictive checks for parametric models
+
+When you fit a parametric model, overlay simulated survival curves from the fitted
+distribution on the observed KM curve. If the model fits, they should track closely.
+
+```r
+# flexsurv provides this directly
+plot(fit_wb, ci = TRUE, col = "steelblue")
+lines(km_fit, conf.int = FALSE, col = "black", lty = 1)
+legend("topright", c("Kaplan-Meier", "Weibull fit"),
+       col = c("black", "steelblue"), lty = c(1, 2))
+```
+
+For parametric TTE models, `vpc::vpc_tte()` produces a VPC with prediction
+intervals. Use it when extrapolating beyond the observation window.
+
+---
+
+## Censoring discipline
+
+Careless censoring encoding is the most common TTE data quality failure.
+
+**Mandatory column convention:**
+
+| Column | Type | Meaning |
+|--------|------|---------|
+| `time_to_event` | numeric (days/hours) | Duration from origin to event or censoring |
+| `event` | integer 0/1 | 1 = event occurred; 0 = censored |
+| `censor_reason` | character | Why censored: `"still_open"`, `"snapshot_date"`, `"deleted"` |
+
+**Never:**
+- Combine event and censor reason in a single coded column
+- Impute a censoring time (e.g. assign `time_to_event = max_follow_up` for open items without recording why)
+- Drop censored observations (this is NOT how you "clean" TTE data)
+
+```r
+# WRONG: drop open items
+df |> filter(closed == 1)  # discards all right-censored observations
+
+# RIGHT: include all rows, set event = 0 for open items
+df |>
+  mutate(
+    event        = as.integer(!is.na(closed_at)),
+    time_days    = coalesce(
+      as.numeric(closed_at - created_at, units = "days"),
+      as.numeric(snapshot_date - created_at, units = "days")
+    ),
+    censor_reason = if_else(event == 1L, NA_character_, "still_open_at_snapshot")
+  )
+```
+
+---
+
+## Reporting checklist
+
+For every survival result published in a vignette, dashboard, or PR:
+
+- [ ] KM curve shown with 95% CI band (not just the median line)
+- [ ] At-risk table beneath the curve
+- [ ] Censoring tick marks visible on the curve
+- [ ] Median survival + 95% CI stated; "not reached" when curve does not cross 0.5
+- [ ] For any group comparison: log-rank p AND HR + 95% CI
+- [ ] Reference category named explicitly when reporting HR
+- [ ] Schoenfeld residuals checked (and result noted) for any Cox model
+- [ ] Units stated (days, hours, etc.)
+
+See `survival-reporting` rule for the full mandatory table.
+
+---
+
+## llmtelemetry use cases
+
+Five TTE outcomes in llmtelemetry data with natural survival framing:
+
+| Outcome | Origin | Event | Censoring |
+|---------|--------|-------|-----------|
+| PR merge time | `created_at` | `merged_at` set | PR still open |
+| Issue close time | `created_at` | `closed_at` set | Issue still open |
+| Finding resolution | `found_at` | `resolved_at` set | Finding still open |
+| CI fix after failure | First red build | Next green build | Branch still red |
+| Session completion | Session start | `/bye` event | Context-compacted |
+
+Sketch for PR merge time survival curve:
+
+```r
+# Assumes df has columns: pr_number, created_at, merged_at, repo, snapshot_date
+pr_surv <- df |>
+  mutate(
+    event     = as.integer(!is.na(merged_at)),
+    time_days = coalesce(
+      as.numeric(merged_at - created_at, units = "days"),
+      as.numeric(snapshot_date - created_at, units = "days")
+    )
+  )
+
+km_pr <- survfit(Surv(time_days, event) ~ repo, data = pr_surv)
+
+ggsurvplot(
+  km_pr, data = pr_surv,
+  conf.int = TRUE, conf.type = "log-log",
+  risk.table = TRUE, censor = TRUE,
+  xlab = "Days since PR opened", ylab = "Probability unmerged",
+  palette = PALETTE
+)
+```
+
+The y-axis label "Probability unmerged" is deliberately informative — it reads as
+"what fraction are still unmerged at day X", which is what 1 − S(t) answers from the
+analyst's perspective when S(t) is the survival function.
+
+---
+
+## Related
+
+- `modeling-baselines` — the parallel "baseline-first" principle; KM is the TTE baseline
+- `model-evaluation-calibration` — would extend with concordance index (C-statistic) for Cox
+- `survival-reporting` rule — mandatory reporting table for every published survival result
+- `narrative-colour-persistence` — same arm MUST use same colour across all survival panels
+- `hover-popup-standard` — arm-level tooltips showing N, events, censored
+- `accessibility` — survival curves with CI bands require 4.5:1 contrast; arms differentiated
+  by BOTH line type AND colour, never colour alone
+- `statistical-reporting` rule — parent rule covering effect size, multiple comparisons

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Single trailing `\| head -N` / `\| tail -N` / `\| wc -l` / `\| sort -u` / `\| un
 **Knowledge Base (raw/wiki/outputs):** Use `knowledge-base-wiki` skill. Central hub at `~/docs_gh/llm/knowledge/` (LOCAL git only — NEVER push to GitHub, `PRIVATE` marker + pre-push hook block). raw/ is append-only (enforced by `file_protection.sh`), wiki/ requires `## Sources` section, AI-inferred claims tagged `> ⚠ AI-inferred:`, cross-wiki links use `[[topic]]` syntax. T1 health check on every Edit/Write via `wiki_health_onwrite.sh`. Run `/wiki-health` after batch updates. Use `wiki-curator` agent to compile, `critic` (wiki validation mode) for adversarial review.
 
 **Mandatory skills:** `adversarial-qa`, `quality-gates`, `r-package-workflow`, `test-driven-development`, `nix-rix-r-environment`, `llm-package-context`, `readme-qmd-standard`, `subagent-delegation`, `spec-bundled-skills`, `knowledge-base-wiki`.
-**Mandatory rules:** `systematic-debugging`, `verification-before-completion`, `btw-timeouts`, `orchestrator-protocol`, `provenance-mandatory`, `raw-folder-readonly`, `confidence-markers`, `wiki-storage-policy`, `git-no-compound-cd`, `look-ahead-bias-prevention`, `nix-agent-shell-protocol`, `worktree-location`, `dark-mode-completeness`, `narrative-evidence-block`, `narrative-colour-persistence`, `mermaid-click-anchors`, `roborev-exclude-patterns`, `cross-cutting-rename`, `dashboard-table-styling`, `uniform-typography`, `branch-harvest-on-fork`, `dashboard-filter-placement`.
+**Mandatory rules:** `systematic-debugging`, `verification-before-completion`, `btw-timeouts`, `orchestrator-protocol`, `provenance-mandatory`, `raw-folder-readonly`, `confidence-markers`, `wiki-storage-policy`, `git-no-compound-cd`, `look-ahead-bias-prevention`, `nix-agent-shell-protocol`, `worktree-location`, `dark-mode-completeness`, `narrative-evidence-block`, `narrative-colour-persistence`, `mermaid-click-anchors`, `roborev-exclude-patterns`, `cross-cutting-rename`, `dashboard-table-styling`, `uniform-typography`, `branch-harvest-on-fork`, `dashboard-filter-placement`, `survival-reporting`.
 
 **Dark-mode contrast (every Quarto project):** Single global script at `~/docs_gh/llm/.claude/scripts/check_dark_contrast.sh` (public mirror: `https://raw.githubusercontent.com/JohnGavin/llm/main/.claude/scripts/check_dark_contrast.sh`). NEVER copy into a project. EVERY `_quarto.yml` MUST add this line under `project: post-render:` — `- /Users/johngavin/docs_gh/llm/.claude/scripts/quarto_post_render_contrast.sh`. Render fails on any uncovered light inline background. See `dark-mode-completeness` rule.
 
@@ -72,7 +72,7 @@ Single trailing `\| head -N` / `\| tail -N` / `\| wc -l` / `\| sort -u` / `\| un
 | `shinylive-builder` | sonnet | Build/test Shinylive WASM vignettes |
 | `wiki-curator` | sonnet | Compile raw/ source material into wiki/ |
 
-## Skills by Category (64)
+## Skills by Category (65)
 
 ### Mandatory (always apply)
 - `adversarial-qa` — QA protocol with severity tiers
@@ -106,6 +106,7 @@ Single trailing `\| head -N` / `\| tail -N` / `\| wc -l` / `\| sort -u` / `\| un
 - `eda-workflow` — Exploratory data analysis
 - `modeling-baselines` — Baseline model patterns + model code checklist
 - `model-evaluation-calibration` — Model assessment
+- `survival-analysis` — Time-to-event analysis: KM curves, Cox PH, parametric TTE, censoring
 - `analysis-rationale-logging` — Decision logging
 - `gdc-genomics` — GDC/genomics data
 - `erddap-ocean-data` — ERDDAP ocean data access
@@ -197,9 +198,9 @@ Single trailing `\| head -N` / `\| tail -N` / `\| wc -l` / `\| sort -u` / `\| un
 
 `deploy-new-project.md`, `onboard-dataset.md`, `debug-ci-failure.md`, `publish-vignette.md`
 
-## Rules (50)
+## Rules (51)
 
-Core: `auto-delegation`, `architecture-planning`, `orchestrator-protocol`, `systematic-debugging`, `verification-before-completion`, `pivot-signal`, `cross-cutting-rename`, `branch-harvest-on-fork`. Nix: `nix-agent-shell-protocol`, `nix-nested-shell-isolation`. MCP: `btw-timeouts`. Bash: `bash-safety`. Data: `data-in-packages`, `data-validation-timeseries`, `credential-management`. Stats: `statistical-reporting`, `suppress-warnings-antipattern`. Viz: `visualization`, `dynamic-prose-values`, `uniform-typography`, `dashboard-table-styling`, `dashboard-filter-placement`. Quarto: `quarto-vignettes`, `acronym-expansion`. Shiny: `module-isolation`, `shiny-module-data-sharing`, `shinylive-webr-nonblocking`. Pipeline: `qa-targets-pipeline`, `ctx-yaml-cache`. Knowledge: `wiki-conventions`. Quality: `accessibility`, `analytical-review-checklist`, `analysis-rationale-mandatory`, `braindump-closed-loop`. Security: `destructive-fs-guard`, `destructive-ops-guard`, `permission-discipline`, `backup-architecture`. Other: `website-index-update`, `t-lang-r-package`, `huggingface-upload`, `gh-pages-nojekyll`, `namespace-discipline`, `portable-paths`, `project-charter`, `roborev-resolution`, `single-change-experiment`, `snapshot-tests-mandatory`, `search-all-pipeline-stages`, `audience-communication`.
+Core: `auto-delegation`, `architecture-planning`, `orchestrator-protocol`, `systematic-debugging`, `verification-before-completion`, `pivot-signal`, `cross-cutting-rename`, `branch-harvest-on-fork`. Nix: `nix-agent-shell-protocol`, `nix-nested-shell-isolation`. MCP: `btw-timeouts`. Bash: `bash-safety`. Data: `data-in-packages`, `data-validation-timeseries`, `credential-management`. Stats: `statistical-reporting`, `suppress-warnings-antipattern`, `survival-reporting`. Viz: `visualization`, `dynamic-prose-values`, `uniform-typography`, `dashboard-table-styling`, `dashboard-filter-placement`. Quarto: `quarto-vignettes`, `acronym-expansion`. Shiny: `module-isolation`, `shiny-module-data-sharing`, `shinylive-webr-nonblocking`. Pipeline: `qa-targets-pipeline`, `ctx-yaml-cache`. Knowledge: `wiki-conventions`. Quality: `accessibility`, `analytical-review-checklist`, `analysis-rationale-mandatory`, `braindump-closed-loop`. Security: `destructive-fs-guard`, `destructive-ops-guard`, `permission-discipline`, `backup-architecture`. Other: `website-index-update`, `t-lang-r-package`, `huggingface-upload`, `gh-pages-nojekyll`, `namespace-discipline`, `portable-paths`, `project-charter`, `roborev-resolution`, `single-change-experiment`, `snapshot-tests-mandatory`, `search-all-pipeline-stages`, `audience-communication`.
 
 ## Hooks (9 scripts, 5 event hooks)
 


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/survival-analysis/SKILL.md` (306 lines): baseline-first TTE workflow — KM via `survival::survfit()` + `survminer::ggsurvplot()`, Cox PH with `cox.zph()` proportional-hazards check, parametric models via `flexsurv::flexsurvreg()` (exponential → Weibull → Gompertz, pick by AIC), censoring column discipline, five concrete llmtelemetry use cases with sketch code for PR merge time survival curve.
- Adds `.claude/rules/survival-reporting.md` (117 lines): mandatory reporting table covering KM figures (CI band + at-risk table + tick marks), hazard ratios (HR + CI + p + reference category + Schoenfeld note), median survival "not reached" convention, and log-rank p always paired with HR. Extends `statistical-reporting`.
- Updates `AGENTS.md`: `survival-analysis` skill added to Data & Analysis (65 total); `survival-reporting` added to mandatory rules list and Stats rule group (50 total).

## What is NOT in this PR (follow-up)

The llmtelemetry dashboard survival panels (PR lifecycle, issue resolution, finding resolution, CI recovery) are deferred to a follow-up issue. This PR ships the skill and reporting rule that panel implementation will cite.

## Test plan

- [x] `wc -l .claude/skills/survival-analysis/SKILL.md` → 306 (< 500)
- [x] `wc -l .claude/rules/survival-reporting.md` → 117 (< 150)
- [x] `grep -c "survival-reporting" AGENTS.md` → 2
- [x] `grep -c "survival-analysis" AGENTS.md` → 1
- [x] `git diff --stat main` → 3 files, 428 insertions

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
