### PR TITLE
chore(agents-md): consolidate Rules count 69→74 + add 3 new mandatory rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Single trailing `\| head -N` / `\| tail -N` / `\| wc -l` / `\| sort -u` / `\| un
 **Knowledge Base (raw/wiki/outputs):** Use `knowledge-base-wiki` skill. Central hub at `~/docs_gh/llm/knowledge/` (LOCAL git only — NEVER push to GitHub, `PRIVATE` marker + pre-push hook block). raw/ is append-only (enforced by `file_protection.sh`), wiki/ requires `## Sources` section, AI-inferred claims tagged `> ⚠ AI-inferred:`, cross-wiki links use `[[topic]]` syntax. T1 health check on every Edit/Write via `wiki_health_onwrite.sh`. Run `/wiki-health` after batch updates. Use `wiki-curator` agent to compile, `critic` (wiki validation mode) for adversarial review.
 
 **Mandatory skills:** `adversarial-qa`, `quality-gates`, `r-package-workflow`, `test-driven-development`, `nix-rix-r-environment`, `llm-package-context`, `readme-qmd-standard`, `subagent-delegation`, `spec-bundled-skills`, `knowledge-base-wiki`.
-**Mandatory rules:** `systematic-debugging`, `verification-before-completion`, `btw-timeouts`, `orchestrator-protocol`, `provenance-mandatory`, `raw-folder-readonly`, `confidence-markers`, `wiki-storage-policy`, `git-no-compound-cd`, `look-ahead-bias-prevention`, `nix-agent-shell-protocol`, `worktree-location`, `dark-mode-completeness`, `narrative-evidence-block`, `narrative-colour-persistence`, `mermaid-click-anchors`, `mermaid-dashboard-pattern`, `roborev-exclude-patterns`, `cross-cutting-rename`, `data-glossary-and-entity-resolution`, `dashboard-table-styling`, `uniform-typography`, `branch-harvest-on-fork`, `dashboard-filter-placement`, `survival-reporting`, `vignette-build-info-block`, `pr-shipping-discipline`.
+**Mandatory rules:** `systematic-debugging`, `verification-before-completion`, `btw-timeouts`, `orchestrator-protocol`, `provenance-mandatory`, `raw-folder-readonly`, `confidence-markers`, `wiki-storage-policy`, `git-no-compound-cd`, `look-ahead-bias-prevention`, `nix-agent-shell-protocol`, `worktree-location`, `dark-mode-completeness`, `narrative-evidence-block`, `narrative-colour-persistence`, `mermaid-click-anchors`, `mermaid-dashboard-pattern`, `roborev-exclude-patterns`, `cross-cutting-rename`, `data-glossary-and-entity-resolution`, `unified-observability-schema`, `agent-identity-and-task-scopes`, `human-in-the-loop-decision-points`, `dashboard-table-styling`, `uniform-typography`, `branch-harvest-on-fork`, `dashboard-filter-placement`, `survival-reporting`, `vignette-build-info-block`, `pr-shipping-discipline`.
 
 **Dark-mode contrast (every Quarto project):** Single global script at `~/docs_gh/llm/.claude/scripts/check_dark_contrast.sh` (public mirror: `https://raw.githubusercontent.com/JohnGavin/llm/main/.claude/scripts/check_dark_contrast.sh`). NEVER copy into a project. EVERY `_quarto.yml` MUST add this line under `project: post-render:` — `- /Users/johngavin/docs_gh/llm/.claude/scripts/quarto_post_render_contrast.sh`. Render fails on any uncovered light inline background. See `dark-mode-completeness` rule.
 
@@ -109,7 +109,7 @@ Full categorised list at `.claude/SKILLS.md` (Mandatory · R Package · Data · 
 
 `deploy-new-project.md`, `onboard-dataset.md`, `debug-ci-failure.md`, `publish-vignette.md`
 
-## Rules (69)
+## Rules (74)
 
 Full categorised list at `.claude/RULES.md` (Core · Nix · MCP · Bash · Data · Stats · Viz · Quarto · Shiny · Pipeline · Knowledge · Quality · Security · Other). Mandatory subset enforced via the `**Mandatory rules:**` line above.
 


### PR DESCRIPTION
## Summary

Consolidates the AGENTS.md drift after yesterday's 5-rule batch landed (#518, #519, #520, #521, #522).

## What changed

- `## Rules (69)` → `## Rules (74)`
- Mandatory rules row: added `unified-observability-schema` (#475), `agent-identity-and-task-scopes` (#476), `human-in-the-loop-decision-points` (#477) — all mandatory
- `llm-portability-statement` (#478) intentionally NOT in the mandatory row — it is **advisory** (lock-in awareness counter to the `claude-api` skill)
- `data-glossary-and-entity-resolution` (#474) was already added in its own PR (#522)

## Follow-up noted in commit

`.claude/scripts/agents_md_audit.sh` uses a relative `AGENTS.md` path, so it false-positives when run from a worktree whose copy of AGENTS.md is older than main. Will file separately.

## Test plan

- [ ] Verify `bash /Users/johngavin/docs_gh/llm/.claude/scripts/agents_md_audit.sh` against the main checkout returns `AGENTS.md: ok (12a 73s 74r 20c 18m)`
- [ ] No DRIFT line on next session start (Phase 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
