### PR TITLE
feat(#536): producer-side skip-and-warn for non-canonical repos

### DIFF
--- a/.claude/scripts/lib/canonical_check.R
+++ b/.claude/scripts/lib/canonical_check.R
@@ -1,0 +1,118 @@
+# canonical_check.R — R helper for producer-side skip-and-warn (#536)
+#
+# Source this file in ETL scripts to get:
+#   - canonical_slugs(con): returns character vector of canonical slugs + aliases
+#   - filter_canonical(df, con): filters a data frame's `repo` column to only
+#     canonical entries, logging skips.
+#   - log_canonical_skip(slugs, producer): appends to the skip log.
+#
+# Opt-out: set env var CANONICAL_PROJECTS_INCLUDE_FIXTURES=1 to bypass filtering.
+#
+# Skip log: ~/.claude/logs/canonical_producer_skip.log
+#
+# Issue: JohnGavin/llm#536
+
+# ── Internal cache (process-local, populated lazily) ─────────────────────────
+
+.canonical_cache <- new.env(parent = emptyenv())
+.canonical_cache$slugs <- NULL  # NULL = not yet loaded
+
+# canonical_slugs(con)
+#
+# Returns a character vector of all active slugs and aliases from unified.duckdb.
+# Caches the result for the lifetime of the R process.
+# con: a DBI connection to unified.duckdb (passed in to avoid circular opens).
+# When con is NULL or query fails, returns character(0) (all-reject fallback).
+canonical_slugs <- function(con) {
+  if (!is.null(.canonical_cache$slugs)) {
+    return(.canonical_cache$slugs)
+  }
+
+  # Opt-out: include all as canonical
+  if (isTRUE(nchar(Sys.getenv("CANONICAL_PROJECTS_INCLUDE_FIXTURES")) > 0) &&
+      Sys.getenv("CANONICAL_PROJECTS_INCLUDE_FIXTURES") == "1") {
+    .canonical_cache$slugs <- character(0L)  # signal: bypass filter
+    return(.canonical_cache$slugs)
+  }
+
+  if (is.null(con)) {
+    .canonical_cache$slugs <- character(0L)
+    return(.canonical_cache$slugs)
+  }
+
+  result <- tryCatch(
+    DBI::dbGetQuery(con, "
+      SELECT slug FROM canonical_projects WHERE is_active = TRUE
+      UNION ALL
+      SELECT alias FROM canonical_project_aliases
+    ")$slug,
+    error = function(e) {
+      message("canonical_check.R: cannot load canonical slugs — ",
+              conditionMessage(e), " — will skip all non-matched repos")
+      character(0L)
+    }
+  )
+
+  .canonical_cache$slugs <- result
+  result
+}
+
+# filter_canonical(df, con, producer, include_fixtures)
+#
+# Filters df$repo to canonical slugs, logs skipped rows, returns filtered df.
+# df:               data.frame with a `repo` column (character)
+# con:              DBI connection to unified.duckdb
+# producer:         string identifying the calling script (for log)
+# include_fixtures: logical; if TRUE, bypass filtering (default: FALSE)
+#
+# Returns the filtered data.frame (same structure as df).
+filter_canonical <- function(df, con, producer = "unknown",
+                              include_fixtures = FALSE) {
+  if (include_fixtures ||
+      identical(Sys.getenv("CANONICAL_PROJECTS_INCLUDE_FIXTURES"), "1")) {
+    return(df)
+  }
+
+  if (nrow(df) == 0L || !"repo" %in% names(df)) {
+    return(df)
+  }
+
+  slugs <- canonical_slugs(con)
+
+  # If slugs is empty (DB unavailable), treat as all-reject
+  if (length(slugs) == 0L) {
+    non_canon <- unique(df$repo)
+    if (length(non_canon) > 0L) {
+      log_canonical_skip(non_canon, producer)
+      message(sprintf(
+        "%s: canonical guard FALLBACK — DB unavailable, skipping %d repos: %s",
+        producer, length(non_canon), paste(non_canon, collapse = ", ")
+      ))
+    }
+    return(df[character(0L), , drop = FALSE])  # empty frame, same structure
+  }
+
+  non_canon <- unique(df$repo[!df$repo %in% slugs])
+  if (length(non_canon) > 0L) {
+    log_canonical_skip(non_canon, producer)
+    message(sprintf(
+      "%s: canonical guard skipped %d non-canonical repo(s): %s",
+      producer, length(non_canon), paste(non_canon, collapse = ", ")
+    ))
+  }
+
+  df[df$repo %in% slugs, , drop = FALSE]
+}
+
+# log_canonical_skip(slugs, producer)
+#
+# Appends one line per slug to ~/.claude/logs/canonical_producer_skip.log
+log_canonical_skip <- function(slugs, producer = "unknown") {
+  skip_log <- file.path(Sys.getenv("HOME"), ".claude", "logs",
+                         "canonical_producer_skip.log")
+  ts <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+  for (slug in slugs) {
+    cat(sprintf("%s SKIP slug=%s producer=%s\n", ts, slug, producer),
+        file = skip_log, append = TRUE)
+  }
+}

--- a/.claude/scripts/lib/canonical_check.sh
+++ b/.claude/scripts/lib/canonical_check.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# canonical_check.sh — shared helper for producer-side skip-and-warn (#536)
+#
+# Source this file; do NOT execute directly.
+#
+# Usage:
+#   source /path/to/.claude/scripts/lib/canonical_check.sh
+#
+#   if is_canonical_project "llm"; then
+#       echo "canonical"
+#   else
+#       log_canonical_skip "roborev_pmhook_test_abc" "my_producer.sh"
+#       echo "skipped"
+#   fi
+#
+# Opt-out: set CANONICAL_PROJECTS_INCLUDE_FIXTURES=1 before sourcing to
+# bypass all checks (useful in CI / self-test harnesses).
+#
+# Skip log: ~/.claude/logs/canonical_producer_skip.log
+#
+# Issue: JohnGavin/llm#536
+
+# Process-local cache — ":delimited:" string, populated lazily on first call.
+_CANONICAL_LIST_CACHE=""
+
+# is_canonical_project SLUG
+#
+# Returns 0 (true) if SLUG appears in canonical_projects or
+# canonical_project_aliases in unified.duckdb.
+# Returns 1 (false) otherwise.
+#
+# When CANONICAL_PROJECTS_INCLUDE_FIXTURES=1 always returns 0.
+is_canonical_project() {
+    local candidate="$1"
+
+    # Opt-out: treat everything as canonical when fixtures are included
+    if [ "${CANONICAL_PROJECTS_INCLUDE_FIXTURES:-0}" = "1" ]; then
+        return 0
+    fi
+
+    # Lazy-load on first call
+    if [ -z "$_CANONICAL_LIST_CACHE" ]; then
+        _load_canonical_cache
+    fi
+
+    # O(1) substring match on ":slug:" pattern
+    case ":${_CANONICAL_LIST_CACHE}:" in
+        *":${candidate}:"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# _load_canonical_cache
+#
+# Internal: populates _CANONICAL_LIST_CACHE from unified.duckdb.
+# Falls back to empty (all-reject) when the DB is unavailable.
+_load_canonical_cache() {
+    local db
+    db="${UNIFIED_DB:-${HOME}/.claude/logs/unified.duckdb}"
+
+    if [ ! -f "$db" ]; then
+        # DB unavailable — treat cache as empty (callers will skip everything)
+        _CANONICAL_LIST_CACHE="__EMPTY__"
+        return
+    fi
+
+    local sql="SELECT slug FROM canonical_projects WHERE is_active = TRUE UNION ALL SELECT alias FROM canonical_project_aliases;"
+    local raw
+    # stdin-pipe to avoid duckdb -c stall risk
+    raw="$(printf '%s\n' "$sql" | duckdb -noheader -list "$db" 2>/dev/null)"
+
+    if [ -z "$raw" ]; then
+        _CANONICAL_LIST_CACHE="__EMPTY__"
+        return
+    fi
+
+    # Build ":slug1:slug2:..." from newline-separated output
+    # Strip DuckDB startup noise lines (Run Time, loaded ..., memory:)
+    local cleaned
+    cleaned="$(printf '%s\n' "$raw" | awk '
+        /^Run Time/           { next }
+        /^loaded /            { next }
+        /^memory:/            { next }
+        /^[a-zA-Z0-9_.-]+: \// { next }
+        /^$/                  { next }
+        { print }
+    ')"
+
+    _CANONICAL_LIST_CACHE="$(printf '%s\n' "$cleaned" | tr '\n' ':')"
+    # Ensure no leading/trailing colons cause false matches
+    _CANONICAL_LIST_CACHE="${_CANONICAL_LIST_CACHE%:}"
+    _CANONICAL_LIST_CACHE="${_CANONICAL_LIST_CACHE#:}"
+}
+
+# log_canonical_skip SLUG PRODUCER
+#
+# Appends one line to the canonical skip log.
+CANONICAL_SKIP_LOG="${HOME}/.claude/logs/canonical_producer_skip.log"
+
+log_canonical_skip() {
+    local slug="$1"
+    local producer="$2"
+    local ts
+    ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf '%s SKIP slug=%s producer=%s\n' "$ts" "$slug" "$producer" >> "$CANONICAL_SKIP_LOG"
+}

--- a/.claude/scripts/roborev_metrics_etl.R
+++ b/.claude/scripts/roborev_metrics_etl.R
@@ -40,15 +40,17 @@ suppressPackageStartupMessages({
 
 args <- commandArgs(trailingOnly = TRUE)
 
-mode  <- "dry-run"   # default
-since <- NULL        # NULL = 7 days back
-repo  <- NULL        # NULL = all repos
+mode             <- "dry-run"  # default
+since            <- NULL       # NULL = 7 days back
+repo             <- NULL       # NULL = all repos
+include_fixtures <- FALSE      # TRUE = bypass canonical-project guard (#536)
 
 i <- 1L
 while (i <= length(args)) {
   switch(args[[i]],
-    "--dry-run" = { mode <- "dry-run"; i <- i + 1L },
-    "--apply"   = { mode <- "apply";   i <- i + 1L },
+    "--dry-run"          = { mode <- "dry-run"; i <- i + 1L },
+    "--apply"            = { mode <- "apply";   i <- i + 1L },
+    "--include-fixtures" = { include_fixtures <- TRUE; i <- i + 1L },
     "--since"   = {
       if (i + 1L > length(args)) stop("--since requires a YYYY-MM-DD argument")
       since <- tryCatch(as.Date(args[[i + 1L]]),
@@ -65,6 +67,11 @@ while (i <= length(args)) {
       stop(paste("unknown argument:", args[[i]]))
     }
   )
+}
+
+# Env-var opt-out (for launchd jobs / CI that can't pass CLI flags)
+if (identical(Sys.getenv("CANONICAL_PROJECTS_INCLUDE_FIXTURES"), "1")) {
+  include_fixtures <- TRUE
 }
 
 # Default since: 7 days back
@@ -229,6 +236,50 @@ jobs_raw <- tryCatch(
     data.frame()
   }
 )
+
+# ── Canonical-project guard (#536) ───────────────────────────────────────────
+# Filter jobs_raw to canonical repos only (unless --include-fixtures / env var
+# CANONICAL_PROJECTS_INCLUDE_FIXTURES=1 is set).  This prevents self-test
+# fixture dirs like /tmp/roborev_pmhook_test_XXXXXX from being written to
+# roborev_review_lifecycle in unified.duckdb.
+if (!include_fixtures && nrow(jobs_raw) > 0L && "repo" %in% names(jobs_raw)) {
+  canon_slugs <- tryCatch(
+    {
+      duck_read <- DBI::dbConnect(duckdb::duckdb(), UNIFIED_DB, read_only = TRUE)
+      on.exit(tryCatch(DBI::dbDisconnect(duck_read, shutdown = TRUE),
+                       error = function(e) NULL), add = TRUE)
+      DBI::dbGetQuery(duck_read, "
+        SELECT slug FROM canonical_projects WHERE is_active = TRUE
+        UNION ALL
+        SELECT alias FROM canonical_project_aliases
+      ")$slug
+    },
+    error = function(e) {
+      log_msg("WARN: canonical_check failed (", conditionMessage(e),
+              ") — skipping guard, all repos pass")
+      NULL  # NULL signals "guard unavailable, let everything through"
+    }
+  )
+  if (!is.null(canon_slugs) && length(canon_slugs) > 0L) {
+    non_canon <- unique(jobs_raw$repo[!jobs_raw$repo %in% canon_slugs])
+    if (length(non_canon) > 0L) {
+      skip_log <- file.path(Sys.getenv("HOME"), ".claude", "logs",
+                             "canonical_producer_skip.log")
+      ts <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+      for (slug in non_canon) {
+        tryCatch(
+          cat(sprintf("%s SKIP slug=%s producer=roborev_metrics_etl.R\n", ts, slug),
+              file = skip_log, append = TRUE),
+          error = function(e) NULL
+        )
+      }
+      log_msg("canonical guard: skipped ", length(non_canon),
+              " non-canonical repo(s): ", paste(non_canon, collapse = ", "))
+      jobs_raw <- jobs_raw[jobs_raw$repo %in% canon_slugs, , drop = FALSE]
+    }
+  }
+}
+# ─────────────────────────────────────────────────────────────────────────────
 
 sql_reviews <- sprintf("
   SELECT


### PR DESCRIPTION
## Summary

Implements producer-side skip-and-warn for non-canonical repos (issue #536).

- **New bash helper** `.claude/scripts/lib/canonical_check.sh`: `is_canonical_project SLUG` + `log_canonical_skip SLUG PRODUCER` with process-local `:delimited:` cache (lazy-loaded from `unified.duckdb`).
- **New R helper** `.claude/scripts/lib/canonical_check.R`: `canonical_slugs(con)`, `filter_canonical(df, con, ...)`, `log_canonical_skip(slugs, producer)` with `new.env()` process-local cache.
- **`roborev_metrics_etl.R`** wired with canonical guard: after `jobs_raw` is fetched, opens a read-only DuckDB connection, queries `canonical_projects` + `canonical_project_aliases`, filters non-canonical repos out, and logs each skipped slug to `~/.claude/logs/canonical_producer_skip.log`.

### Noise addressed

`roborev_pmhook_test_*` entries account for 91/175 distinct noise slugs (>50%). These originate from the self-test in `roborev_install_post_merge_hook.sh:89` which creates `/tmp/roborev_pmhook_test_XXXXXX` temp dirs. The guard prevents these from reaching `roborev_review_lifecycle`.

### Opt-out

Pass `--include-fixtures` to `roborev_metrics_etl.R` or set `CANONICAL_PROJECTS_INCLUDE_FIXTURES=1` to bypass the guard (useful for self-test harnesses and CI fixture runs).

### Skip log

Every skipped slug is appended to `~/.claude/logs/canonical_producer_skip.log` in the format:
```
2026-06-06T16:30:05Z SKIP slug=roborev_pmhook_test_abc123 producer=roborev_metrics_etl.R
```

## Test plan

- [x] bash smoke: `is_canonical_project "llm"` → 0 (canonical)
- [x] bash smoke: `is_canonical_project "roborev_pmhook_test_abc"` → 1 (non-canonical, skipped)
- [x] bash smoke: `CANONICAL_PROJECTS_INCLUDE_FIXTURES=1` → always canonical (opt-out works)
- [x] bash smoke: `log_canonical_skip` appends correct timestamped line
- [x] R smoke: `canonical_slugs(con)` returns 19 slugs with "llm" included
- [x] R smoke: `filter_canonical()` with fixture entry → 2/3 rows kept, fixture dropped, skip logged
- [ ] Run `roborev_metrics_etl.R --dry-run` with real `unified.duckdb` and confirm `roborev_pmhook_test_*` entries no longer appear in lifecycle output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
