### PR TITLE
fix(%||%): treat empty string as missing in 3 email scripts (#559)

### DIFF
--- a/.claude/scripts/roborev_weekly_rollup.R
+++ b/.claude/scripts/roborev_weekly_rollup.R
@@ -327,7 +327,15 @@ query_reviews_db <- function(db_path, week_start_str, week_end_str) {
 }
 
 # Null-coalescing helper
-`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0L && !is.na(a[1L])) a else b
+# Treats NULL, length-0, NA, AND empty string as missing.
+# Empty-string handling matters because Sys.getenv() returns "" not NA.
+# See llm#559.
+`%||%` <- function(a, b) {
+  if (is.null(a) || length(a) == 0L) return(b)
+  if (is.na(a[[1L]])) return(b)
+  if (is.character(a) && !nzchar(a[[1L]])) return(b)
+  a
+}
 
 # Load RSQLite if available; fall back gracefully
 has_rsqlite <- requireNamespace("RSQLite", quietly = TRUE)

--- a/.claude/scripts/send_overnight_self_review_email.R
+++ b/.claude/scripts/send_overnight_self_review_email.R
@@ -42,7 +42,17 @@
 source(file.path(.scripts_dir, "email_styles.R"))
 
 # ── Null-coalescing operator ───────────────────────────────────────────────────
-`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0 && !is.na(a[[1]])) a else b
+# Treats NULL, length-0, NA, AND empty string as "missing" — falls through to b.
+# Empty-string handling matters because Sys.getenv() returns "" for unset vars
+# (not NA), so the prior version silently used "" as a valid value.
+# See llm#559 / PR #560 — wrapper had to export UNIFIED_DB_PATH explicitly to
+# work around this.
+`%||%` <- function(a, b) {
+  if (is.null(a) || length(a) == 0L) return(b)
+  if (is.na(a[[1L]])) return(b)
+  if (is.character(a) && !nzchar(a[[1L]])) return(b)
+  a
+}
 
 # ── Configuration ──────────────────────────────────────────────────────────────
 dry_run        <- identical(Sys.getenv("EMAIL_DRY_RUN"), "1")

--- a/.claude/scripts/send_stage1_findings_email.R
+++ b/.claude/scripts/send_stage1_findings_email.R
@@ -30,7 +30,15 @@ suppressPackageStartupMessages({
 
 # ── Shared email styles (font sizes, palette, collapsible_block helper) ───────
 
-`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0 && !is.na(a[1])) a else b
+`%||%` <- function(a, b) {
+  # Treats NULL, length-0, NA, AND empty string as missing.
+  # Empty-string handling matters because Sys.getenv() returns "" not NA.
+  # See llm#559.
+  if (is.null(a) || length(a) == 0L) return(b)
+  if (is.na(a[[1L]])) return(b)
+  if (is.character(a) && !nzchar(a[[1L]])) return(b)
+  a
+}
 
 .scripts_dir_s1 <- tryCatch(
   dirname(normalizePath(sys.frame(0L)$ofile, mustWork = FALSE)),


### PR DESCRIPTION
## Summary

Fixes the underlying `%||%` empty-string bug flagged in #559 / PR #560. Replaces a buggy definition in 3 email scripts with the same robust pattern already used in 4 sibling scripts (kb_digest, config_digest, launchd_health_email, roborev_weekly_rollup_email).

## Why this matters

`Sys.getenv("X")` returns an empty string `""` when X is unset (not `NA`). The original operator:

```r
`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0 && !is.na(a[[1]])) a else b
```

returns `""` as a "valid" value for `Sys.getenv("UNDEFINED") %||% "default"`, so the default never wins. This caused the `ERROR: DuckDB not found at` failure documented in #559 (#560 worked around by exporting `UNIFIED_DB_PATH` explicitly in the bash wrapper).

The new operator:

```r
`%||%` <- function(a, b) {
  if (is.null(a) || length(a) == 0L) return(b)
  if (is.na(a[[1L]])) return(b)
  if (is.character(a) && !nzchar(a[[1L]])) return(b)
  a
}
```

falls through to `b` when `a` is NULL, length-0, NA, OR an empty character. Numeric `0` and `FALSE` stay valid (matches rlang convention).

## Scripts fixed

| Script | Before | After |
|---|---|---|
| `send_overnight_self_review_email.R` | buggy | fixed |
| `roborev_weekly_rollup.R` | buggy | fixed |
| `send_stage1_findings_email.R` | buggy | fixed |

Scripts that already had the correct pattern (untouched):

| Script | Pattern |
|---|---|
| `send_kb_digest_email.R` | `!nzchar(as.character(a))` variant |
| `send_config_digest_email.R` | same |
| `send_launchd_health_email.R` | same |
| `send_roborev_weekly_rollup_email.R` | same |

## Test plan

- [x] Logic mirrors the 4 already-correct definitions; no new pattern introduced
- [x] Numeric 0 and FALSE preserved as valid (per assertion in commit message)
- [ ] Tomorrow's 06:30 digest fires successfully (already worked end-to-end yesterday with the workaround in #560; this PR makes the operator robust on its own)
- [ ] `UNIFIED_DB_PATH` export in the wrapper from #560 is retained as defensive belt-and-suspenders — can be removed in a separate cleanup if desired

## Follow-up candidates (not in this PR)

- `send_roborev_email.R` has `if (!is.null(a) && !is.na(a))` — no length or nzchar check. Less buggy but still fragile if `Sys.getenv()` returns `""`.
- `launchd_health_report.R` has `if (!is.null(a))` only — even more fragile.
- Could consolidate to a single shared definition in a helper file (out of scope here).

## Related

- #559 (origin)
- #560 (the wrapper PR that worked around this bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
