### PR TITLE
feat(canonical/#537): apply canonical filter to weekly rollup remaining consumers

### DIFF
--- a/.claude/scripts/roborev_weekly_rollup.R
+++ b/.claude/scripts/roborev_weekly_rollup.R
@@ -31,6 +31,23 @@ suppressPackageStartupMessages({
   library(DBI)
 })
 
+# ── Canonical-projects filter (#537) ──────────────────────────────────────────
+# Source helper from lib/canonical_check.R (provides filter_canonical, canonical_slugs).
+# Set INCLUDE_NON_CANONICAL=1 to bypass (e.g. for fixture/test repo debugging).
+
+.scripts_dir_rollup <- tryCatch(
+  dirname(normalizePath(sys.frame(0L)$ofile, mustWork = FALSE)),
+  error = function(e) {
+    args <- commandArgs(trailingOnly = FALSE)
+    idx  <- grep("^--file=", args)
+    if (length(idx)) dirname(normalizePath(sub("^--file=", "", args[idx]), mustWork = FALSE))
+    else dirname(normalizePath(file.path(Sys.getenv("HOME"), "docs_gh", "llm",
+                                         ".claude", "scripts", "roborev_weekly_rollup.R"),
+                               mustWork = FALSE))
+  }
+)
+source(file.path(.scripts_dir_rollup, "lib", "canonical_check.R"))
+
 # ── Paths ─────────────────────────────────────────────────────────────────────
 
 ROBOREV_DAILY_BACKLOG_DIR <- Sys.getenv(
@@ -329,6 +346,66 @@ if (!has_rsqlite) {
   )
 } else {
   db_data <- query_reviews_db(REVIEWS_DB, week_start_str, week_end_str)
+}
+
+# ── 2b. Apply canonical-projects filter to per_project and stuck_findings ────
+# Both data frames come from reviews.db (SQLite); canonical_projects lives in
+# unified.duckdb.  We cannot JOIN across DBs, so we fetch slugs from duckdb
+# first and filter in R.
+#
+# Opt-out: INCLUDE_NON_CANONICAL=1 skips filtering (useful for debugging).
+# CANONICAL_PROJECTS_INCLUDE_FIXTURES=1 is also honoured (set inside filter_canonical).
+
+if (!identical(Sys.getenv("INCLUDE_NON_CANONICAL"), "1") &&
+    requireNamespace("duckdb", quietly = TRUE) &&
+    file.exists(UNIFIED_DUCKDB)) {
+
+  duck_con_filter <- tryCatch(
+    DBI::dbConnect(duckdb::duckdb(), UNIFIED_DUCKDB, read_only = TRUE),
+    error = function(e) {
+      message("roborev_weekly_rollup: cannot open unified.duckdb for canonical filter — ",
+              conditionMessage(e))
+      NULL
+    }
+  )
+
+  if (!is.null(duck_con_filter)) {
+    on.exit(DBI::dbDisconnect(duck_con_filter, shutdown = FALSE), add = TRUE)
+
+    # Filter per_project (has repo_name, not repo — rename before/after)
+    pp <- db_data$per_project
+    n_pp_before <- nrow(pp)
+    if (n_pp_before > 0L) {
+      names(pp)[names(pp) == "repo_name"] <- "repo"
+      pp <- filter_canonical(pp, duck_con_filter,
+                             producer = "roborev_weekly_rollup/per_project")
+      names(pp)[names(pp) == "repo"] <- "repo_name"
+    }
+    n_pp_after <- nrow(pp)
+    if (n_pp_before != n_pp_after) {
+      message(sprintf(
+        "roborev_weekly_rollup: per_project: %d → %d rows after canonical filter",
+        n_pp_before, n_pp_after
+      ))
+    }
+    db_data$per_project <- pp
+
+    # Filter stuck_findings (already has repo column)
+    sf <- db_data$stuck_findings
+    n_sf_before <- nrow(sf)
+    sf <- filter_canonical(sf, duck_con_filter,
+                           producer = "roborev_weekly_rollup/stuck_findings")
+    n_sf_after <- nrow(sf)
+    if (n_sf_before != n_sf_after) {
+      message(sprintf(
+        "roborev_weekly_rollup: stuck_findings: %d → %d rows after canonical filter",
+        n_sf_before, n_sf_after
+      ))
+    }
+    db_data$stuck_findings <- sf
+  }
+} else if (identical(Sys.getenv("INCLUDE_NON_CANONICAL"), "1")) {
+  message("roborev_weekly_rollup: INCLUDE_NON_CANONICAL=1 — canonical filter bypassed")
 }
 
 # ── 3. Query unified.duckdb for close_reason distribution ────────────────────


### PR DESCRIPTION
## Summary

Closes #537. Completes the #528 sub-issue chain for the canonical-projects filter.

### Files modified

| File | Change | Lines |
|---|---|---|
| `.claude/scripts/roborev_weekly_rollup.R` | Add `source(lib/canonical_check.R)` at top; add 2b filter block after `query_reviews_db()` | +77 |

### Consumers audited — no change needed

| Script | Why no filter needed |
|---|---|
| `send_roborev_weekly_rollup_email.R` | Pure renderer — calls `roborev_weekly_rollup.R` via `system2()`, no project/repo aggregation of its own |
| `send_kb_digest_email.R` | Four signals: by commit, by wiki file, by skill/rule name — none has a project/repo dimension |
| `vignettes/articles/roborev-architecture.qmd` | Architecture Mermaid diagram only — references table names as text, not a data consumer |

### Technical rationale

**Cross-DB constraint**: `per_proj_sql` and `stuck_sql` query `reviews.db` (SQLite). `canonical_projects` lives in `unified.duckdb`. A direct SQL JOIN across DBs is impossible. Solution: open a fresh read-only duckdb connection after `query_reviews_db()` returns, call `filter_canonical()` in R, then disconnect.

**Column rename for `per_project`**: `per_proj_sql` returns `repo_name`, not `repo`. `filter_canonical()` requires `repo`. We rename `repo_name → repo` before filtering, then rename back.

**`stuck_findings`**: already returns `repo` — passed directly to `filter_canonical()`.

### Before / after (estimated)

| Consumer | Distinct repos before filter | After filter (canonical only) |
|---|---|---|
| `per_project` | All repos with activity in reviews.db | Canonical slugs + aliases only |
| `stuck_findings` | All repos with stuck findings | Canonical slugs + aliases only |

### Escape hatch

`INCLUDE_NON_CANONICAL=1` bypasses the filter (matching the #534 daily-email pattern). `CANONICAL_PROJECTS_INCLUDE_FIXTURES=1` is also honoured inside `filter_canonical()`.

### Sub-issue chain

- #533 — canonical filter foundation (DB schema + `canonical_check.R`)
- #534 — daily roborev email consumer
- #535 — audit pass
- #536 — producer helper (`canonical_check.R` finalised)
- **#537 — this PR** — remaining consumers (weekly rollup)

Closes the #528 umbrella sub-issue chain — #528 umbrella ready to close.

## Test plan

- [ ] `INCLUDE_NON_CANONICAL=1 Rscript .claude/scripts/roborev_weekly_rollup.R` — verify "bypassed" message and rollup generates normally
- [ ] `Rscript .claude/scripts/roborev_weekly_rollup.R` — verify filter log entries appear in `~/.claude/logs/canonical_producer_skip.log` for any non-canonical repos
- [ ] Check `per_project` table in weekly digest contains only canonical slugs
- [ ] Check `stuck_findings` section contains only canonical repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)
