### PR TITLE
feat(#491): overnight self-review email — ETL starvation visibility via collapsible source-table delta

### DIFF
--- a/.claude/launchd/README.md
+++ b/.claude/launchd/README.md
@@ -19,6 +19,7 @@ canonical, version-controlled copies; the live copies live at
 | `com.claude.pr-status-pulse` | Daily 09:30 / 12:30 / 16:30 | Logs open PR + CI status across tracked repos to `~/.claude/logs/pr_status.log`. Part of #137 Phase 4. |
 | `com.claude.wiki-health-pulse` | Daily 09:45 | Runs `wiki_health_check.sh` against the local knowledge wiki. Part of #137 Phase 4. |
 | `com.claude.codex-overnight-learning` | Daily 06:10 | Scans recent Codex sessions and writes a nightly learning digest to `~/.codex/learning/`. Startup surfacing comes from `.claude/scripts/codex-start.sh`. Tracked in #231. |
+| `com.claude.overnight-self-review-email` | Daily 06:30 | Queries unified.duckdb for 24h deltas across 4 ETL source tables (sessions, agent_runs, hook_events, errors); sends collapsible HTML digest surfacing stale/dead tables and new self-review findings. Part of #491. |
 
 ## Install / reload after editing
 

--- a/.claude/launchd/com.claude.overnight-self-review-email.plist
+++ b/.claude/launchd/com.claude.overnight-self-review-email.plist
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.claude.overnight-self-review-email.plist
+     Overnight self-review digest email — surfaces ETL starvation and new
+     self-review findings from unified.duckdb. Sends a collapsible HTML email
+     at 06:30 daily (after self-review-stage1 at 02:30).
+
+     Install:
+       cp .claude/launchd/com.claude.overnight-self-review-email.plist \
+          ~/Library/LaunchAgents/com.claude.overnight-self-review-email.plist
+       launchctl load -w ~/Library/LaunchAgents/com.claude.overnight-self-review-email.plist
+
+     Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.claude.overnight-self-review-email.plist
+       rm ~/Library/LaunchAgents/com.claude.overnight-self-review-email.plist
+
+     Manual dry-run (no SMTP, prints HTML to log):
+       EMAIL_DRY_RUN=1 Rscript ~/docs_gh/llm/.claude/scripts/send_overnight_self_review_email.R
+
+     Credentials (set in ~/.claude/env/overnight_email.env or ~/.Renviron):
+       GMAIL_USERNAME=you@gmail.com
+       GMAIL_APP_PASSWORD=<16-char app password>
+       REPORT_RECIPIENT=you@gmail.com
+
+     Tracked in llm#491.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.overnight-self-review-email</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/nix/var/nix/profiles/default/bin/Rscript</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/send_overnight_self_review_email.R</string>
+    </array>
+
+    <!-- Daily at 06:30 local time (after self-review-stage1 at 02:30) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>6</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+
+    <!-- Do NOT run immediately on launchctl load -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- PATH includes nix profile (for R + packages), homebrew, and standard dirs.
+         HOME is required for ~/.Renviron credential loading.
+         NIX_SSL_CERT_FILE is required for any nix-shell network calls. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/johngavin/.local/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+        <key>NIX_SSL_CERT_FILE</key>
+        <string>/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/overnight_self_review_email_launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/overnight_self_review_email_launchd.log</string>
+
+    <!-- Retry interval (seconds) if job exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+</dict>
+</plist>

--- a/.claude/scripts/send_overnight_self_review_email.R
+++ b/.claude/scripts/send_overnight_self_review_email.R
@@ -1,0 +1,524 @@
+#!/usr/bin/env Rscript
+# send_overnight_self_review_email.R
+#
+# Daily overnight email surfacing ETL-starvation and self-review findings.
+# Reads from ~/.claude/logs/unified.duckdb (read-only, never writes).
+# Sends via blastula/SMTP, or prints HTML to stdout in dry-run mode.
+#
+# Usage:
+#   # Dry run (prints HTML, no SMTP):
+#   EMAIL_DRY_RUN=1 Rscript .claude/scripts/send_overnight_self_review_email.R
+#
+#   # Live (requires GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT):
+#   Rscript .claude/scripts/send_overnight_self_review_email.R
+#
+# Environment:
+#   EMAIL_DRY_RUN       "1" → dry-run (default off)
+#   GMAIL_USERNAME      sender address
+#   GMAIL_APP_PASSWORD  16-char app password
+#   REPORT_RECIPIENT    destination address
+#   UNIFIED_DB_PATH     override DB path (default ~/.claude/logs/unified.duckdb)
+#
+# Tracked in llm#491.
+
+# ── Script self-location ───────────────────────────────────────────────────────
+.scripts_dir <- tryCatch(
+  dirname(normalizePath(sys.frame(0L)$ofile, mustWork = FALSE)),
+  error = function(e) {
+    args <- commandArgs(trailingOnly = FALSE)
+    idx  <- grep("^--file=", args)
+    if (length(idx)) {
+      dirname(normalizePath(sub("^--file=", "", args[idx]), mustWork = FALSE))
+    } else {
+      dirname(normalizePath(
+        file.path(Sys.getenv("HOME"), "docs_gh", "llm", ".claude", "scripts",
+                  "email_styles.R"),
+        mustWork = FALSE
+      ))
+    }
+  }
+)
+
+source(file.path(.scripts_dir, "email_styles.R"))
+
+# ── Null-coalescing operator ───────────────────────────────────────────────────
+`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0 && !is.na(a[[1]])) a else b
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+dry_run        <- identical(Sys.getenv("EMAIL_DRY_RUN"), "1")
+gmail_user     <- Sys.getenv("GMAIL_USERNAME")   %||% ""
+report_recip   <- Sys.getenv("REPORT_RECIPIENT") %||% gmail_user
+db_path        <- Sys.getenv("UNIFIED_DB_PATH")  %||%
+                  file.path(Sys.getenv("HOME"), ".claude", "logs", "unified.duckdb")
+
+if (!dry_run) {
+  if (!nzchar(gmail_user)) {
+    message("ERROR: GMAIL_USERNAME not set. Use EMAIL_DRY_RUN=1 to preview.")
+    quit(status = 1L)
+  }
+  if (!nzchar(Sys.getenv("GMAIL_APP_PASSWORD"))) {
+    message("ERROR: GMAIL_APP_PASSWORD not set.")
+    quit(status = 1L)
+  }
+}
+
+# ── Required packages ─────────────────────────────────────────────────────────
+for (.pkg in c("DBI", "duckdb", "blastula")) {
+  if (!requireNamespace(.pkg, quietly = TRUE)) {
+    message(sprintf("ERROR: required package '%s' is not installed.", .pkg))
+    quit(status = 1L)
+  }
+}
+
+# ── Open DB (read-only) ────────────────────────────────────────────────────────
+if (!file.exists(db_path)) {
+  message(sprintf("ERROR: DuckDB not found at %s", db_path))
+  quit(status = 1L)
+}
+con <- DBI::dbConnect(duckdb::duckdb(), db_path, read_only = TRUE)
+on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+# ── Helper: safe query ────────────────────────────────────────────────────────
+safe_query <- function(sql, fallback = data.frame()) {
+  tryCatch(DBI::dbGetQuery(con, sql), error = function(e) {
+    message(sprintf("  [WARN] query failed: %s", conditionMessage(e)))
+    fallback
+  })
+}
+
+# ── Section 1: New self-review findings (last 24h) ────────────────────────────
+sec1_data <- safe_query("
+  SELECT
+    finding_type,
+    severity,
+    COUNT(*) AS n
+  FROM self_review_findings_stage1
+  WHERE detected_at >= current_timestamp::TIMESTAMP - INTERVAL '24' HOUR
+  GROUP BY finding_type, severity
+  ORDER BY
+    CASE severity
+      WHEN 'critical' THEN 1 WHEN 'major' THEN 2 WHEN 'minor' THEN 3 ELSE 4
+    END, finding_type
+")
+
+n_new_findings <- if (nrow(sec1_data) > 0L) sum(sec1_data$n) else 0L
+n_critical     <- if (nrow(sec1_data) > 0L)
+  sum(sec1_data$n[sec1_data$severity == "critical"], na.rm = TRUE) else 0L
+n_major        <- if (nrow(sec1_data) > 0L)
+  sum(sec1_data$n[sec1_data$severity == "major"], na.rm = TRUE) else 0L
+
+severity_badge <- function(sev) {
+  col <- switch(sev,
+    critical = "#ff5252",
+    major    = "#ff9800",
+    minor    = "#ffd54f",
+    "#a0a0a0"
+  )
+  sprintf(
+    '<span style="background-color:%s;color:#000;padding:2px 6px;border-radius:3px;
+font-size:12px;font-weight:bold;">%s</span>',
+    col, toupper(sev)
+  )
+}
+
+if (nrow(sec1_data) > 0L) {
+  rows_html <- paste(apply(sec1_data, 1, function(r) {
+    sprintf(
+      '<tr style="background-color:%s;">
+<td style="padding:6px 10px;">%s</td>
+<td style="padding:6px 10px;">%s</td>
+<td style="padding:6px 10px;text-align:right;font-weight:bold;">%s</td>
+</tr>',
+      DARK_CARD, r[["finding_type"]], severity_badge(r[["severity"]]), r[["n"]]
+    )
+  }), collapse = "\n")
+  sec1_table <- sprintf(
+    '<table style="width:auto;border-collapse:collapse;color:%s;font-size:%s;">
+<thead>
+<tr style="background-color:%s;">
+<th style="padding:6px 10px;text-align:left;">Finding type</th>
+<th style="padding:6px 10px;text-align:left;">Severity</th>
+<th style="padding:6px 10px;text-align:right;">Count</th>
+</tr>
+</thead>
+<tbody>%s</tbody>
+</table>',
+    DARK_TEXT, EMAIL_FONT_BODY, DARK_ROW_ALT, rows_html
+  )
+} else {
+  sec1_table <- sprintf(
+    '<p style="color:%s;font-size:%s;">No new findings in the last 24 h.</p>',
+    ACCENT_GREEN, EMAIL_FONT_BODY
+  )
+}
+
+sec1_summary <- sprintf(
+  "%d new · %d critical · %d major",
+  n_new_findings, n_critical, n_major
+)
+
+sec1_block <- collapsible_block(
+  "New self-review findings (last 24h)",
+  sec1_summary,
+  sec1_table
+)
+
+# ── Section 2: Source table volume (last 24h) — ETL starvation detector ────────
+source_tables <- c("sessions", "agent_runs", "hook_events", "errors")
+
+sec2_rows <- lapply(source_tables, function(tbl) {
+  ts_col <- switch(tbl,
+    sessions   = "started_at",
+    agent_runs = "started_at",
+    hook_events = "fired_at",
+    errors     = "logged_at"
+  )
+
+  info <- safe_query(sprintf("
+    SELECT
+      COUNT(*) AS total,
+      COUNT(CASE WHEN %s >= current_timestamp::TIMESTAMP - INTERVAL '24' HOUR THEN 1 END) AS last_24h,
+      MAX(%s) AS latest_ts
+    FROM %s
+  ", ts_col, ts_col, tbl))
+
+  if (nrow(info) == 0L) {
+    return(list(table = tbl, total = 0L, last_24h = 0L,
+                latest_ts = NA_character_, status = "DEAD"))
+  }
+
+  n24      <- as.integer(info$last_24h[[1]])
+  latest   <- info$latest_ts[[1]]
+  total    <- as.integer(info$total[[1]])
+
+  hours_since <- if (!is.na(latest) && !is.null(latest)) {
+    as.numeric(difftime(Sys.time(),
+                        as.POSIXct(latest, tz = "UTC"),
+                        units = "hours"))
+  } else {
+    Inf
+  }
+
+  status <- if (n24 >= 10L) {
+    "live"
+  } else if (n24 >= 1L) {
+    "sparse"
+  } else if (hours_since <= 48) {
+    "STALE"
+  } else {
+    "DEAD"
+  }
+
+  list(table = tbl, total = total, last_24h = n24,
+       latest_ts = as.character(latest), status = status)
+})
+
+status_color <- function(s) {
+  switch(s,
+    "live"   = ACCENT_GREEN,
+    "sparse" = ACCENT_ORANGE,
+    "STALE"  = "#ff5252",
+    "DEAD"   = "#ff5252",
+    DARK_MUTED
+  )
+}
+
+status_badge <- function(s) {
+  col <- status_color(s)
+  sprintf(
+    '<span style="background-color:%s;color:%s;padding:2px 8px;border-radius:3px;
+font-size:12px;font-weight:bold;">%s</span>',
+    col,
+    if (s %in% c("STALE", "DEAD")) "#fff" else "#000",
+    s
+  )
+}
+
+sec2_rows_html <- paste(lapply(sec2_rows, function(r) {
+  sprintf(
+    '<tr style="background-color:%s;">
+<td style="padding:6px 10px;font-family:monospace;">%s</td>
+<td style="padding:6px 10px;text-align:right;">%s</td>
+<td style="padding:6px 10px;text-align:right;">%s</td>
+<td style="padding:6px 10px;font-size:11px;color:%s;">%s</td>
+<td style="padding:6px 10px;text-align:center;">%s</td>
+</tr>',
+    DARK_CARD,
+    r$table,
+    format(r$total, big.mark = ","),
+    format(r$last_24h, big.mark = ","),
+    DARK_MUTED,
+    r$latest_ts %||% "—",
+    status_badge(r$status)
+  )
+}), collapse = "\n")
+
+n_stale_tables <- sum(sapply(sec2_rows, function(r) r$status %in% c("STALE", "DEAD")))
+
+sec2_table <- sprintf(
+  '<table style="width:auto;border-collapse:collapse;color:%s;font-size:%s;">
+<thead>
+<tr style="background-color:%s;">
+<th style="padding:6px 10px;text-align:left;">Table</th>
+<th style="padding:6px 10px;text-align:right;">Total rows</th>
+<th style="padding:6px 10px;text-align:right;">Last 24h</th>
+<th style="padding:6px 10px;text-align:left;">Latest row</th>
+<th style="padding:6px 10px;text-align:center;">Status</th>
+</tr>
+</thead>
+<tbody>%s</tbody>
+</table>
+<p style="color:%s;font-size:%s;margin-top:8px;">
+  Status: <b>live</b> ≥10 rows/24h &nbsp;|&nbsp;
+  <b style="color:%s;">sparse</b> 1–9 rows/24h &nbsp;|&nbsp;
+  <b style="color:#ff5252;">STALE</b> 0 rows, gap &lt;48h &nbsp;|&nbsp;
+  <b style="color:#ff5252;">DEAD</b> 0 rows, gap ≥48h
+</p>',
+  DARK_TEXT, EMAIL_FONT_BODY, DARK_ROW_ALT,
+  sec2_rows_html,
+  DARK_MUTED, EMAIL_FONT_SUBTITLE,
+  ACCENT_ORANGE
+)
+
+sec2_summary <- sprintf("%d source tables · %d stale/dead", length(source_tables), n_stale_tables)
+
+sec2_block <- collapsible_block(
+  "Source table volume (last 24h)",
+  sec2_summary,
+  sec2_table
+)
+
+# ── Section 3: Cumulative table health ────────────────────────────────────────
+all_tables <- c("sessions", "agent_runs", "hook_events", "errors",
+                "self_review_findings_stage1")
+
+sec3_rows <- lapply(all_tables, function(tbl) {
+  ts_col <- switch(tbl,
+    sessions                    = "started_at",
+    agent_runs                  = "started_at",
+    hook_events                 = "fired_at",
+    errors                      = "logged_at",
+    self_review_findings_stage1 = "detected_at"
+  )
+
+  info <- safe_query(sprintf("
+    SELECT
+      COUNT(*) AS total_rows,
+      MIN(%s)  AS earliest,
+      MAX(%s)  AS latest
+    FROM %s
+  ", ts_col, ts_col, tbl))
+
+  if (nrow(info) == 0L) {
+    return(list(table = tbl, total = 0L, earliest = "—", latest = "—"))
+  }
+
+  list(
+    table    = tbl,
+    total    = as.integer(info$total_rows[[1]]),
+    earliest = as.character(info$earliest[[1]]) %||% "—",
+    latest   = as.character(info$latest[[1]])   %||% "—"
+  )
+})
+
+sec3_rows_html <- paste(lapply(sec3_rows, function(r) {
+  sprintf(
+    '<tr style="background-color:%s;">
+<td style="padding:6px 10px;font-family:monospace;">%s</td>
+<td style="padding:6px 10px;text-align:right;font-weight:bold;">%s</td>
+<td style="padding:6px 10px;font-size:11px;color:%s;">%s</td>
+<td style="padding:6px 10px;font-size:11px;color:%s;">%s</td>
+</tr>',
+    DARK_CARD,
+    r$table,
+    format(r$total, big.mark = ","),
+    DARK_MUTED, r$earliest,
+    DARK_MUTED, r$latest
+  )
+}), collapse = "\n")
+
+sec3_table <- sprintf(
+  '<table style="width:auto;border-collapse:collapse;color:%s;font-size:%s;">
+<thead>
+<tr style="background-color:%s;">
+<th style="padding:6px 10px;text-align:left;">Table</th>
+<th style="padding:6px 10px;text-align:right;">Total rows</th>
+<th style="padding:6px 10px;text-align:left;">Earliest</th>
+<th style="padding:6px 10px;text-align:left;">Latest</th>
+</tr>
+</thead>
+<tbody>%s</tbody>
+</table>',
+  DARK_TEXT, EMAIL_FONT_BODY, DARK_ROW_ALT, sec3_rows_html
+)
+
+sec3_total <- sum(sapply(sec3_rows, function(r) r$total))
+sec3_summary <- sprintf("%d tables · %s total rows",
+                        length(all_tables),
+                        format(sec3_total, big.mark = ","))
+
+sec3_block <- collapsible_block(
+  "Cumulative table health",
+  sec3_summary,
+  sec3_table
+)
+
+# ── Section 4: New findings — detail (top 20) ─────────────────────────────────
+sec4_data <- safe_query("
+  SELECT
+    finding_type,
+    severity,
+    session_id,
+    evidence,
+    detected_at
+  FROM self_review_findings_stage1
+  WHERE detected_at >= current_timestamp::TIMESTAMP - INTERVAL '24' HOUR
+  ORDER BY
+    CASE severity
+      WHEN 'critical' THEN 1 WHEN 'major' THEN 2 WHEN 'minor' THEN 3 ELSE 4
+    END,
+    detected_at DESC
+  LIMIT 20
+")
+
+if (nrow(sec4_data) > 0L) {
+  detail_rows_html <- paste(apply(sec4_data, 1, function(r) {
+    evidence_str <- tryCatch({
+      ev <- jsonlite::fromJSON(r[["evidence"]])
+      paste(
+        mapply(function(k, v) sprintf("<b>%s</b>: %s", k, v),
+               names(ev), as.character(ev)),
+        collapse = " &nbsp;·&nbsp; "
+      )
+    }, error = function(e) as.character(r[["evidence"]]))
+    sid <- if (!is.na(r[["session_id"]]) && nchar(r[["session_id"]]) >= 8L)
+      substr(r[["session_id"]], 1L, 8L) else "—"
+    sprintf(
+      '<tr style="background-color:%s;">
+<td style="padding:6px 10px;font-size:11px;white-space:nowrap;">%s</td>
+<td style="padding:6px 10px;">%s</td>
+<td style="padding:6px 10px;font-family:monospace;font-size:11px;">%s…</td>
+<td style="padding:6px 10px;font-size:11px;color:%s;max-width:320px;
+   white-space:normal;word-break:break-word;">%s</td>
+</tr>',
+      DARK_CARD,
+      format(as.POSIXct(r[["detected_at"]], tz = "UTC"), "%H:%M"),
+      severity_badge(r[["severity"]]),
+      sid,
+      DARK_MUTED,
+      evidence_str
+    )
+  }), collapse = "\n")
+
+  sec4_table <- sprintf(
+    '<table style="width:auto;border-collapse:collapse;color:%s;font-size:%s;">
+<thead>
+<tr style="background-color:%s;">
+<th style="padding:6px 10px;text-align:left;">Time</th>
+<th style="padding:6px 10px;text-align:left;">Severity</th>
+<th style="padding:6px 10px;text-align:left;">Session</th>
+<th style="padding:6px 10px;text-align:left;">Evidence</th>
+</tr>
+</thead>
+<tbody>%s</tbody>
+</table>',
+    DARK_TEXT, EMAIL_FONT_BODY, DARK_ROW_ALT, detail_rows_html
+  )
+} else {
+  sec4_table <- sprintf(
+    '<p style="color:%s;font-size:%s;">No new findings in the last 24 h.</p>',
+    ACCENT_GREEN, EMAIL_FONT_BODY
+  )
+}
+
+sec4_summary <- sprintf("top %d by severity · last 24h", min(nrow(sec4_data), 20L))
+sec4_block <- collapsible_block(
+  "New findings — detail",
+  sec4_summary,
+  sec4_table
+)
+
+# ── Assemble email body ────────────────────────────────────────────────────────
+today_str <- format(Sys.Date(), "%Y-%m-%d")
+
+header_html <- sprintf(
+  '<div style="background-color:%s;padding:16px 20px;margin-bottom:12px;
+border-radius:6px;">
+<h2 style="color:%s;font-size:%s;margin:0 0 4px 0;">
+  Overnight Self-Review &mdash; %s
+</h2>
+<p style="color:%s;font-size:%s;margin:0;">
+  %d new findings &nbsp;·&nbsp; %d source tables stale or dead
+</p>
+</div>',
+  DARK_CARD, ACCENT_BLUE, EMAIL_FONT_H2,
+  today_str,
+  DARK_MUTED, EMAIL_FONT_SUBTITLE,
+  n_new_findings, n_stale_tables
+)
+
+footer_html <- sprintf(
+  '<hr style="border-color:%s;margin:20px 0 12px 0;">
+<p style="color:%s;font-size:%s;">
+  Generated by <code>send_overnight_self_review_email.R</code> at %s &nbsp;·&nbsp;
+  DB: <code>%s</code> &nbsp;·&nbsp;
+  <a href="https://github.com/JohnGavin/llm/issues/491"
+     style="color:%s;">llm#491</a>
+</p>',
+  DARK_BORDER, DARK_MUTED, EMAIL_FONT_FOOTER,
+  format(Sys.time(), "%Y-%m-%dT%H:%M:%S UTC"),
+  db_path,
+  ACCENT_BLUE
+)
+
+# QA markers (HTML comments at end of body)
+qa_block <- sprintf(
+  '<!-- QA:overnight_self_review_email=true -->
+<!-- QA:n_new_findings_24h=%d -->
+<!-- QA:n_stale_tables=%d -->
+<!-- QA:overnight_email_date=%s -->',
+  n_new_findings, n_stale_tables, today_str
+)
+
+email_body <- paste0(
+  sprintf('<div style="background-color:%s;color:%s;font-family:Arial,sans-serif;
+padding:20px;max-width:800px;margin:0 auto;">', DARK_BG, DARK_TEXT),
+  header_html,
+  sec1_block, "\n",
+  sec2_block, "\n",
+  sec3_block, "\n",
+  sec4_block, "\n",
+  footer_html,
+  "\n", qa_block, "\n",
+  "</div>"
+)
+
+# ── Dry run: print and exit ────────────────────────────────────────────────────
+if (dry_run) {
+  cat(email_body, "\n")
+  quit(status = 0L)
+}
+
+# ── Send via blastula ──────────────────────────────────────────────────────────
+email_obj <- blastula::compose_email(
+  body = blastula::html(email_body)
+)
+
+smtp_creds <- blastula::creds_envvar(
+  user        = gmail_user,
+  pass_envvar = "GMAIL_APP_PASSWORD",
+  host        = "smtp.gmail.com",
+  port        = 465L,
+  use_ssl     = TRUE
+)
+
+blastula::smtp_send(
+  email      = email_obj,
+  to         = report_recip,
+  from       = gmail_user,
+  subject    = sprintf("[llm] Overnight self-review: %s · %d new findings · %d stale tables",
+                       today_str, n_new_findings, n_stale_tables),
+  credentials = smtp_creds
+)
+
+message(sprintf("Sent overnight self-review email to %s", report_recip))

--- a/tests/testthat/test-overnight-self-review-email.R
+++ b/tests/testthat/test-overnight-self-review-email.R
@@ -1,0 +1,201 @@
+# test-overnight-self-review-email.R
+#
+# Smoke tests for send_overnight_self_review_email.R
+#
+# Coverage:
+#   - dry-run produces non-empty HTML output
+#   - dry-run output contains QA markers (overnight_self_review_email, n_new_findings_24h,
+#     n_stale_tables, overnight_email_date)
+#   - dry-run output contains at least 4 <details> collapsible blocks
+#   - dry-run output contains all 4 source table names in Section 2
+#   - script exits non-zero when DB is absent
+#   - plist passes xmllint syntax check (if xmllint available)
+#
+# Tests run against the dev-time source tree path, with the installed package
+# path (system.file) as the primary fallback when available.
+#
+# Environment:
+#   UNIFIED_DB_PATH  may point to a real or dummy DuckDB file
+#   EMAIL_DRY_RUN    forced to "1" in all tests
+
+library(testthat)
+
+# ── Locate sender script ──────────────────────────────────────────────────────
+
+.email_script <- local({
+  # Primary: installed package (CI)
+  s <- system.file(
+    "scripts/send_overnight_self_review_email.R",
+    package  = "llm",
+    mustWork = FALSE
+  )
+  # Fallback: dev-time source tree
+  if (!nzchar(s) || !file.exists(s)) {
+    s <- normalizePath(
+      file.path(
+        dirname(dirname(testthat::test_path())),
+        ".claude", "scripts", "send_overnight_self_review_email.R"
+      ),
+      mustWork = FALSE
+    )
+  }
+  s
+})
+
+.plist_path <- normalizePath(
+  file.path(
+    dirname(dirname(testthat::test_path())),
+    ".claude", "launchd", "com.claude.overnight-self-review-email.plist"
+  ),
+  mustWork = FALSE
+)
+
+# ── Real DuckDB (if available) ─────────────────────────────────────────────────
+
+.real_db <- normalizePath("~/.claude/logs/unified.duckdb", mustWork = FALSE)
+
+run_dry_run <- function(db_path = .real_db, extra_env = character(0)) {
+  expect_true(
+    nzchar(.email_script) && file.exists(.email_script),
+    info = "send_overnight_self_review_email.R not found"
+  )
+  env_vars <- c(
+    "EMAIL_DRY_RUN=1",
+    paste0("UNIFIED_DB_PATH=", db_path),
+    "GMAIL_USERNAME=",
+    "GMAIL_APP_PASSWORD=",
+    "REPORT_RECIPIENT=",
+    extra_env
+  )
+  system2(
+    "Rscript",
+    args   = .email_script,
+    stdout = TRUE,
+    stderr = TRUE,
+    env    = c(Sys.getenv(), env_vars)
+  )
+}
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+test_that("sender script exists", {
+  expect_true(
+    nzchar(.email_script) && file.exists(.email_script),
+    info = paste("Script not found at:", .email_script)
+  )
+})
+
+test_that("dry-run output is non-empty when DB present", {
+  skip_if_not_installed("blastula")
+  skip_if_not_installed("duckdb")
+  skip_if_not(file.exists(.real_db), "unified.duckdb not available in test environment")
+
+  out      <- run_dry_run()
+  combined <- paste(out, collapse = "\n")
+  expect_gt(nchar(combined), 200L,
+            info = "dry-run output is too short — likely an early error")
+})
+
+test_that("dry-run output contains required QA markers", {
+  skip_if_not_installed("blastula")
+  skip_if_not_installed("duckdb")
+  skip_if_not(file.exists(.real_db), "unified.duckdb not available in test environment")
+
+  out      <- run_dry_run()
+  combined <- paste(out, collapse = "\n")
+
+  expect_true(grepl("QA:overnight_self_review_email=true", combined),
+              info = "Missing QA:overnight_self_review_email marker")
+  expect_true(grepl("QA:n_new_findings_24h=", combined),
+              info = "Missing QA:n_new_findings_24h marker")
+  expect_true(grepl("QA:n_stale_tables=", combined),
+              info = "Missing QA:n_stale_tables marker")
+  expect_true(grepl("QA:overnight_email_date=", combined),
+              info = "Missing QA:overnight_email_date marker")
+})
+
+test_that("dry-run output contains at least 4 collapsible <details> blocks", {
+  skip_if_not_installed("blastula")
+  skip_if_not_installed("duckdb")
+  skip_if_not(file.exists(.real_db), "unified.duckdb not available in test environment")
+
+  out      <- run_dry_run()
+  combined <- paste(out, collapse = "\n")
+
+  n_details <- length(gregexpr("<details", combined)[[1]])
+  expect_gte(n_details, 4L,
+             info = paste("Expected ≥4 <details> blocks, found:", n_details))
+})
+
+test_that("dry-run output contains all 4 source table names in Section 2", {
+  skip_if_not_installed("blastula")
+  skip_if_not_installed("duckdb")
+  skip_if_not(file.exists(.real_db), "unified.duckdb not available in test environment")
+
+  out      <- run_dry_run()
+  combined <- paste(out, collapse = "\n")
+
+  for (tbl in c("sessions", "agent_runs", "hook_events", "errors")) {
+    expect_true(grepl(tbl, combined),
+                info = sprintf("Source table '%s' not found in output", tbl))
+  }
+})
+
+test_that("dry-run output references llm#491", {
+  skip_if_not_installed("blastula")
+  skip_if_not_installed("duckdb")
+  skip_if_not(file.exists(.real_db), "unified.duckdb not available in test environment")
+
+  out      <- run_dry_run()
+  combined <- paste(out, collapse = "\n")
+
+  expect_true(grepl("491", combined),
+              info = "Issue #491 reference not found in dry-run output")
+})
+
+test_that("script exits non-zero when DB path does not exist", {
+  skip_if_not_installed("blastula")
+  skip_if_not_installed("duckdb")
+
+  fake_db <- "/tmp/does_not_exist_test_overnight.duckdb"
+  if (file.exists(fake_db)) file.remove(fake_db)
+
+  cmd <- sprintf(
+    "EMAIL_DRY_RUN=1 UNIFIED_DB_PATH='%s' Rscript '%s' > /dev/null 2>&1; echo $?",
+    fake_db, .email_script
+  )
+  exit_code <- as.integer(trimws(system(cmd, intern = TRUE)))
+  expect_true(exit_code != 0L,
+              info = sprintf("Expected non-zero exit for missing DB, got %d", exit_code))
+})
+
+test_that("launchd plist passes xmllint syntax check", {
+  skip_if_not(file.exists(.plist_path),
+              "Plist not found — skipping xmllint check")
+  xmllint <- Sys.which("xmllint")
+  skip_if(xmllint == "", "xmllint not available")
+
+  exit_code <- system2(xmllint,
+                       args = c("--noout", .plist_path),
+                       stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L,
+               info = "Plist does not pass xmllint syntax check")
+})
+
+test_that("launchd plist file exists", {
+  expect_true(
+    file.exists(.plist_path),
+    info = paste("Plist not found at:", .plist_path)
+  )
+})
+
+test_that("launchd plist schedules at hour 6, minute 30", {
+  skip_if_not(file.exists(.plist_path), "Plist not found")
+
+  plist_text <- paste(readLines(.plist_path), collapse = "\n")
+  # The Hour integer block should be 6
+  expect_true(grepl("<key>Hour</key>\\s*<integer>6</integer>", plist_text),
+              info = "Plist does not schedule at hour 6")
+  expect_true(grepl("<key>Minute</key>\\s*<integer>30</integer>", plist_text),
+              info = "Plist does not schedule at minute 30")
+})


### PR DESCRIPTION
## Summary

- Adds `send_overnight_self_review_email.R` — a daily digest querying `unified.duckdb` for 24h source-table deltas across `sessions`, `agent_runs`, `hook_events`, and `errors`, plus new `self_review_findings_stage1` findings
- Adds launchd plist `com.claude.overnight-self-review-email.plist` (daily 06:30, **NOT yet installed** — orchestrator/user installs)
- Updates `.claude/launchd/README.md` with the new job row
- Adds smoke-test file `tests/testthat/test-overnight-self-review-email.R` (9 cases)

**ETL starvation now visible in email:**  `hook_events` (1 row, last write 2026-04-24) and `errors` (1 row, last write 2026-04-20) both surface as RED DEAD in Section 2 — exactly the gaps tracked in #491.

**PARTIAL close of #491:** this PR delivers the email visibility layer only. The underlying ETL gaps (dead `hook_events` and `errors` pipelines) remain open in #491.

## Test plan

- [x] `EMAIL_DRY_RUN=1` dry-run exits 0 with all 4 QA markers present
- [x] Section 2 shows correct live/sparse/DEAD status tags with real counts (sessions=763/41 live, agent_runs=149/7 sparse, hook_events=1/0 DEAD, errors=1/0 DEAD)
- [x] 4 `<details>` collapsible blocks present
- [x] DuckDB TIMESTAMPTZ fix verified (`current_timestamp::TIMESTAMP - INTERVAL` — no binder errors)
- [x] Plist passes xmllint syntax check
- [ ] Manual SMTP send (orchestrator: set `GMAIL_USERNAME`, `GMAIL_APP_PASSWORD`, `REPORT_RECIPIENT` in `~/.Renviron` and run without `EMAIL_DRY_RUN=1`)
- [ ] Install plist: `cp .claude/launchd/com.claude.overnight-self-review-email.plist ~/Library/LaunchAgents/ && launchctl load -w ~/Library/LaunchAgents/com.claude.overnight-self-review-email.plist`

## Self-checks

1. pwd = `/Users/johngavin/worktrees/llm/feat/491-overnight-self-review-email`
2. branch = `feat/491-overnight-self-review-email` (NOT main, NOT feat/cc-*)
3. last commit SHA = `3a74d94`
4. push ref = `feat/491-overnight-self-review-email` (matches branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)