### PR TITLE
feat(#449): roborev daily — 1-day metrics + linkified outliers + rename TTC + per-project severity

### DIFF
--- a/.claude/scripts/roborev_daily_report.R
+++ b/.claude/scripts/roborev_daily_report.R
@@ -7,6 +7,8 @@
 #                          (median/p90), close_rate
 #   §3  Trends:            each metric vs prior equivalent window (% + absolute)
 #   §4  Outliers (14d):    top-10 by attempts_to_close + top-10 by time_to_close_hrs
+#   §5  Severity by project (7d):  per-repo counts of High/Medium/Low/Unknown findings
+#                                  (llm#449)
 #
 # Writes:
 #   - JSON snapshot → $ROBOREV_DAILY_DIR/YYYY-MM-DD.json  (default ~/.claude/logs/roborev_daily_report/)
@@ -334,6 +336,62 @@ trend_delta <- function(cur_val, pri_val) {
   }
 }
 
+# ── §5 Per-project severity frequency (7-day window) ─────────────────────────
+#
+# Returns a list of records {repo, High, Medium, Low, Unknown, Total}
+# sorted descending by Total.  Uses severity_max column from lifecycle table.
+
+compute_severity_by_project <- function(con, anchor, days) {
+  bounds <- window_bounds(anchor, days)
+  sql <- sprintf(
+    "SELECT
+       repo,
+       COALESCE(severity_max, 'Unknown') AS severity,
+       COUNT(*)::INTEGER AS n
+     FROM roborev_review_lifecycle
+     WHERE verdict = 'F'
+       AND created_at::TIMESTAMP >= TIMESTAMP '%s'
+       AND created_at::TIMESTAMP <  TIMESTAMP '%s'
+     GROUP BY repo, severity_max
+     ORDER BY repo",
+    fmt_ts(bounds$cur$start), fmt_ts(bounds$cur$end)
+  )
+  raw <- tryCatch(
+    dbGetQuery(con, sql),
+    error = function(e) {
+      message("roborev_daily_report.R: severity_by_project query error: ",
+              conditionMessage(e))
+      data.frame(repo = character(), severity = character(), n = integer(),
+                 stringsAsFactors = FALSE)
+    }
+  )
+  if (nrow(raw) == 0L) return(list())
+
+  sev_levels <- c("High", "Medium", "Low", "Unknown")
+  repos <- unique(raw$repo)
+  pivot <- lapply(repos, function(r) {
+    sub_df <- raw[raw$repo == r, ]
+    counts <- setNames(
+      vapply(sev_levels, function(s) {
+        idx <- sub_df$severity == s
+        if (any(idx)) as.integer(sub_df$n[idx][1L]) else 0L
+      }, integer(1L)),
+      sev_levels
+    )
+    list(
+      repo    = r,
+      High    = counts[["High"]],
+      Medium  = counts[["Medium"]],
+      Low     = counts[["Low"]],
+      Unknown = counts[["Unknown"]],
+      Total   = sum(counts)
+    )
+  })
+  # Sort desc by Total
+  totals <- vapply(pivot, function(x) x[["Total"]], integer(1L))
+  pivot[order(-totals)]
+}
+
 # ── §4 Outliers (14-day window) ───────────────────────────────────────────────
 #
 # Returns list(by_attempts, by_time) — each a data.frame of top-10 closed
@@ -469,6 +527,10 @@ df_14d_global <- load_window(con, bounds_14d$cur$start, bounds_14d$cur$end)
 df_14d_global <- enrich_with_attempts(con, df_14d_global, has_lineage_table)
 outliers_14d  <- compute_outliers(df_14d_global)
 
+# §5 Severity by project: 7d global
+cat("roborev_daily_report.R: computing 7d per-project severity table...\n")
+severity_by_project_7d <- compute_severity_by_project(con, anchor_date, 7L)
+
 # ── Assemble JSON output ───────────────────────────────────────────────────────
 
 report_date   <- format(anchor_date, "%Y-%m-%d", tz = "UTC")
@@ -519,7 +581,8 @@ json_payload <- list(
   outliers_14d   = list(
     by_attempts = outliers_14d$by_attempts,
     by_time     = outliers_14d$by_time
-  )
+  ),
+  severity_by_project_7d = severity_by_project_7d  # §5: per-repo severity counts (llm#449)
 )
 
 # ── Write JSON snapshot ───────────────────────────────────────────────────────

--- a/.claude/scripts/send_roborev_email.R
+++ b/.claude/scripts/send_roborev_email.R
@@ -87,6 +87,7 @@ accent_purple <- "#bb86fc"
 # ── Formatting helpers ─────────────────────────────────────────────────────────
 
 fmt_hrs  <- function(x) if (is.null(x) || is.na(x)) "n/a" else sprintf("%.1fh", as.numeric(x))
+fmt_num  <- function(x) if (is.null(x) || is.na(x)) "n/a" else sprintf("%.1f", as.numeric(x))  # bare number (no unit suffix) — llm#449
 fmt_att  <- function(x) if (is.null(x) || is.na(x)) "n/a" else sprintf("%.1f", as.numeric(x))
 fmt_rate <- function(x) {
   if (is.null(x) || is.na(x)) return("n/a")
@@ -105,8 +106,9 @@ fmt_trend <- function(td) {
 }
 fmt_int  <- function(x) if (is.null(x) || is.na(x)) "0" else formatC(as.integer(x), format = "d", big.mark = ",")
 
-# ── Extract 7-day window slice ─────────────────────────────────────────────────
+# ── Extract window slices ──────────────────────────────────────────────────────
 
+d1 <- snap[["global_windows"]][["d1"]]  # 1-day window — llm#449
 d7 <- snap[["global_windows"]][["d7"]]
 
 # §1 Frequency table
@@ -143,6 +145,21 @@ outliers_by_att <- snap[["outliers_14d"]][["by_attempts"]]
 if (is.null(outliers_by_att)) outliers_by_att <- list()
 n_outliers_att <- min(5L, length(outliers_by_att))
 
+# ── Extract 1-day metrics for headline (llm#449) ──────────────────────────────
+
+d1_freq_rows <- if (!is.null(d1)) d1[["freq_table"]] else list()
+d1_found_closed <- 0L; d1_found_open <- 0L; d1_clean_closed <- 0L; d1_clean_open <- 0L
+for (row in d1_freq_rows) {
+  v <- row[["verdict_label"]]; s <- row[["status"]]; n <- as.integer(row[["n"]])
+  if (identical(v, "issues_found") && identical(s, "closed")) d1_found_closed <- n
+  if (identical(v, "issues_found") && identical(s, "open"))   d1_found_open   <- n
+  if (identical(v, "clean")        && identical(s, "closed")) d1_clean_closed <- n
+  if (identical(v, "clean")        && identical(s, "open"))   d1_clean_open   <- n
+}
+d1_sp <- if (!is.null(d1)) d1[["speed"]] else list()
+d1_ttc_p50 <- d1_sp[["ttc_p50_hrs"]]; d1_close_rate <- d1_sp[["close_rate"]]
+d1_att_p50 <- d1_sp[["att_p50"]]
+
 # ── Build headline summary table (Metric | Value — no bar/pie charts) ─────────
 
 report_date <- snap[["report_date"]] %||% format(Sys.Date())
@@ -166,7 +183,41 @@ dashboard_block <- sprintf(
   ROBOREV_DASHBOARD_URL, accent_blue
 )
 
-# §1 + §2 Headline two-column table
+# §1 + §2 Headline Metrics (last 24h) — shown FIRST (llm#449)
+headline_1d_rows <- list(
+  c("24h: issues found (closed)",  fmt_int(d1_found_closed)),
+  c("24h: issues found (open)",    fmt_int(d1_found_open)),
+  c("24h: clean (closed)",         fmt_int(d1_clean_closed)),
+  c("24h: clean (open)",           fmt_int(d1_clean_open)),
+  c("24h: close rate",             fmt_rate(d1_close_rate)),
+  c("24h: hours to close p50",     fmt_num(d1_ttc_p50)),
+  c("24h: attempts p50",           fmt_att(d1_att_p50))
+)
+
+headline_1d_html <- sprintf(
+  '<h3 style="color:%s; margin-top:20px;">Headline Metrics (last 24h)</h3>
+<table style="border-collapse:collapse; width:100%%; font-size:12px;">
+  <tr style="background-color:%s;">
+    <th style="padding:6px 8px; border:1px solid %s; color:white; text-align:left;">Metric</th>
+    <th style="padding:6px 8px; border:1px solid %s; color:white; text-align:right;">Value</th>
+  </tr>',
+  accent_green, dark_row_alt, dark_border, dark_border
+)
+for (i in seq_along(headline_1d_rows)) {
+  bg <- if (i %% 2 == 0) dark_row_alt else dark_card
+  headline_1d_html <- paste0(headline_1d_html, sprintf(
+    '<tr style="background-color:%s;">
+      <td style="padding:5px 8px; border:1px solid %s; color:%s;">%s</td>
+      <td style="padding:5px 8px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+    </tr>',
+    bg,
+    dark_border, dark_text, headline_1d_rows[[i]][1],
+    dark_border, accent_green, headline_1d_rows[[i]][2]
+  ))
+}
+headline_1d_html <- paste0(headline_1d_html, "</table>")
+
+# §1 + §2 Headline two-column table (7-day)
 headline_rows <- list(
   c("7d: issues found (closed)",  fmt_int(issues_found_closed)),
   c("7d: issues found (open)",    fmt_int(issues_found_open)),
@@ -232,7 +283,7 @@ for (i in seq_along(trend_rows)) {
 }
 trends_html <- paste0(trends_html, "</table>")
 
-# §4 Outliers — top-5 by time-to-close
+# §4 Outliers — top-5 by time-to-close (llm#449: linkified IDs+Repos, renamed TTC header)
 outlier_ttc_html <- sprintf(
   '<h3 style="color:%s; margin-top:20px;">Top-5 Outliers by Time-to-Close (14d)</h3>
 <p style="color:%s; font-size:11px; margin-bottom:6px;">Full detail (top-10) in the JSON snapshot and on the dashboard.</p>
@@ -240,7 +291,7 @@ outlier_ttc_html <- sprintf(
   <tr style="background-color:%s;">
     <th style="padding:5px; border:1px solid %s; color:white;">ID</th>
     <th style="padding:5px; border:1px solid %s; color:white;">Repo</th>
-    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">TTC</th>
+    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">Hours to close (h)</th>
     <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">Attempts</th>
     <th style="padding:5px; border:1px solid %s; color:white;">Reason</th>
   </tr>',
@@ -251,6 +302,16 @@ if (n_outliers > 0L) {
   for (i in seq_len(n_outliers)) {
     r <- outliers_by_time[[i]]
     bg <- if (i %% 2 == 0) dark_row_alt else dark_card
+    rid  <- r[["review_id"]] %||% ""
+    repo <- r[["repo"]] %||% ""
+    id_link   <- if (nzchar(rid) && nzchar(repo))
+      sprintf('<a href="https://github.com/JohnGavin/%s/issues/%s" style="color:%s;">%s</a>',
+              repo, rid, accent_blue, rid)
+    else rid
+    repo_link <- if (nzchar(repo))
+      sprintf('<a href="https://github.com/JohnGavin/%s" style="color:%s;">%s</a>',
+              repo, accent_blue, repo)
+    else repo
     outlier_ttc_html <- paste0(outlier_ttc_html, sprintf(
       '<tr style="background-color:%s;">
         <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
@@ -260,9 +321,9 @@ if (n_outliers > 0L) {
         <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
       </tr>',
       bg,
-      dark_border, accent_blue, r[["review_id"]] %||% "",
-      dark_border, dark_text, r[["repo"]] %||% "",
-      dark_border, accent_orange, fmt_hrs(r[["time_to_close_hrs"]]),
+      dark_border, accent_blue, id_link,
+      dark_border, dark_text, repo_link,
+      dark_border, accent_orange, fmt_num(r[["time_to_close_hrs"]]),
       dark_border, dark_text, fmt_int(r[["n_attempts"]]),
       dark_border, dark_muted, r[["close_reason"]] %||% ""
     ))
@@ -273,7 +334,7 @@ if (n_outliers > 0L) {
 }
 outlier_ttc_html <- paste0(outlier_ttc_html, "</table>")
 
-# §4 Outliers — top-5 by attempts
+# §4 Outliers — top-5 by attempts (llm#449: linkified IDs+Repos, renamed TTC header)
 outlier_att_html <- sprintf(
   '<h3 style="color:%s; margin-top:20px;">Top-5 Outliers by Attempts-to-Close (14d)</h3>
 <table style="border-collapse:collapse; width:100%%; font-size:11px;">
@@ -281,7 +342,7 @@ outlier_att_html <- sprintf(
     <th style="padding:5px; border:1px solid %s; color:white;">ID</th>
     <th style="padding:5px; border:1px solid %s; color:white;">Repo</th>
     <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">Attempts</th>
-    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">TTC</th>
+    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">Hours to close (h)</th>
     <th style="padding:5px; border:1px solid %s; color:white;">Reason</th>
   </tr>',
   accent_purple, dark_row_alt, dark_border, dark_border, dark_border, dark_border, dark_border
@@ -290,6 +351,16 @@ if (n_outliers_att > 0L) {
   for (i in seq_len(n_outliers_att)) {
     r <- outliers_by_att[[i]]
     bg <- if (i %% 2 == 0) dark_row_alt else dark_card
+    rid  <- r[["review_id"]] %||% ""
+    repo <- r[["repo"]] %||% ""
+    id_link   <- if (nzchar(rid) && nzchar(repo))
+      sprintf('<a href="https://github.com/JohnGavin/%s/issues/%s" style="color:%s;">%s</a>',
+              repo, rid, accent_blue, rid)
+    else rid
+    repo_link <- if (nzchar(repo))
+      sprintf('<a href="https://github.com/JohnGavin/%s" style="color:%s;">%s</a>',
+              repo, accent_blue, repo)
+    else repo
     outlier_att_html <- paste0(outlier_att_html, sprintf(
       '<tr style="background-color:%s;">
         <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
@@ -299,10 +370,10 @@ if (n_outliers_att > 0L) {
         <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
       </tr>',
       bg,
-      dark_border, accent_blue, r[["review_id"]] %||% "",
-      dark_border, dark_text, r[["repo"]] %||% "",
+      dark_border, accent_blue, id_link,
+      dark_border, dark_text, repo_link,
       dark_border, accent_orange, fmt_int(r[["n_attempts"]]),
-      dark_border, dark_text, fmt_hrs(r[["time_to_close_hrs"]]),
+      dark_border, dark_text, fmt_num(r[["time_to_close_hrs"]]),
       dark_border, dark_muted, r[["close_reason"]] %||% ""
     ))
   }
@@ -311,6 +382,54 @@ if (n_outliers_att > 0L) {
     sprintf('<tr><td colspan="5" style="padding:6px; color:%s;">(no data in 14-day window)</td></tr>', dark_muted))
 }
 outlier_att_html <- paste0(outlier_att_html, "</table>")
+
+# §5 Per-project severity frequency table (llm#449)
+severity_rows_data <- snap[["severity_by_project_7d"]]
+if (is.null(severity_rows_data)) severity_rows_data <- list()
+
+severity_html <- sprintf(
+  '<h3 style="color:%s; margin-top:20px;">Severity by Project (7d)</h3>
+<table style="border-collapse:collapse; width:100%%; font-size:11px;">
+  <tr style="background-color:%s;">
+    <th style="padding:5px 8px; border:1px solid %s; color:white; text-align:left;">Project</th>
+    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">High</th>
+    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">Medium</th>
+    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">Low</th>
+    <th style="padding:5px; border:1px solid %s; color:white; text-align:right;">Total</th>
+  </tr>',
+  accent_purple,
+  dark_row_alt, dark_border, dark_border, dark_border, dark_border, dark_border
+)
+if (length(severity_rows_data) > 0L) {
+  for (i in seq_along(severity_rows_data)) {
+    sr <- severity_rows_data[[i]]
+    bg <- if (i %% 2 == 0) dark_row_alt else dark_card
+    repo_val <- sr[["repo"]] %||% ""
+    repo_link <- if (nzchar(repo_val))
+      sprintf('<a href="https://github.com/JohnGavin/%s" style="color:%s;">%s</a>',
+              repo_val, accent_blue, repo_val)
+    else repo_val
+    severity_html <- paste0(severity_html, sprintf(
+      '<tr style="background-color:%s;">
+        <td style="padding:4px 8px; border:1px solid %s; color:%s;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s; text-align:right;">%s</td>
+        <td style="padding:4px 5px; border:1px solid %s; color:%s; text-align:right; font-weight:bold;">%s</td>
+      </tr>',
+      bg,
+      dark_border, dark_text, repo_link,
+      dark_border, accent_orange, fmt_int(sr[["High"]]),
+      dark_border, accent_blue, fmt_int(sr[["Medium"]]),
+      dark_border, dark_muted, fmt_int(sr[["Low"]]),
+      dark_border, dark_text, fmt_int(sr[["Total"]])
+    ))
+  }
+} else {
+  severity_html <- paste0(severity_html,
+    sprintf('<tr><td colspan="5" style="padding:6px; color:%s;">(no data in 7-day window)</td></tr>', dark_muted))
+}
+severity_html <- paste0(severity_html, "</table>")
 
 # QA markers (tested by test-send-roborev-email.R)
 qa_markers <- sprintf(
@@ -331,6 +450,8 @@ email_body <- sprintf(
 %s
 %s
 %s
+%s
+%s
 <p style="color:%s; font-size:10px; margin-top:20px;">
   JSON snapshot: %s
 </p>
@@ -340,10 +461,12 @@ email_body <- sprintf(
   accent_orange, report_date,
   dark_muted, generated_at, lineage_src,
   dashboard_block,
+  headline_1d_html,
   headline_html,
   trends_html,
   outlier_ttc_html,
   outlier_att_html,
+  severity_html,
   dark_muted, json_path,
   qa_markers
 )


### PR DESCRIPTION
## Summary

Implements all four enhancements from llm#449 to the roborev Daily Report email:

- **1-day change tables first** — new "Headline Metrics (last 24h)" section appears ABOVE the existing 7-day section, using `d1` window data already computed in the JSON snapshot pipeline
- **Linkified outlier IDs and Repo cells** — ID cells link to `https://github.com/JohnGavin/<repo>/issues/<id>`; Repo cells link to `https://github.com/JohnGavin/<repo>`; applied to both outlier tables
- **Rename TTC column** — header changed from `TTC` to `Hours to close (h)` in both outlier tables; cell values use new `fmt_num` helper (bare `%.1f`, no trailing `h`) to avoid double-labelling
- **Per-project severity frequency table** — new `compute_severity_by_project()` in `roborev_daily_report.R` writes `severity_by_project_7d` to the JSON snapshot; `send_roborev_email.R` renders "Severity by Project (7d)" table: Project (linkified) | High | Medium | Low | Total, sorted desc by Total

## Test plan

- [x] `parse("roborev_daily_report.R")` → `PARSE OK`
- [x] `parse("send_roborev_email.R")` → `PARSE OK`
- [x] `EMAIL_DRY_RUN=1` dry-run generates HTML containing:
  - `Headline Metrics (last 24h)` (1 occurrence)
  - `Hours to close (h)` (2 occurrences — one per outlier table)
  - `href="https://github.com/JohnGavin/` (20 occurrences — IDs + repos)
  - `Severity by Project` (1 occurrence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
