### PR TITLE
fix(#492): align AGENTS.md section header counts with live filesystem

### DIFF
--- a/.claude/state/492-audit-analysis.md
+++ b/.claude/state/492-audit-analysis.md
@@ -1,0 +1,75 @@
+# Issue #492 — AGENTS.md audit analysis
+
+## What the audit checks
+
+`.claude/scripts/agents_md_audit.sh` (invoked by `session_init.sh` Phase 11)
+compares **section header counts** in `AGENTS.md` against the **live filesystem**:
+
+| AGENTS.md header | Filesystem source |
+|---|---|
+| `## Agents (N)` | `~/.claude/agents/*.md` |
+| `## Skills (N)` | `~/.claude/skills/*/` |
+| `## Commands (N)` | `~/.claude/commands/*.md` |
+| `## Rules (N)` | `~/.claude/rules/*.md` |
+| `## Memory (N files at ...)` | `~/.claude/projects/<proj>/memory/*.md` |
+
+There is **no separate canonical mapping file**. The audit is "header count vs
+live filesystem", not "list-of-rules vs list-of-rules". The mandatory-rules row
+that PR #487 modified is NOT inspected by the audit.
+
+## What the audit does NOT check
+
+- The `**Mandatory rules:**` inline list (the row #487 modified)
+- The `**Mandatory skills:**` inline list
+- Any cross-reference between AGENTS.md content and rule/skill file existence
+- The Hooks header (only counts `*.sh`, but Hooks header has a free-form label)
+
+## Was the drift from #487?
+
+No. PR #487's AGENTS.md diff (commit `8eb4cb6`) only changed one line: it added
+`mermaid-dashboard-pattern` to the inline mandatory-rules list. It did NOT
+touch the four section headers (`## Skills`, `## Rules`, `## Commands`,
+`## Memory`).
+
+The drift the audit reported on 2026-06-04 was **pre-existing**: multiple
+skills/rules/commands/memory files had accumulated since the headers were last
+updated. #487 was the most recent of many additions.
+
+```
+AGENTS.md: DRIFT skills:65→73 rules:54→67 cmds:15→20 mem:16→18
+```
+
+## Fix applied
+
+Bumped the four stale section headers in `AGENTS.md` to match the live
+filesystem at the time of fix:
+
+| Section | Was | Now |
+|---|---|---|
+| Skills | 65 | 73 |
+| Rules | 54 | 67 |
+| Commands | 15 | 20 |
+| Memory | 16 | 18 |
+
+Audit after fix: `AGENTS.md: ok (12a 73s 67r 20c 18m)` (exit 0).
+
+## Why this will keep happening
+
+Every new skill, rule, command, or memory file added under `~/.claude/`
+shifts the live count. AGENTS.md's section header is a manually-maintained
+number. Future-proofing options (out of scope here):
+
+1. Make the header generic: `## Skills` (no count) — audit would need to skip
+   when count is absent
+2. Auto-bump the header from a pre-commit hook
+3. Track via `make audit-fix` that rewrites the four numbers in place
+
+For now: bump the counts when the audit DRIFTs.
+
+## Related
+
+- Issue #492 — this analysis
+- PR #487 — `mermaid-dashboard-pattern` rule (triggered the user-facing
+  WARN, but the rule's addition was not the drift cause)
+- `.claude/scripts/agents_md_audit.sh` — the audit script
+- `.claude/hooks/session_init.sh` Phase 11 — where the audit runs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,11 +72,11 @@ Single trailing `\| head -N` / `\| tail -N` / `\| wc -l` / `\| sort -u` / `\| un
 | `shinylive-builder` | sonnet | Build/test Shinylive WASM vignettes |
 | `wiki-curator` | sonnet | Compile raw/ source material into wiki/ |
 
-## Skills (65)
+## Skills (73)
 
 Full categorised list at `.claude/SKILLS.md` (Mandatory · R Package · Data · Targets · Shiny · Quarto · Prose · DevOps · PM · AI · Specialized). Mandatory subset enforced via the `**Mandatory skills:**` line above.
 
-## Commands (15)
+## Commands (20)
 
 `/hi`(`/session-start`), `/bye`(`/session-end`), `/check`, `/ctx-check`, `/pr-status`, `/cleanup`, `/issue-triage`, `/new-issue`, `/triage`, `/wiki-health`, `/wiki-promote`, `/write-alt-text`, `/skillify`
 
@@ -109,7 +109,7 @@ Full categorised list at `.claude/SKILLS.md` (Mandatory · R Package · Data · 
 
 `deploy-new-project.md`, `onboard-dataset.md`, `debug-ci-failure.md`, `publish-vignette.md`
 
-## Rules (54)
+## Rules (67)
 
 Full categorised list at `.claude/RULES.md` (Core · Nix · MCP · Bash · Data · Stats · Viz · Quarto · Shiny · Pipeline · Knowledge · Quality · Security · Other). Mandatory subset enforced via the `**Mandatory rules:**` line above.
 
@@ -117,7 +117,7 @@ Full categorised list at `.claude/RULES.md` (Core · Nix · MCP · Bash · Data 
 
 `session_init.sh`(SessionStart), `context_survival.sh`(compact/resume+PreCompact), `file_protection.sh`(PreToolUse:Edit|Write), `context_monitor.sh`(PostToolUse:Bash|Task), `wiki_health_onwrite.sh`(PostToolUse:Edit|Write), `skill_quality_onwrite.sh`(PostToolUse:Edit|Write), `session_stop.sh`(Stop). Audit: `agents_md_audit.sh`, `r_code_check.sh`, `qa_gate_check.sh`, `vignette_check.sh`.
 
-## Memory (16 files at `.claude/memory/`)
+## Memory (18 files at `.claude/memory/`)
 
 In-repo at `.claude/memory/`; the runtime path `~/.claude/projects/-Users-johngavin-docs-gh-llm/memory` is a symlink into this directory (#144).
 


### PR DESCRIPTION
## Summary

Closes #492.

The session-start `AGENTS.md` audit (`session_init.sh` Phase 11) reported drift after #487 landed. Investigation: the audit reads section header counts (e.g., `## Rules (54)`) and compares against the live filesystem at `~/.claude/{skills,rules,commands,projects/.../memory}`. There is **no separate canonical mapping file** — the audit is "header count vs live FS".

The drift was **pre-existing**, not caused by #487. PR #487 only modified the inline `**Mandatory rules:**` row (which the audit does NOT inspect). The drift accumulated across many additions; #487 was just the most recent.

## What changed

Bumped four section header counts to match live filesystem:

| Section | Was | Now |
|---|---|---|
| Skills | 65 | 73 |
| Commands | 15 | 20 |
| Rules | 54 | 67 |
| Memory | 16 | 18 |

Added `.claude/state/492-audit-analysis.md` documenting what the audit does/doesn't check and why future drifts will keep happening (the header is a manual count).

## Verification

Audit before:
```
AGENTS.md: DRIFT skills:65→73 rules:54→67 cmds:15→20 mem:16→18
```

Audit after:
```
AGENTS.md: ok (12a 73s 67r 20c 18m)
```

## Test plan

- [x] `bash .claude/scripts/agents_md_audit.sh` exits 0 from the worktree
- [x] All four headers match `ls ~/.claude/{skills,rules,commands}` + memory counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
