### PR TITLE
feat(#534): filter Severity by Project against canonical_projects

### DIFF
--- a/.claude/scripts/roborev_daily_report.R
+++ b/.claude/scripts/roborev_daily_report.R
@@ -341,21 +341,56 @@ trend_delta <- function(cur_val, pri_val) {
 # Returns a list of records {repo, High, Medium, Low, Unknown, Total}
 # sorted descending by Total.  Uses severity_max column from lifecycle table.
 
-compute_severity_by_project <- function(con, anchor, days) {
+compute_severity_by_project <- function(con, anchor, days,
+                                       filtered = TRUE) {
+  # Honour env-var escape hatch: INCLUDE_NON_CANONICAL=1 forces unfiltered.
+  if (nzchar(Sys.getenv("INCLUDE_NON_CANONICAL"))) filtered <- FALSE
+
   bounds <- window_bounds(anchor, days)
-  sql <- sprintf(
-    "SELECT
-       repo,
-       COALESCE(severity_max, 'Unknown') AS severity,
-       COUNT(*)::INTEGER AS n
-     FROM roborev_review_lifecycle
-     WHERE verdict = 'F'
-       AND created_at::TIMESTAMP >= TIMESTAMP '%s'
-       AND created_at::TIMESTAMP <  TIMESTAMP '%s'
-     GROUP BY repo, severity_max
-     ORDER BY repo",
-    fmt_ts(bounds$cur$start), fmt_ts(bounds$cur$end)
-  )
+
+  if (filtered) {
+    # Join against canonical_projects + canonical_project_aliases so fixture
+    # repos, test repos, and one-off repos are excluded.  Aliases (e.g.
+    # "coMMpass") are resolved to the canonical slug before pivoting.
+    # See issue #534 and the canonical_projects table seeded by PR #540.
+    sql <- sprintf(
+      "WITH valid_slugs AS (
+         SELECT slug FROM canonical_projects WHERE is_active = TRUE
+       ),
+       alias_map AS (
+         SELECT alias, slug FROM canonical_project_aliases
+       )
+       SELECT
+         COALESCE(a.slug, s.repo) AS repo,
+         COALESCE(s.severity_max, 'Unknown') AS severity,
+         COUNT(*)::INTEGER AS n
+       FROM roborev_review_lifecycle s
+       LEFT JOIN alias_map a ON s.repo = a.alias
+       WHERE s.verdict = 'F'
+         AND s.created_at::TIMESTAMP >= TIMESTAMP '%s'
+         AND s.created_at::TIMESTAMP <  TIMESTAMP '%s'
+         AND (s.repo IN (SELECT slug FROM valid_slugs)
+              OR s.repo IN (SELECT alias FROM alias_map))
+       GROUP BY COALESCE(a.slug, s.repo), s.severity_max
+       ORDER BY repo",
+      fmt_ts(bounds$cur$start), fmt_ts(bounds$cur$end)
+    )
+  } else {
+    sql <- sprintf(
+      "SELECT
+         repo,
+         COALESCE(severity_max, 'Unknown') AS severity,
+         COUNT(*)::INTEGER AS n
+       FROM roborev_review_lifecycle
+       WHERE verdict = 'F'
+         AND created_at::TIMESTAMP >= TIMESTAMP '%s'
+         AND created_at::TIMESTAMP <  TIMESTAMP '%s'
+       GROUP BY repo, severity_max
+       ORDER BY repo",
+      fmt_ts(bounds$cur$start), fmt_ts(bounds$cur$end)
+    )
+  }
+
   raw <- tryCatch(
     dbGetQuery(con, sql),
     error = function(e) {
@@ -527,9 +562,10 @@ df_14d_global <- load_window(con, bounds_14d$cur$start, bounds_14d$cur$end)
 df_14d_global <- enrich_with_attempts(con, df_14d_global, has_lineage_table)
 outliers_14d  <- compute_outliers(df_14d_global)
 
-# §5 Severity by project: 7d global
+# §5 Severity by project: 7d global (filtered to canonical_projects)
 cat("roborev_daily_report.R: computing 7d per-project severity table...\n")
-severity_by_project_7d <- compute_severity_by_project(con, anchor_date, 7L)
+severity_by_project_7d     <- compute_severity_by_project(con, anchor_date, 7L, filtered = TRUE)
+severity_by_project_7d_all <- compute_severity_by_project(con, anchor_date, 7L, filtered = FALSE)
 
 # ── Assemble JSON output ───────────────────────────────────────────────────────
 
@@ -582,7 +618,8 @@ json_payload <- list(
     by_attempts = outliers_14d$by_attempts,
     by_time     = outliers_14d$by_time
   ),
-  severity_by_project_7d = severity_by_project_7d  # §5: per-repo severity counts (llm#449)
+  severity_by_project_7d     = severity_by_project_7d,      # §5: filtered (llm#534)
+  severity_by_project_7d_all = severity_by_project_7d_all   # §5: unfiltered (debug/legacy)
 )
 
 # ── Write JSON snapshot ───────────────────────────────────────────────────────

--- a/.claude/scripts/send_roborev_email.R
+++ b/.claude/scripts/send_roborev_email.R
@@ -566,8 +566,9 @@ if (length(severity_rows_data) > 0L) {
 }
 severity_inner <- paste0(severity_inner, "</table>")
 # llm#527: wrap severity table in collapsible_block(open=FALSE) — collapsed by default
+# llm#534: caption updated to reflect canonical-only filtering
 severity_html <- collapsible_block(
-  "Severity by Project (7d)",
+  "Severity by Project (7d, canonical only — see #528)",
   sprintf("%d project(s) tracked", length(severity_rows_data)),
   severity_inner,
   open = FALSE


### PR DESCRIPTION
## Summary

Fixes the 93% fixture-repo noise in the "Severity by Project (7d)" section of the roborev daily email by filtering against the `canonical_projects` table.

- **`compute_severity_by_project()`** gains a `filtered = TRUE` default parameter
- **SQL**: `WITH valid_slugs AS (SELECT slug FROM canonical_projects WHERE is_active = TRUE)` + `alias_map` CTE for `canonical_project_aliases`
- **Alias resolution**: `COALESCE(a.slug, s.repo)` ensures `coMMpass` → `commpass` (and any future aliases)
- **Escape hatch**: `INCLUDE_NON_CANONICAL=1` env var reverts to unfiltered mode
- **JSON snapshot**: Both `severity_by_project_7d` (filtered) and `severity_by_project_7d_all` (unfiltered) kept for debugging/legacy consumers
- **Email caption**: Updated to `"Severity by Project (7d, canonical only — see #528)"`

## Before / After

| | Distinct repos in 7d window |
|---|---|
| **Before** (unfiltered) | 14 (50+ in earlier sessions with more fixture activity) |
| **After** (filtered) | 4 (`historical`, `llm`, `mycare`, `premortem`) |

Grep-zero test confirmed: `config_digest_git_fixture_*`, `kb_fixture_*`, `test_repo`, `repo1`, `tmprepo_test`, etc. — all absent from filtered output.

## Test plan

- [x] `parse("roborev_daily_report.R")` → PARSE OK
- [x] Verification script `/tmp/verify_534.R` run against live `unified.duckdb`
- [x] Filtered output: 4 repos (canonical only)
- [x] Unfiltered output: 14 repos (includes fixture noise — confirms filter is working)
- [x] Grep-zero test: PASS — no fixture/test patterns in filtered results
- [x] `INCLUDE_NON_CANONICAL=1` escape hatch: forces `filtered <- FALSE` via env var
- [ ] Run `roborev_daily_report.R --dry-run` in nix-shell to confirm end-to-end (post-merge smoke test)

Closes #534. References #528 (collapsible email sections), #540 (canonical_projects seeding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
