### PR TITLE
feat(#461): wire email_styles.R into weekly email senders

### DIFF
--- a/.claude/scripts/send_launchd_health_email.R
+++ b/.claude/scripts/send_launchd_health_email.R
@@ -20,6 +20,24 @@ suppressPackageStartupMessages({
   library(blastula)
 })
 
+# ── Shared email styles (font sizes, palette, collapsible_block helper) ───────
+
+`%||%` <- function(a, b) if (!is.null(a) && !is.na(a) && nzchar(as.character(a))) a else b
+
+.scripts_dir <- tryCatch(
+  dirname(normalizePath(sys.frame(0L)$ofile, mustWork = FALSE)),
+  error = function(e) {
+    args  <- commandArgs(trailingOnly = FALSE)
+    idx   <- grep("^--file=", args)
+    if (length(idx)) dirname(normalizePath(sub("^--file=", "", args[idx]), mustWork = FALSE))
+    else dirname(normalizePath(file.path(Sys.getenv("HOME"), "docs_gh", "llm",
+                                         ".claude", "scripts", "email_styles.R"),
+                               mustWork = FALSE))
+  }
+)
+
+source(file.path(.scripts_dir, "email_styles.R"))
+
 # ── Configuration ─────────────────────────────────────────────────────────────
 
 SCRIPTS_DIR <- Sys.getenv(
@@ -68,19 +86,19 @@ if (!file.exists(md_tmp)) {
 
 report_md <- paste(readLines(md_tmp, warn = FALSE), collapse = "\n")
 
-# ── Colour palette (matches llmtelemetry convention) ──────────────────────────
+# ── Colour aliases (sourced from email_styles.R above) ────────────────────────
 
-dark_bg       <- "#1a1a2e"
-dark_card     <- "#16213e"
-dark_row_alt  <- "#0f3460"
-dark_text     <- "#e8e8e8"
-dark_muted    <- "#a0a0a0"
-dark_border   <- "#2a2a4a"
-accent_green  <- "#00d26a"
-accent_blue   <- "#4fc3f7"
-accent_orange <- "#ff9800"
-accent_purple <- "#bb86fc"
-accent_red    <- "#f08080"
+dark_bg       <- DARK_BG
+dark_card     <- DARK_CARD
+dark_row_alt  <- DARK_ROW_ALT
+dark_text     <- DARK_TEXT
+dark_muted    <- DARK_MUTED
+dark_border   <- DARK_BORDER
+accent_green  <- ACCENT_GREEN
+accent_blue   <- ACCENT_BLUE
+accent_orange <- ACCENT_ORANGE
+accent_purple <- ACCENT_PURPLE
+accent_red    <- "#f08080"   # script-local: not in email_styles.R palette
 
 # ── Parse report sections ──────────────────────────────────────────────────────
 
@@ -129,11 +147,11 @@ md_table_to_html <- function(md_text, header_bg = dark_row_alt, header_color = "
   }
 
   sprintf(
-    '<table style="border-collapse:collapse; width:100%%; font-size:12px;">
+    '<table style="border-collapse:collapse; width:100%%; font-size:%s;">
   <tr style="background-color:%s;">%s</tr>
   %s
 </table>',
-    header_bg, th_html, paste(rows_html, collapse = "\n  ")
+    EMAIL_FONT_BODY, header_bg, th_html, paste(rows_html, collapse = "\n  ")
   )
 }
 
@@ -154,16 +172,31 @@ md_to_simple_html <- function(s) {
 }
 
 # Section 1 tables
-s1_tables <- md_table_to_html(s1, header_bg = dark_row_alt)
+s1_tables_inner <- md_table_to_html(s1, header_bg = dark_row_alt)
+s1_n_rows <- length(grep("^\\|", strsplit(s1, "\n")[[1L]])) - 2L   # minus header + separator
+s1_n_rows <- max(0L, s1_n_rows)
+s1_tables <- collapsible_block(
+  "&#x1F534; Section 1 — Inventory (Priority × Time-of-Day)",
+  sprintf("%d job%s", s1_n_rows, if (s1_n_rows == 1L) "" else "s"),
+  s1_tables_inner
+)
+
 # Section 2 check for placeholder text vs table
 has_s2_table <- grepl("^\\|", trimws(s2))
-s2_html <- if (has_s2_table) {
+s2_html_inner <- if (has_s2_table) {
   md_table_to_html(s2)
 } else {
   sprintf('<p style="color:%s; font-style:italic;">%s</p>',
           dark_muted, md_to_simple_html(gsub("\n", " ", trimws(s2))))
 }
-# Section 3 bullets
+s2_n_rows <- if (has_s2_table) max(0L, length(grep("^\\|", strsplit(s2, "\n")[[1L]])) - 2L) else 0L
+s2_html <- collapsible_block(
+  "&#x1F4CA; Section 2 — Per-Job Run Metrics (7-Day)",
+  sprintf("%d job%s", s2_n_rows, if (s2_n_rows == 1L) "" else "s"),
+  s2_html_inner
+)
+
+# Section 3 bullets (not collapsible — suggestions are short, always show)
 s3_bullets <- strsplit(trimws(s3), "\n")[[1L]]
 s3_bullets <- s3_bullets[nzchar(s3_bullets)]
 s3_html <- paste(sprintf(
@@ -171,13 +204,21 @@ s3_html <- paste(sprintf(
   dark_text,
   vapply(gsub("^[-*] ", "", s3_bullets), md_to_simple_html, character(1L))
 ), collapse = "\n")
+
 # Section 4
-s4_html <- if (grepl("^\\|", trimws(sub("^[^|]*", "", s4)))) {
+has_s4_table <- grepl("^\\|", trimws(sub("^[^|]*", "", s4)))
+s4_html_inner <- if (has_s4_table) {
   md_table_to_html(s4, header_bg = "#2d1b6e")
 } else {
   sprintf('<p style="color:%s; font-style:italic;">%s</p>',
           dark_muted, md_to_simple_html(gsub("\n", " ", trimws(s4))))
 }
+s4_n_rows <- if (has_s4_table) max(0L, length(grep("^\\|", strsplit(s4, "\n")[[1L]])) - 2L) else 0L
+s4_html <- collapsible_block(
+  "&#x2601; Section 4 — Related Cloud Crons (GitHub Actions)",
+  sprintf("%d cron%s", s4_n_rows, if (s4_n_rows == 1L) "" else "s"),
+  s4_html_inner
+)
 
 # ── Build full HTML body ───────────────────────────────────────────────────────
 
@@ -194,16 +235,10 @@ email_body <- sprintf(
   '<div style="background-color:%s; color:%s; padding:20px;
                font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">
 <h2 style="color:%s; margin-bottom:4px;">Weekly Scheduled-Task Health Report — %s</h2>
-<p style="color:%s; font-size:11px; margin-top:0;">Generated: %s</p>
+<p style="color:%s; font-size:%s; margin-top:0;">Generated: %s</p>
 
-<h3 style="color:%s; margin-top:20px; border-bottom:1px solid %s; padding-bottom:4px;">
-  &#x1F534; Section 1 — Inventory (Priority &times; Time-of-Day)
-</h3>
 %s
 
-<h3 style="color:%s; margin-top:24px; border-bottom:1px solid %s; padding-bottom:4px;">
-  &#x1F4CA; Section 2 — Per-Job Run Metrics (7-Day)
-</h3>
 %s
 
 <h3 style="color:%s; margin-top:24px; border-bottom:1px solid %s; padding-bottom:4px;">
@@ -213,12 +248,9 @@ email_body <- sprintf(
 %s
 </ul>
 
-<h3 style="color:%s; margin-top:24px; border-bottom:1px solid %s; padding-bottom:4px;">
-  &#x2601; Section 4 — Related Cloud Crons (GitHub Actions)
-</h3>
 %s
 
-<p style="color:%s; font-size:10px; margin-top:24px;">
+<p style="color:%s; font-size:%s; margin-top:24px;">
   Tracked in <a href="https://github.com/JohnGavin/llm/issues/300" style="color:%s;">llm#300</a>.
   Ledger: ~/.claude/logs/launchd_runs.duckdb
 </p>
@@ -226,16 +258,13 @@ email_body <- sprintf(
 </div>',
   dark_bg, dark_text,
   accent_orange, report_date,
-  dark_muted, generated_at,
-  accent_orange, dark_border,
+  dark_muted, EMAIL_FONT_SUBTITLE, generated_at,
   s1_tables,
-  accent_blue, dark_border,
   s2_html,
   accent_red, dark_border,
   s3_html,
-  accent_purple, dark_border,
   s4_html,
-  dark_muted, accent_blue,
+  dark_muted, EMAIL_FONT_FOOTER, accent_blue,
   qa_markers
 )
 

--- a/.claude/scripts/send_roborev_weekly_rollup_email.R
+++ b/.claude/scripts/send_roborev_weekly_rollup_email.R
@@ -31,6 +31,24 @@ suppressPackageStartupMessages({
   library(blastula)
 })
 
+# ── Shared email styles (font sizes, palette, collapsible_block helper) ───────
+
+`%||%` <- function(a, b) if (!is.null(a) && !is.na(a) && nzchar(as.character(a))) a else b
+
+.scripts_dir <- tryCatch(
+  dirname(normalizePath(sys.frame(0L)$ofile, mustWork = FALSE)),
+  error = function(e) {
+    args  <- commandArgs(trailingOnly = FALSE)
+    idx   <- grep("^--file=", args)
+    if (length(idx)) dirname(normalizePath(sub("^--file=", "", args[idx]), mustWork = FALSE))
+    else dirname(normalizePath(file.path(Sys.getenv("HOME"), "docs_gh", "llm",
+                                         ".claude", "scripts", "email_styles.R"),
+                               mustWork = FALSE))
+  }
+)
+
+source(file.path(.scripts_dir, "email_styles.R"))
+
 # ── Configuration ──────────────────────────────────────────────────────────────
 
 ROBOREV_DASHBOARD_URL <- Sys.getenv(
@@ -48,7 +66,7 @@ dry_run <- identical(Sys.getenv("EMAIL_DRY_RUN"), "1")
 # ── Locate or generate the weekly rollup ──────────────────────────────────────
 
 rollup_script <- file.path(
-  dirname(normalizePath(sys.frame(0)$filename %||% ".")),
+  .scripts_dir,
   "roborev_weekly_rollup.R"
 )
 # Fallback: resolve from this file's own path
@@ -58,10 +76,6 @@ rollup_script_candidates <- c(
             "roborev_weekly_rollup.R")
 )
 rollup_script <- rollup_script_candidates[file.exists(rollup_script_candidates)][1L]
-
-# Null coalescing helper (must precede any use)
-`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0L) a else b
-
 rollup_script <- rollup_script %||% NA_character_
 
 today_str <- format(Sys.Date(), "%Y-%m-%d")
@@ -98,17 +112,17 @@ if (file.exists(rollup_path)) {
   )
 }
 
-# ── Colour palette (dark-mode safe, matches llmtelemetry convention) ──────────
+# ── Colour aliases (sourced from email_styles.R above) ────────────────────────
 
-dark_bg       <- "#1a1a2e"
-dark_card     <- "#16213e"
-dark_row_alt  <- "#0f3460"
-dark_text     <- "#e8e8e8"
-dark_muted    <- "#a0a0a0"
-dark_border   <- "#2a2a4a"
-accent_green  <- "#00d26a"
-accent_blue   <- "#4fc3f7"
-accent_orange <- "#ff9800"
+dark_bg       <- DARK_BG
+dark_card     <- DARK_CARD
+dark_row_alt  <- DARK_ROW_ALT
+dark_text     <- DARK_TEXT
+dark_muted    <- DARK_MUTED
+dark_border   <- DARK_BORDER
+accent_green  <- ACCENT_GREEN
+accent_blue   <- ACCENT_BLUE
+accent_orange <- ACCENT_ORANGE
 
 # ── Convert markdown to simple HTML ──────────────────────────────────────────
 
@@ -134,14 +148,14 @@ md_to_simple_html <- function(md) {
     } else if (grepl("^_.*_$", l)) {
       # Italics line (e.g. _Generated: ..._)
       inner <- gsub("^_(.*)_$", "\\1", l)
-      html_parts[i] <- sprintf('<p style="color:%s; font-size:11px; margin:2px 0;">%s</p>',
-                                dark_muted, inner)
+      html_parts[i] <- sprintf('<p style="color:%s; font-size:%s; margin:2px 0;">%s</p>',
+                                dark_muted, EMAIL_FONT_SUBTITLE, inner)
     } else if (grepl("^\\|", l) && grepl("\\|$", l)) {
       # Table row
       if (!in_table) {
         html_parts[i] <- sprintf(
-          '<table style="border-collapse:collapse; width:100%%; font-size:12px; margin:8px 0;">\n',
-          NULL
+          '<table style="border-collapse:collapse; width:100%%; font-size:%s; margin:8px 0;">\n',
+          EMAIL_FONT_BODY
         )
         in_table <- TRUE
       }
@@ -167,11 +181,11 @@ md_to_simple_html <- function(md) {
     } else {
       if (in_table) {
         html_parts[i] <- paste0("</table>\n",
-                                sprintf('<p style="color:%s; font-size:12px;">%s</p>', dark_text, l))
+                                sprintf('<p style="color:%s; font-size:%s;">%s</p>', dark_text, EMAIL_FONT_BODY, l))
         in_table <- FALSE
       } else if (nzchar(trimws(l))) {
-        html_parts[i] <- sprintf('<p style="color:%s; font-size:12px; margin:4px 0;">%s</p>',
-                                  dark_text, l)
+        html_parts[i] <- sprintf('<p style="color:%s; font-size:%s; margin:4px 0;">%s</p>',
+                                  dark_text, EMAIL_FONT_BODY, l)
       } else {
         html_parts[i] <- ""
       }
@@ -181,7 +195,13 @@ md_to_simple_html <- function(md) {
   paste(html_parts, collapse = "\n")
 }
 
-body_inner <- md_to_simple_html(rollup_md)
+body_inner_html <- md_to_simple_html(rollup_md)
+rollup_lines <- length(strsplit(rollup_md, "\n")[[1L]])
+body_inner <- collapsible_block(
+  "&#x1F4CB; Weekly Rollup",
+  sprintf("~%d lines", rollup_lines),
+  body_inner_html
+)
 
 # Dashboard CTA
 dashboard_block <- sprintf(
@@ -201,12 +221,12 @@ email_body <- sprintf(
                font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">
 %s
 %s
-<p style="color:%s; font-size:10px; margin-top:20px;">Rollup file: %s</p>
+<p style="color:%s; font-size:%s; margin-top:20px;">Rollup file: %s</p>
 </div>',
   dark_bg, dark_text,
   body_inner,
   dashboard_block,
-  dark_muted, rollup_path
+  dark_muted, EMAIL_FONT_FOOTER, rollup_path
 )
 
 # ── Dry-run mode ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Source shared `email_styles.R` in both `send_launchd_health_email.R` and `send_roborev_weekly_rollup_email.R`, using the same `.scripts_dir` + `source()` idiom as `send_config_digest_email.R`
- Replace every hardcoded `font-size:` literal with named constants: `EMAIL_FONT_BODY` (14px), `EMAIL_FONT_SUBTITLE` (13px), `EMAIL_FONT_FOOTER` (12px)
- Replace local palette hex literals with named constants: `DARK_BG`, `DARK_CARD`, `DARK_TEXT`, `ACCENT_GREEN`, `ACCENT_BLUE`, `ACCENT_ORANGE`, etc.
- Wrap `<table>` / content sections in `collapsible_block(title, summary_stats, html_body)` — sections 1, 2, 4 in launchd; the rollup body in roborev
- No changes to what either email reports; no cosmetic restyling beyond fonts and collapsibility

## Dry-run verification

Both scripts run with `EMAIL_DRY_RUN=1` inside the project nix shell and exit 0:

- `font-size: 14px` in `<summary>` elements (EMAIL_FONT_BODY)
- `font-size:13px` for italic/subtitle text (EMAIL_FONT_SUBTITLE)
- `font-size:12px` in footer `<p>` (EMAIL_FONT_FOOTER)
- `<details>` collapsible blocks present in both outputs

## Test plan

- [x] `EMAIL_DRY_RUN=1 Rscript send_launchd_health_email.R` exits 0, HTML contains `font-size: 14px`, `font-size:12px`, `<details>` blocks
- [x] `EMAIL_DRY_RUN=1 Rscript send_roborev_weekly_rollup_email.R` exits 0, HTML contains correct font sizes and `<details>` block
- [ ] Live email send on next Sunday cron (production verification)

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
