### PR TITLE
feat(#474): data-glossary-and-entity-resolution rule (mandatory)

### DIFF
--- a/.claude/rules/data-glossary-and-entity-resolution.md
+++ b/.claude/rules/data-glossary-and-entity-resolution.md
@@ -1,0 +1,184 @@
+# Rule: Data Glossary and Entity Resolution (Mandatory)
+
+## When This Applies
+
+Every project that joins data from two or more sources where the join key has
+more than one human form. Examples:
+
+- `user_id` vs `email` vs `username` — three forms for one identity concept
+- `repo` vs `repo_full_name` vs `slug` vs `project` — same repository, four names
+- `severity` vs `sev` vs `severity_level` — roborev DB vs GitHub labels vs internal config
+- `"Acme Corp"` vs `"Acme Corporation"` vs `"ACME-NA"` — three strings for one account
+
+If your code has a raw string join condition, a CASE WHEN map, or a manually
+maintained `left_join(by = c("col_a" = "col_b"))` with no backing source of
+truth, this rule applies.
+
+## Source
+
+JohnGavin/llm#474 — Salesforce 8 Design Principles gap analysis (Principle 2:
+Harmonise data with metadata-driven understanding). Concrete trigger: the
+roborev daily report joined `findings` (roborev DB) with `commits` (GitHub)
+by repo slug. Slug normalisation differed by source; findings were attributed
+to the wrong repo and the cross-repo severity comparison (#471) was
+meaningless.
+
+## CRITICAL: Every Join Key Has One Canonical Form
+
+Two systems disagreeing on a name is not a data-quality bug — it is a missing
+mapping. The canonical name is the project's authoritative identifier. Every
+alias is a deviation that MUST be resolved to the canonical form before any
+join, aggregation, or display. The mapping lives in one place; all code reads
+from that place.
+
+A join that hard-codes `col_a = "GitHub"` when the DB stores `"github"` is an
+untracked alias — invisible until it produces a silent wrong answer.
+
+## The Pattern
+
+### 1. Glossary file (single source of truth for canonical names)
+
+Create `data/glossary.yaml` (or `inst/glossary.yaml` for R packages). One
+entry per business entity:
+
+```yaml
+# data/glossary.yaml
+entities:
+  repo_id:
+    canonical: repo_id
+    description: "Unique repository identifier — owner/repo form, lowercase"
+    example: "johngavin/llm"
+  severity_level:
+    canonical: severity_level
+    description: "Roborev finding severity: critical | major | minor | info"
+    values: [critical, major, minor, info]
+  account_name:
+    canonical: account_name
+    description: "Canonical account name (ALLCAPS short form)"
+    example: "ACME"
+```
+
+### 2. Entity-resolution map (alias → canonical)
+
+Create `data/entity_resolution.yaml`:
+
+```yaml
+# data/entity_resolution.yaml
+# format: alias: canonical_value
+repo_id:
+  - alias: "JohnGavin/llm"
+    canonical: "johngavin/llm"
+  - alias: "johngavin/LLM"
+    canonical: "johngavin/llm"
+severity_level:
+  - alias: "sev"
+    canonical: "severity_level"
+  - alias: "HIGH"
+    canonical: "critical"
+  - alias: "high"
+    canonical: "critical"
+  - alias: "MEDIUM"
+    canonical: "major"
+account_name:
+  - alias: "Acme Corp"
+    canonical: "ACME"
+  - alias: "Acme Corporation"
+    canonical: "ACME"
+  - alias: "ACME-NA"
+    canonical: "ACME"
+```
+
+### 3. Load both as pipeline inputs (R / targets)
+
+`load_entity_resolution()` reads the YAML and flattens it to a long tibble
+(`entity`, `alias`, `canonical`). `resolve_entity(values, entity, tbl)` looks
+up each value and `cli::cli_abort()` on any unmapped alias.
+
+Expose both as `targets` inputs so downstream targets rebuild on glossary
+changes:
+
+```r
+# _targets.R (fragment)
+tar_target(glossary,         load_glossary()),
+tar_target(entity_resolution, load_entity_resolution()),
+tar_target(findings_normalised, {
+  findings_raw |>
+    dplyr::mutate(
+      repo_id        = resolve_entity(repo, "repo_id", entity_resolution),
+      severity_level = resolve_entity(severity, "severity_level", entity_resolution)
+    )
+}),
+```
+
+### 4. SQL / DuckDB equivalent (duckplyr)
+
+For SQL-heavy pipelines, materialise the resolution map as a reference table
+and join before downstream queries. Follow with a validation query to fail
+fast on any unmapped values — see Worked Example 2 below for the full pattern.
+
+## Forbidden Patterns
+
+| Pattern | Why wrong | Fix |
+|---|---|---|
+| `dplyr::left_join(by = c("slug" = "project_name"))` with no backing map | Implicit alias; silently wrong when either side adds a new form | Create an `entity_resolution.yaml` entry; join via the resolved canonical column |
+| `CASE WHEN repo = 'GitHub' THEN 'github' END` in raw SQL | Ad-hoc, undiscoverable, not reused across queries | Move to entity_resolution.yaml; load as a reference table |
+| Canonical name defined in a comment | Not machine-readable; cannot be enforced | Glossary YAML entry with `canonical:` and `description:` fields |
+| Two YAML files with overlapping alias lists | Ambiguous mapping; which wins? | One `entity_resolution.yaml` per project; one entry per alias |
+| Alias map inside a targets plan (not a separate file) | Rebuild requires editing pipeline code, not data | Separate data file loaded as a target input |
+| `tolower()` or `str_to_lower()` as a normalisation substitute | Case-folding misses structural differences (`repo` vs `repo_full_name`) | Explicit alias map |
+| `resolve_entity()` called after join (post-hoc) | Wrong answers already computed | Resolve before any join or aggregation |
+
+## Worked Examples
+
+### Example 1 — roborev cross-repo joins (R / targets)
+
+```r
+# Context: roborev DB uses "johngavin/llm"; GitHub API returns "JohnGavin/llm"
+
+# WRONG — silent mismatch; zero rows joined
+findings |> dplyr::left_join(commits, by = c("repo" = "repo_name"))
+
+# RIGHT — resolve both sides to canonical before joining
+findings_norm <- findings |>
+  dplyr::mutate(repo_id = resolve_entity(repo, "repo_id", entity_resolution))
+commits_norm  <- commits  |>
+  dplyr::mutate(repo_id = resolve_entity(repo_name, "repo_id", entity_resolution))
+findings_norm |> dplyr::left_join(commits_norm, by = "repo_id")
+```
+
+### Example 2 — severity mapping in DuckDB SQL
+
+```sql
+-- WRONG: ad-hoc CASE WHEN, not in the glossary
+SELECT CASE
+  WHEN sev = 'HIGH' THEN 'critical'
+  WHEN sev = 'MEDIUM' THEN 'major'
+  ELSE sev
+END AS severity_level
+FROM findings;
+
+-- RIGHT: load entity_resolution as a reference table, then join
+-- (materialise resolution_tbl from data/entity_resolution.yaml via R before this query)
+SELECT f.*, r.canonical AS severity_level
+FROM findings f
+LEFT JOIN resolution_tbl r
+  ON r.entity = 'severity_level' AND r.alias = f.sev;
+-- Follow with a validation query: any unmatched sev values should error
+```
+
+## Related
+
+- `cross-cutting-rename` — same single-source-of-truth discipline applied to
+  user-facing labels; this rule applies it to join keys and entity identifiers
+- `dynamic-prose-values` — canonical values in prose must come from the
+  glossary, not hardcoded strings
+- `data-validation-pointblank` skill — validate that canonical columns contain
+  only values in the glossary after entity resolution
+- `duckdb-patterns` skill — duckplyr join patterns; pair with this rule to
+  ensure joins are canonical-key-based
+- `data-in-packages` rule — data packaging convention; glossary.yaml belongs
+  in `inst/` for R packages
+- JohnGavin/llm#474 — origin issue
+- JohnGavin/llm#471 — cross-repo severity comparison (canonical repo_id required)
+- JohnGavin/llm#470 — goodpractice custom check (future: verifies glossary
+  covers every distinct value in configured join columns)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Single trailing `\| head -N` / `\| tail -N` / `\| wc -l` / `\| sort -u` / `\| un
 **Knowledge Base (raw/wiki/outputs):** Use `knowledge-base-wiki` skill. Central hub at `~/docs_gh/llm/knowledge/` (LOCAL git only — NEVER push to GitHub, `PRIVATE` marker + pre-push hook block). raw/ is append-only (enforced by `file_protection.sh`), wiki/ requires `## Sources` section, AI-inferred claims tagged `> ⚠ AI-inferred:`, cross-wiki links use `[[topic]]` syntax. T1 health check on every Edit/Write via `wiki_health_onwrite.sh`. Run `/wiki-health` after batch updates. Use `wiki-curator` agent to compile, `critic` (wiki validation mode) for adversarial review.
 
 **Mandatory skills:** `adversarial-qa`, `quality-gates`, `r-package-workflow`, `test-driven-development`, `nix-rix-r-environment`, `llm-package-context`, `readme-qmd-standard`, `subagent-delegation`, `spec-bundled-skills`, `knowledge-base-wiki`.
-**Mandatory rules:** `systematic-debugging`, `verification-before-completion`, `btw-timeouts`, `orchestrator-protocol`, `provenance-mandatory`, `raw-folder-readonly`, `confidence-markers`, `wiki-storage-policy`, `git-no-compound-cd`, `look-ahead-bias-prevention`, `nix-agent-shell-protocol`, `worktree-location`, `dark-mode-completeness`, `narrative-evidence-block`, `narrative-colour-persistence`, `mermaid-click-anchors`, `mermaid-dashboard-pattern`, `roborev-exclude-patterns`, `cross-cutting-rename`, `dashboard-table-styling`, `uniform-typography`, `branch-harvest-on-fork`, `dashboard-filter-placement`, `survival-reporting`, `vignette-build-info-block`, `pr-shipping-discipline`.
+**Mandatory rules:** `systematic-debugging`, `verification-before-completion`, `btw-timeouts`, `orchestrator-protocol`, `provenance-mandatory`, `raw-folder-readonly`, `confidence-markers`, `wiki-storage-policy`, `git-no-compound-cd`, `look-ahead-bias-prevention`, `nix-agent-shell-protocol`, `worktree-location`, `dark-mode-completeness`, `narrative-evidence-block`, `narrative-colour-persistence`, `mermaid-click-anchors`, `mermaid-dashboard-pattern`, `roborev-exclude-patterns`, `cross-cutting-rename`, `data-glossary-and-entity-resolution`, `dashboard-table-styling`, `uniform-typography`, `branch-harvest-on-fork`, `dashboard-filter-placement`, `survival-reporting`, `vignette-build-info-block`, `pr-shipping-discipline`.
 
 **Dark-mode contrast (every Quarto project):** Single global script at `~/docs_gh/llm/.claude/scripts/check_dark_contrast.sh` (public mirror: `https://raw.githubusercontent.com/JohnGavin/llm/main/.claude/scripts/check_dark_contrast.sh`). NEVER copy into a project. EVERY `_quarto.yml` MUST add this line under `project: post-render:` — `- /Users/johngavin/docs_gh/llm/.claude/scripts/quarto_post_render_contrast.sh`. Render fails on any uncovered light inline background. See `dark-mode-completeness` rule.
 
@@ -109,7 +109,7 @@ Full categorised list at `.claude/SKILLS.md` (Mandatory · R Package · Data · 
 
 `deploy-new-project.md`, `onboard-dataset.md`, `debug-ci-failure.md`, `publish-vignette.md`
 
-## Rules (67)
+## Rules (69)
 
 Full categorised list at `.claude/RULES.md` (Core · Nix · MCP · Bash · Data · Stats · Viz · Quarto · Shiny · Pipeline · Knowledge · Quality · Security · Other). Mandatory subset enforced via the `**Mandatory rules:**` line above.
 


### PR DESCRIPTION
## Summary

Closes #474.

Adds a new mandatory rule **`data-glossary-and-entity-resolution`** that enforces a single canonical form for every join key across all projects. When two systems disagree on a name (e.g. `"JohnGavin/llm"` vs `"johngavin/llm"`), the canonical name wins and the alias mapping in `data/entity_resolution.yaml` is the bridge.

Key points:
- `data/glossary.yaml` defines one canonical name per business entity
- `data/entity_resolution.yaml` maps every alias → canonical value
- Both files loaded as `targets` pipeline inputs so glossary changes trigger rebuilds
- `resolve_entity()` R helper aborts via `cli::cli_abort()` on any unmapped alias
- SQL/DuckDB equivalent: materialise resolution map as reference table, join before downstream queries

## Worked examples

1. **roborev cross-repo joins** — resolving `repo` and `repo_name` to canonical `repo_id` before joining `findings` with `commits`
2. **severity mapping in DuckDB SQL** — replacing ad-hoc `CASE WHEN` with a reference-table join

## AGENTS.md change

- Added `data-glossary-and-entity-resolution` to mandatory rules row (after `cross-cutting-rename`)
- Bumped `## Rules (N)` from 67 → 69 (was stale; actual count is 69 after this PR merges)

## Test plan

- [x] Rule file 184 lines (within 100–220 target)
- [x] `data-glossary-and-entity-resolution` present in AGENTS.md mandatory rules row
- [x] `agents_md_audit.sh` passes: `AGENTS.md: ok (12a 73s 69r 20c 18m)`
- [x] Commit subject matches spec: `feat(#474): data-glossary-and-entity-resolution rule (mandatory)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
