### PR TITLE
fix(#559): wrapper script for 06:30 overnight digest + blastula API fix

### DIFF
--- a/.claude/launchd/com.claude.overnight-self-review-email.plist
+++ b/.claude/launchd/com.claude.overnight-self-review-email.plist
@@ -15,14 +15,20 @@
        rm ~/Library/LaunchAgents/com.claude.overnight-self-review-email.plist
 
      Manual dry-run (no SMTP, prints HTML to log):
-       EMAIL_DRY_RUN=1 Rscript ~/docs_gh/llm/.claude/scripts/send_overnight_self_review_email.R
+       EMAIL_DRY_RUN=1 bash ~/docs_gh/llm/bin/overnight_self_review_email_cron.sh
 
-     Credentials (set in ~/.claude/env/overnight_email.env or ~/.Renviron):
+     Manual live run (sends email):
+       bash ~/docs_gh/llm/bin/overnight_self_review_email_cron.sh
+
+     Credentials (set in ~/.claude/env/overnight_self_review.env):
        GMAIL_USERNAME=you@gmail.com
        GMAIL_APP_PASSWORD=<16-char app password>
        REPORT_RECIPIENT=you@gmail.com
 
-     Tracked in llm#491.
+     The wrapper is required because launchd does NOT inherit ~/.zshenv.
+     The wrapper sources the env file before invoking nix-shell + Rscript.
+
+     Tracked in llm#491, llm#559.
 -->
 <plist version="1.0">
 <dict>
@@ -31,8 +37,8 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/nix/var/nix/profiles/default/bin/Rscript</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/send_overnight_self_review_email.R</string>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/overnight_self_review_email_cron.sh</string>
     </array>
 
     <!-- Daily at 06:30 local time (after self-review-stage1 at 02:30) -->

--- a/.claude/scripts/send_overnight_self_review_email.R
+++ b/.claude/scripts/send_overnight_self_review_email.R
@@ -593,8 +593,10 @@ if (dry_run) {
 }
 
 # ── Send via blastula ──────────────────────────────────────────────────────────
+# Modern blastula (>= 0.3.x) does not export `html()`; compose_email() accepts
+# `htmltools::HTML()` objects as body (see llm#559 — Rapsody upgraded blastula's API).
 email_obj <- blastula::compose_email(
-  body = blastula::html(email_body)
+  body = htmltools::HTML(email_body)
 )
 
 smtp_creds <- blastula::creds_envvar(

--- a/bin/overnight_self_review_email_cron.sh
+++ b/bin/overnight_self_review_email_cron.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# overnight_self_review_email_cron.sh — Wrapper for 06:30 overnight digest email.
+#
+# Same pattern as kb_digest_daily_cron.sh: launchd cannot inherit ~/.zshenv,
+# so SMTP creds (GMAIL_USERNAME / GMAIL_APP_PASSWORD / REPORT_RECIPIENT) must be
+# sourced from ~/.claude/env/overnight_self_review.env before invoking Rscript.
+#
+# Env vars sourced from ~/.claude/env/overnight_self_review.env:
+#   GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT
+#
+# All R execution wrapped in nix-shell per nix-agent-shell-protocol rule.
+# Auto-pulls main per cron-auto-pull-discipline rule.
+#
+# Manual run (dry — no email send):
+#   EMAIL_DRY_RUN=1 bash bin/overnight_self_review_email_cron.sh
+#
+# Manual run (live):
+#   bash bin/overnight_self_review_email_cron.sh
+#
+# Log: ~/.claude/logs/overnight_self_review_email_launchd.log
+#
+# Tracked in llm#559.
+
+set -uo pipefail
+
+# ── PATH (launchd runs with a bare PATH; must resolve nix-shell, Rscript) ─────
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# ── Recursion guard ───────────────────────────────────────────────────────────
+: "${OVERNIGHT_DIGEST_CRON_DEPTH:=0}"
+if (( OVERNIGHT_DIGEST_CRON_DEPTH > 0 )); then
+  echo "[overnight_self_review_email_cron] ERROR: recursion detected (depth=${OVERNIGHT_DIGEST_CRON_DEPTH}). Abort." >&2
+  exit 1
+fi
+export OVERNIGHT_DIGEST_CRON_DEPTH=$(( OVERNIGHT_DIGEST_CRON_DEPTH + 1 ))
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LLM_NIX="${REPO_ROOT}/default.nix"
+LOG_FILE="${HOME}/.claude/logs/overnight_self_review_email_launchd.log"
+ENV_FILE="${HOME}/.claude/env/overnight_self_review.env"
+LOCK_FILE="/tmp/overnight_self_review_email_cron.lock"
+
+# Dry-run flag (passes through to the R script)
+EMAIL_DRY_RUN="${EMAIL_DRY_RUN:-0}"
+export EMAIL_DRY_RUN
+
+# Explicit DB path — the R script's %||% operator treats empty string as
+# truthy, so Sys.getenv("UNIFIED_DB_PATH") = "" never falls through to the
+# default. Export the canonical path here so nix-shell sees it.
+export UNIFIED_DB_PATH="${UNIFIED_DB_PATH:-${HOME}/.claude/logs/unified.duckdb}"
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+mkdir -p "$(dirname "${LOG_FILE}")"
+
+log() {
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  printf '%s: %s\n' "${ts}" "$1" | tee -a "${LOG_FILE}"
+}
+
+log "=== overnight_self_review_email_cron.sh starting (EMAIL_DRY_RUN=${EMAIL_DRY_RUN}) ==="
+
+# ── Lock ──────────────────────────────────────────────────────────────────────
+if [ -f "${LOCK_FILE}" ]; then
+  existing_pid="$(cat "${LOCK_FILE}" 2>/dev/null || true)"
+  if [ -n "${existing_pid}" ] && kill -0 "${existing_pid}" 2>/dev/null; then
+    log "SKIP: another instance running (PID ${existing_pid})"
+    exit 0
+  fi
+fi
+printf '%d' "$$" > "${LOCK_FILE}"
+trap 'rm -f "${LOCK_FILE}"' EXIT
+
+# ── Deploy: pull latest main before running (cron-auto-pull-discipline) ───────
+if [ -z "${SKIP_CRON_PULL:-}" ]; then
+    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
+    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
+        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+    else
+        log "deploy WARN: ff-only failed — running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+    fi
+fi
+log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
+
+# ── Load credentials from env file ────────────────────────────────────────────
+if [ -f "${ENV_FILE}" ]; then
+  log "Loading env from ${ENV_FILE}"
+  set -a
+  while IFS='=' read -r key val; do
+    [[ "${key}" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${key}" ]] && continue
+    val="${val#\"}"; val="${val%\"}"
+    val="${val#\'}"; val="${val%\'}"
+    export "${key}=${val}"
+  done < "${ENV_FILE}"
+  set +a
+else
+  log "INFO: ${ENV_FILE} not found — relying on existing environment"
+  log "  Create it with: GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT"
+fi
+
+# ── Verify nix shell ──────────────────────────────────────────────────────────
+if [ ! -f "${LLM_NIX}" ]; then
+  log "ERROR: nix file not found at ${LLM_NIX}"
+  exit 1
+fi
+
+if ! command -v nix-shell > /dev/null 2>&1; then
+  log "ERROR: nix-shell not on PATH (${PATH})"
+  exit 1
+fi
+
+# ── Run digest ────────────────────────────────────────────────────────────────
+log "Running send_overnight_self_review_email.R via nix-shell..."
+
+R_SCRIPT="${REPO_ROOT}/.claude/scripts/send_overnight_self_review_email.R"
+if [ ! -f "${R_SCRIPT}" ]; then
+  log "ERROR: R script not found at ${R_SCRIPT}"
+  exit 1
+fi
+
+set +e
+nix-shell "${LLM_NIX}" --run "Rscript ${R_SCRIPT}" >> "${LOG_FILE}" 2>&1
+rc=$?
+set -e
+
+if [ $rc -eq 0 ]; then
+  log "=== overnight_self_review_email_cron.sh completed OK ==="
+else
+  log "=== overnight_self_review_email_cron.sh FAILED (exit ${rc}) ==="
+fi
+
+exit $rc


### PR DESCRIPTION
## Summary

Closes #559. The 06:30 overnight self-review digest could not send because launchd does not inherit `~/.zshenv`, so SMTP creds never reached the R process. Three coordinated changes resolve the gap end-to-end.

## Changes

### 1. `bin/overnight_self_review_email_cron.sh` (NEW)

Bash wrapper following the existing `kb_digest_daily_cron.sh` pattern:

- Sources `~/.claude/env/overnight_self_review.env` for `GMAIL_USERNAME` / `GMAIL_APP_PASSWORD` / `REPORT_RECIPIENT`
- Exports `UNIFIED_DB_PATH` explicitly (workaround for the R script's `%||%` empty-string bug — `Sys.getenv()` returns `""` not `NA`, so the operator doesn't fall through to the default path)
- Auto-pulls main per `cron-auto-pull-discipline` rule
- Recursion / fork-bomb guard via `OVERNIGHT_DIGEST_CRON_DEPTH`
- Lock file at `/tmp/overnight_self_review_email_cron.lock`
- Logs HEAD SHA + step transitions to `~/.claude/logs/overnight_self_review_email_launchd.log`

### 2. `.claude/launchd/com.claude.overnight-self-review-email.plist` (MODIFIED)

`ProgramArguments` now invokes the wrapper instead of calling Rscript directly:

```
- /nix/var/nix/profiles/default/bin/Rscript
- /Users/johngavin/docs_gh/llm/.claude/scripts/send_overnight_self_review_email.R

+ /bin/bash
+ /Users/johngavin/docs_gh/llm/bin/overnight_self_review_email_cron.sh
```

Comment block updated to reference the wrapper and the canonical env file path. `EnvironmentVariables` block retained because launchd still needs `PATH` / `HOME` / `NIX_SSL_CERT_FILE` before invoking bash.

### 3. `.claude/scripts/send_overnight_self_review_email.R` (MODIFIED)

`blastula::html()` is no longer exported in modern blastula (≥ 0.3.x). Replaced with `htmltools::HTML()`, which `compose_email()` accepts directly.

## Verification (manual run, just now)

```
2026-06-07 20:50:22: === overnight_self_review_email_cron.sh starting (EMAIL_DRY_RUN=0) ===
2026-06-07 20:50:22: deploy: ff to af1726d
2026-06-07 20:50:22: HEAD: af1726d docs(changelog): session-end 2026-06-07 — CLAUDE.md trim + housekeeping framework
2026-06-07 20:50:22: Loading env from /Users/johngavin/.claude/env/overnight_self_review.env
2026-06-07 20:50:22: Running send_overnight_self_review_email.R via nix-shell...
The email message was sent successfully.
Sent overnight self-review email to john.b.gavin@gmail.com
2026-06-07 20:50:38: === overnight_self_review_email_cron.sh completed OK ===
```

The email contains the new "Worktree footprint (24h)" section (#550 Phase C) populated from 52 events seeded by a manual `worktree_gc.sh` dry-run:

```
worktree_gc_events
─────────────────────┬───────
       action        │   n
─────────────────────┼───────
 skipped_age         │    19
 skipped_locked      │    18
 skipped_unmerged    │    12
 skipped_uncommitted │     3

housekeeping_runs
 task=worktree_gc status=ok rows_written=52
```

## Failed approaches

- **First attempt**: launched the unmodified plist (Rscript direct) → exit 1: `ERROR: DuckDB not found at` (empty path). Root cause: R script's `%||%` operator treats `""` as truthy, so `Sys.getenv("UNIFIED_DB_PATH") %||% default` never falls through. The R script bug is pre-existing; workaround is to export the var in the wrapper. The bug itself can be fixed in a follow-up if desired (one-line change to `%||%`).
- **Second attempt** (with `UNIFIED_DB_PATH` exported): exit 1: `Error: 'html' is not an exported object from 'namespace:blastula'`. Root cause: blastula API change. Fixed in this PR (htmltools::HTML).
- **Third attempt**: success.

## Test plan

- [x] Manual `launchctl kickstart` produces "completed OK" log + email delivered (verified above)
- [ ] Tomorrow's 06:30 scheduled fire delivers an email (will be visible in logs + inbox)
- [ ] `worktree_gc.sh` at 00:04 writes rows; 06:30 digest's "Worktree footprint" section shows them populated by that overnight run (not the manual seed used here)
- [ ] If desired, fix the underlying `%||%` bug separately (treat `""` as null-ish — one-line change)

## Related

- Closes #559
- Unblocks #550 end-to-end signal path
- Sibling jobs needing same fix: `stage1-findings-email` (will be retired by #551 anyway), and any other email-sending plist that runs Rscript directly without a bash wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)
