### PR TITLE
feat: trim CLAUDE.md auto-load + add worktree-parent guards

### DIFF
--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -131,6 +131,46 @@ phase_scope() {
   fi
 }
 
+# ── Phase 1e: Worktree-Parent CWD Detection (advisory) ───────────────
+# Detects when cwd is under ~/worktrees/<project>/ but is NOT itself a git
+# worktree (only contains worktree subdirs). Lists active worktrees so the
+# user can cd into one, or back to the canonical main checkout.
+# See rule: worktree-location
+phase_worktree_parent() {
+  local cwd
+  cwd=$(pwd 2>/dev/null) || return 0
+  case "$cwd" in
+    "$HOME/worktrees"/*) : ;;
+    *) return 0 ;;
+  esac
+  # If we're in an actual git repo / worktree, Phase 7 handles it.
+  if git rev-parse --git-dir >/dev/null 2>&1; then
+    return 0
+  fi
+  # Find candidate worktrees 1-2 levels under cwd (.git can be a dir or file).
+  local found_any=0
+  local candidates=""
+  while IFS= read -r d; do
+    [ -e "$d/.git" ] || continue
+    candidates="${candidates}    - ${d#$cwd/}\n"
+    found_any=1
+  done < <(find "$cwd" -mindepth 1 -maxdepth 2 -type d 2>/dev/null)
+  if [ "$found_any" -eq 0 ]; then
+    echo "WORKTREE-PARENT: cwd is under ~/worktrees/ but no active worktrees found here."
+    echo "  Try: cd ~/docs_gh/<project>/  (canonical main checkout)"
+    return 0
+  fi
+  echo "WORKTREE-PARENT: cwd is a worktree parent dir, not a worktree itself."
+  echo "  Active worktrees here:"
+  printf "$candidates"
+  local proj
+  proj=$(basename "$cwd")
+  if [ -d "$HOME/docs_gh/$proj" ]; then
+    echo "  Either: cd ~/worktrees/$proj/<one above>"
+    echo "      or: cd ~/docs_gh/$proj  (canonical main checkout)"
+  fi
+}
+
 # ── Phase 2: Mapping Validation ───────────────────────────────────────
 phase_mappings() {
   local has_mismatch=0
@@ -748,6 +788,9 @@ fi
 # Phase 1d: Cross-project scope (llm#190)
 scope_output=$(phase_scope 2>/dev/null)
 echo "$scope_output"
+
+# Phase 1e: Worktree-parent cwd detection (advisory)
+phase_worktree_parent 2>/dev/null || true
 
 # Phase 2: Mappings (capture warnings)
 map_output=$(phase_mappings 2>/dev/null)

--- a/.claude/rules/session-init-phases.md
+++ b/.claude/rules/session-init-phases.md
@@ -13,6 +13,7 @@ Update this table in the same commit.
 | 1b | Permission Mode | Workspace kind vs settings.json defaultMode | One line: `Permission Mode: ok/WARN` |
 | 1c | Project Environment Class | Reads `Environment:` from `.claude/CLAUDE.md` | One line: `Environment: <val>` |
 | 1d | Cross-Project Scope | Reads cross-project authority from `.claude/CLAUDE.md` | One line: `project-scope: …` |
+| 1e | Worktree-Parent CWD | Detects cwd under `~/worktrees/<project>/` that is NOT itself a git worktree; lists active worktree subdirs and offers `cd` targets (advisory). See `worktree-location` rule. | Silent when cwd is fine; `WORKTREE-PARENT: …` block when triggered |
 | 2 | Mapping Validation | Skills/Rules/Commands/Hooks/Memory consistency | Summary line + warnings |
 | 3 | Size Audit | Line counts for CLAUDE.md, MEMORY.md, dir summaries | Per-file lines + WARN/FAIL |
 | 4 | Skill Token Audit | Skills dir line counts vs 500-line limit | Summary + per-skill WARN |

--- a/.claude/rules/worktree-location.md
+++ b/.claude/rules/worktree-location.md
@@ -82,6 +82,32 @@ git -C ~/docs_gh/llm worktree remove ~/worktrees/llm/feat/fix-foo
 git -C ~/docs_gh/llm worktree prune
 ```
 
+## Never start a session in the worktree-parent dir
+
+`~/worktrees/<project>/` (and `~/worktrees/<project>/feat/`, `.../fix/`, etc.)
+are parent directories, not checkouts. They contain no `.git`, no source code —
+only the actual worktrees nested beneath. Starting a Claude session there loads
+the full project context (via `additionalDirectories` in `settings.json`) plus
+all global rules, but cwd is functionally empty — every relative path resolves
+to nothing useful.
+
+Valid session-start cwds:
+
+- `~/docs_gh/<project>/` — canonical main checkout (default for everyday work)
+- `~/worktrees/<project>/<branch>/` — a specific worktree (only when deliberately
+  working on that branch in isolation)
+
+Two layers enforce this:
+
+1. **`cc.sh` auto-redirect (primary).** If launched anywhere under
+   `~/worktrees/<project>/` that is not a real worktree, the wrapper `cd`s to
+   `~/docs_gh/<project>/` and prints a one-line note before exec'ing `claude`.
+   Set `CC_NO_REDIRECT=1` to skip (rarely needed).
+2. **`session_init.sh` Phase 1e (backstop).** If a session somehow starts in a
+   worktree-parent (e.g. `claude` invoked directly, not via `cc.sh`), Phase 1e
+   prints a `WORKTREE-PARENT:` block listing the active worktrees and the two
+   valid `cd` targets. Advisory — does not block.
+
 ## Agent Dispatch
 
 When spawning an agent with `isolation: "worktree"`, the harness creates its

--- a/.claude/scripts/cc.sh
+++ b/.claude/scripts/cc.sh
@@ -538,6 +538,36 @@ for arg in "$@"; do
 done
 
 # ---------------------------------------------------------------------------
+# Worktree-parent redirect
+# ---------------------------------------------------------------------------
+# If launched from anywhere under ~/worktrees/<proj>/ that is NOT itself a
+# git worktree (i.e. ~/worktrees/llm, ~/worktrees/llm/feat, etc.), redirect
+# to ~/docs_gh/<proj>/ (canonical main checkout). The parent dirs contain
+# no source code and starting there loads project context with no useful
+# cwd, wasting tokens. Set CC_NO_REDIRECT=1 to skip.
+if [ "${CC_NO_REDIRECT:-0}" != "1" ]; then
+  case "$PWD" in
+    "$HOME/worktrees"/*)
+      if ! git rev-parse --git-dir >/dev/null 2>&1; then
+        _wp_rel="${PWD#$HOME/worktrees/}"
+        _wp_proj="${_wp_rel%%/*}"
+        _wp_target="$HOME/docs_gh/$_wp_proj"
+        if [ -d "$_wp_target/.git" ]; then
+          echo "cc: cwd was $PWD (under ~/worktrees/ but not a worktree)"
+          echo "cc: redirecting to $_wp_target  (set CC_NO_REDIRECT=1 to skip)"
+          cd "$_wp_target"
+        else
+          echo "cc: cwd is $PWD but $_wp_target does not exist."
+          echo "cc: cd into the canonical main checkout or a real worktree, then re-run."
+          exit 2
+        fi
+        unset _wp_rel _wp_proj _wp_target
+      fi
+      ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
 # Initial project-name + colour resolution (from current directory)
 # ---------------------------------------------------------------------------
 resolve_project_name_and_color "$PWD"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,15 @@ Single trailing `\| head -N` / `\| tail -N` / `\| wc -l` / `\| sort -u` / `\| un
 **Knowledge Base (raw/wiki/outputs):** Use `knowledge-base-wiki` skill. Central hub at `~/docs_gh/llm/knowledge/` (LOCAL git only — NEVER push to GitHub, `PRIVATE` marker + pre-push hook block). raw/ is append-only (enforced by `file_protection.sh`), wiki/ requires `## Sources` section, AI-inferred claims tagged `> ⚠ AI-inferred:`, cross-wiki links use `[[topic]]` syntax. T1 health check on every Edit/Write via `wiki_health_onwrite.sh`. Run `/wiki-health` after batch updates. Use `wiki-curator` agent to compile, `critic` (wiki validation mode) for adversarial review.
 
 **Mandatory skills:** `adversarial-qa`, `quality-gates`, `r-package-workflow`, `test-driven-development`, `nix-rix-r-environment`, `llm-package-context`, `readme-qmd-standard`, `subagent-delegation`, `spec-bundled-skills`, `knowledge-base-wiki`.
-**Mandatory rules:** `systematic-debugging`, `verification-before-completion`, `btw-timeouts`, `orchestrator-protocol`, `provenance-mandatory`, `raw-folder-readonly`, `confidence-markers`, `wiki-storage-policy`, `git-no-compound-cd`, `look-ahead-bias-prevention`, `nix-agent-shell-protocol`, `worktree-location`, `dark-mode-completeness`, `narrative-evidence-block`, `narrative-colour-persistence`, `mermaid-click-anchors`, `mermaid-dashboard-pattern`, `roborev-exclude-patterns`, `cross-cutting-rename`, `data-glossary-and-entity-resolution`, `unified-observability-schema`, `agent-identity-and-task-scopes`, `human-in-the-loop-decision-points`, `dashboard-table-styling`, `uniform-typography`, `branch-harvest-on-fork`, `dashboard-filter-placement`, `survival-reporting`, `vignette-build-info-block`, `pr-shipping-discipline`.
+**Mandatory rules** (auto-loaded — safety-critical, fire on every session): `verification-before-completion`, `systematic-debugging`, `btw-timeouts`, `git-no-compound-cd`, `nix-agent-shell-protocol`, `worktree-location`, `agent-identity-and-task-scopes`, `human-in-the-loop-decision-points`.
+
+**Context-load rules** (read when the task matches — NOT auto-loaded; load via Read tool when relevant):
+- Orchestration / provenance: `orchestrator-protocol`, `provenance-mandatory`, `look-ahead-bias-prevention`, `pr-shipping-discipline`, `branch-harvest-on-fork`
+- Knowledge base: `raw-folder-readonly`, `confidence-markers`, `wiki-storage-policy`
+- Quarto / vignettes: `dark-mode-completeness`, `narrative-evidence-block`, `narrative-colour-persistence`, `vignette-build-info-block`, `uniform-typography`
+- Dashboards / viz: `dashboard-table-styling`, `dashboard-filter-placement`, `mermaid-click-anchors`, `mermaid-dashboard-pattern`
+- Data / analysis: `cross-cutting-rename`, `data-glossary-and-entity-resolution`, `unified-observability-schema`, `survival-reporting`
+- Tooling: `roborev-exclude-patterns`
 
 **Dark-mode contrast (every Quarto project):** Single global script at `~/docs_gh/llm/.claude/scripts/check_dark_contrast.sh` (public mirror: `https://raw.githubusercontent.com/JohnGavin/llm/main/.claude/scripts/check_dark_contrast.sh`). NEVER copy into a project. EVERY `_quarto.yml` MUST add this line under `project: post-render:` — `- /Users/johngavin/docs_gh/llm/.claude/scripts/quarto_post_render_contrast.sh`. Render fails on any uncovered light inline background. See `dark-mode-completeness` rule.
 


### PR DESCRIPTION
## Summary

Two coherent changes that together prevent a context-limit failure mode hit earlier this session: `implement #495` failing after a single shell command following `/clear`. Root cause was the auto-loaded Mandatory rules list (30 files, ~60–80k tokens) leaving no headroom for actual work.

## Change 1 — CLAUDE.md auto-load trim (`AGENTS.md`)

- **Mandatory rules: 30 → 8.** Kept only the safety-critical rules that genuinely fire on every session: `verification-before-completion`, `systematic-debugging`, `btw-timeouts`, `git-no-compound-cd`, `nix-agent-shell-protocol`, `worktree-location`, `agent-identity-and-task-scopes`, `human-in-the-loop-decision-points`.
- **Context-load section (NEW):** the other 22 rules grouped by topic (Orchestration / provenance, Knowledge base, Quarto / vignettes, Dashboards / viz, Data / analysis, Tooling). Still discoverable, but not auto-loaded — read via Read tool when relevant.

## Change 2 — Worktree-parent session guards

Three files implement the layered defence:

- **`cc.sh`** — wrapper now detects cwd under `~/worktrees/<proj>/` that is NOT itself a git worktree and auto-`cd`s to `~/docs_gh/<proj>/` before launching `claude`. Set `CC_NO_REDIRECT=1` to skip.
- **`.claude/hooks/session_init.sh`** — new Phase 1e is the backstop: if `claude` is launched directly (not via `cc.sh`), detects worktree-parent cwd, lists active worktrees, offers both valid cd targets.
- **`.claude/rules/worktree-location.md`** — new "Never start a session in the worktree-parent dir" section documenting both layers.
- **`.claude/rules/session-init-phases.md`** — Phase 1e row added to inventory.

## Verified behaviour

| Cwd | Action |
|---|---|
| `~/worktrees/llm` | `cc.sh` redirect → `~/docs_gh/llm` |
| `~/worktrees/llm/feat` | `cc.sh` redirect → `~/docs_gh/llm` |
| `~/worktrees/llm/feat/495-transcript-etl` | leave alone (real worktree) |
| `~/docs_gh/llm` | leave alone (canonical checkout) |

Session-init Phase 1e tested separately by sourcing and calling the function from `~/worktrees/llm`; output correctly enumerated all 3 active worktrees and offered both `cd` targets.

## Test plan

- [ ] Start a new `claude` session from `~/docs_gh/llm` — should behave exactly as before (no warning, no redirect)
- [ ] Start a session from `~/worktrees/llm` via `cc` alias — should print `cc: redirecting to ~/docs_gh/llm` and land in the main checkout
- [ ] Run `claude` directly from `~/worktrees/llm` (bypassing `cc.sh`) — Phase 1e advisory block should fire
- [ ] Verify session-init output shows shorter mandatory rule list (8 not 30)
- [ ] Trigger any rule from the Context-load list (e.g. `dashboard-table-styling`) — confirm it's still accessible via Read

## Interaction with #556

PR #556 (housekeeping framework, currently OPEN) modifies the SAME `AGENTS.md` Mandatory rules line. That PR appends `housekeeping-framework` to the OLD 30-rule list. After this PR merges, #556 will need to rebase and place `housekeeping-framework` in the Context-load section instead (where it belongs — it's task-pattern doc, not safety-critical). A follow-up message to the fixer has been queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
