### PR TITLE
docs(rule): add bslib 0.11.0 toolbar patterns to dashboard-filter-placement (#558)

### DIFF
--- a/.claude/rules/dashboard-filter-placement.md
+++ b/.claude/rules/dashboard-filter-placement.md
@@ -23,7 +23,9 @@ Use it to co-locate filters with the data they govern.
 |---|---|
 | Filter applies to ONE card (chart or table) | `toolbar()` inside `card_header()` or `card_footer()` |
 | Filter applies to a single input (preset or reset) | `toolbar()` inline with the input's label |
+| Spacer to push controls to opposing ends of a toolbar | `toolbar_spacer()` between the groups |
 | Filter applies to MULTIPLE cards or the whole page | `sidebar()` or a page-top toolbar |
+| Cross-cutting filter + resizable sidebar | `sidebar(resizable = TRUE)` — per-card filters still go in card toolbars because the sidebar can shrink and occlude them |
 | Static KPI (no user input) | Compact two-column table (`dashboard-table-styling` rule) |
 | Big standalone metric | NOT `value_box()` — see AGENTS.md Shiny UI ban |
 
@@ -33,17 +35,36 @@ every card, it belongs in the sidebar.
 
 ## Toolbar API (bslib 0.11.0+)
 
-Seven functions cover all placement scenarios:
+Nine functions cover all placement scenarios:
 
 | Function | Purpose |
 |---|---|
-| `toolbar()` | Compact container; accepts `align` and fluid arrangement |
+| `toolbar()` | Compact container; accepts `align = "left"` (default) or `align = "right"` to anchor controls |
 | `toolbar_input_button()` | Action buttons inside toolbars |
 | `toolbar_input_select()` | Dropdowns inside toolbars |
 | `toolbar_divider()` | Visual separator between toolbar groups |
-| `toolbar_spacer()` | Flexible space to push groups apart |
-| `update_toolbar_input_button()` | Reactive updates (e.g. icon flip after save) |
-| `update_toolbar_input_select()` | Reactive updates for dropdowns |
+| `toolbar_spacer()` | Flexible space to push groups apart (e.g. label left, buttons right) |
+| `update_toolbar_input_button()` | Reactive updates (e.g. icon flip after save, disabled toggle) |
+| `update_toolbar_input_select()` | Reactive updates for dropdowns (choices, label, selected) |
+| `input_submit_textarea()` | Message-composer textarea with attachment / priority / clear toolbar embedded in the label |
+
+### `align` parameter
+
+`toolbar(align = "right")` anchors the entire toolbar to the trailing edge of its
+container. Use `align = "left"` (the default) for most card-header filters; use
+`align = "right"` when the controls are secondary to a title that occupies the
+left side:
+
+```r
+card_header(
+  "Monthly Revenue",
+  toolbar(
+    align = "right",
+    toolbar_input_select("rev_region", label = NULL,
+      choices = c("All regions", "EMEA", "APAC", "Americas"))
+  )
+)
+```
 
 ## Card Header with Embedded Filter
 
@@ -87,15 +108,143 @@ numericInput("threshold", label = toolbar(
 ), value = 50)
 ```
 
+## `toolbar_spacer()` — Full-Width Controls Inside a Label
+
+`toolbar_spacer()` inserts flexible space that expands to push sibling elements
+apart. Use it when you want label text on the left and action buttons flush right
+within the same toolbar:
+
+```r
+numericInput("budget", label = toolbar(
+  "Budget cap",
+  toolbar_spacer(),          # pushes the buttons to the right edge
+  toolbar_input_button("budget_reset",
+    label = bsicons::bs_icon("arrow-counterclockwise", title = "Reset to default")),
+  toolbar_input_button("budget_help",
+    label = bsicons::bs_icon("question-circle", title = "Show help"))
+), value = 10000)
+```
+
+## Message-Composer Textarea (`input_submit_textarea()`)
+
+`input_submit_textarea()` ships a textarea whose label is itself a toolbar. Use it
+for AI chat / LLM-output panels where the user attaches context, sets a priority,
+or clears the input from within the input control itself:
+
+```r
+input_submit_textarea(
+  "user_prompt",
+  label = toolbar(
+    toolbar_input_select(
+      "prompt_priority",
+      label = NULL,
+      choices = c("Normal", "High", "Critical")
+    ),
+    toolbar_spacer(),
+    toolbar_input_button(
+      "attach_file",
+      label = bsicons::bs_icon("paperclip", title = "Attach file")
+    ),
+    toolbar_input_button(
+      "clear_prompt",
+      label = bsicons::bs_icon("x-circle", title = "Clear message")
+    )
+  ),
+  placeholder = "Ask the model…",
+  submit_button = bsicons::bs_icon("send", title = "Send")
+)
+```
+
+The submit button is keyboard-accessible (Enter sends; Shift+Enter inserts a
+newline) and fires `input$user_prompt` like a standard `actionButton`.
+
+## Reactive Updates
+
+### `update_toolbar_input_button()` — Icon flip after save
+
+Use this server-side to reflect state changes without re-rendering the card.
+Common pattern: toggle a save button between "unsaved" and "saved" state:
+
+```r
+# UI
+toolbar_input_button(
+  "save_btn",
+  label = bsicons::bs_icon("floppy", title = "Save changes")
+)
+
+# Server
+observeEvent(input$save_btn, {
+  save_data()
+  update_toolbar_input_button(
+    session, "save_btn",
+    label    = bsicons::bs_icon("check-circle", title = "Saved"),
+    disabled = TRUE
+  )
+  # Re-enable after 2 seconds
+  later::later(function() {
+    update_toolbar_input_button(
+      session, "save_btn",
+      label    = bsicons::bs_icon("floppy", title = "Save changes"),
+      disabled = FALSE
+    )
+  }, delay = 2)
+})
+```
+
+### `update_toolbar_input_select()` — Dynamic choices from server
+
+Use this to narrow dropdown choices reactively (e.g. filter available regions
+based on a dataset loaded after app startup):
+
+```r
+# UI
+toolbar_input_select("rev_region", label = NULL,
+  choices = c("Loading..."), selected = "Loading...")
+
+# Server
+observe({
+  regions <- get_available_regions()  # computed reactively
+  update_toolbar_input_select(
+    session, "rev_region",
+    choices  = c("All regions", regions),
+    selected = "All regions"
+  )
+})
+```
+
+## Tooltips on Icon-Only Toolbar Buttons
+
+Icon-only buttons MUST supply a `title` to `bs_icon()`. bslib wires this to
+`aria-label` automatically. The same `title` text also renders as a browser
+tooltip on hover, giving sighted users a visible affordance:
+
+```r
+toolbar_input_button(
+  "export_csv",
+  label = bsicons::bs_icon("download", title = "Export as CSV")
+  # title= gives aria-label for screen readers AND a hover tooltip for sighted users
+)
+```
+
+Do NOT add a separate `tooltip()` wrapper around an icon-only button — the
+`title=` on `bs_icon()` already handles both the accessibility and tooltip
+requirements.
+
 ## Sidebar for Page-Wide Filters
 
 When a filter genuinely governs all cards (e.g. a date range that affects
 every chart), keep it in the sidebar. The sidebar is the right tool for
 cross-cutting controls; toolbars are for per-card controls.
 
+`sidebar(resizable = TRUE)` (bslib 0.11.0+) lets users narrow the sidebar.
+Because a narrow sidebar can occlude wide controls, keep per-card filters in
+card-header toolbars — do not move them to the sidebar just because the sidebar
+is present.
+
 ```r
 page_sidebar(
   sidebar = sidebar(
+    resizable = TRUE,
     dateRangeInput("date_range", "Date range",
       start = Sys.Date() - 90, end = Sys.Date())
   ),
@@ -110,11 +259,14 @@ page_sidebar(
 
 | Pattern | Why wrong | Fix |
 |---|---|---|
-| `selectInput()` at the top of `page_sidebar()` when it only affects one card | Global placement for a local filter | Move into that card's `card_header()` via `toolbar()` |
+| Page-level `selectInput()` for a filter that only affects one card | Global placement for a local filter; forces reader to scan back to the top | Move into that card's `card_header()` via `toolbar()` |
+| `selectInput()` at the top of `page_sidebar()` when it only affects one card | Same as above — page-sidebar context does not change the rule | Move into that card's toolbar |
 | `value_box()` for any metric | Space-wasting; AGENTS.md ban | Compact two-column `<table>` |
-| Toolbar without `bslib` version ≥ 0.11.0 in `default.R` / `DESCRIPTION` | Functions not available | Add `bslib (>= 0.11.0)` to Imports |
-| `toolbar_input_button()` icon with no `title=` | Inaccessible to screen readers | `bs_icon("x", title = "Clear filter")` |
+| Toolbar without `bslib` version >= 0.11.0 in `default.R` / `DESCRIPTION` | Functions not available | Add `bslib (>= 0.11.0)` to Imports |
+| `toolbar_input_button()` icon with no `title=` | Inaccessible to screen readers; no hover tooltip | `bs_icon("x", title = "Clear filter")` |
 | Using `toolbar()` for controls that affect multiple cards | Wrong placement level | Use `sidebar()` or page-top row |
+| Extra `tooltip()` wrapper around an icon-only toolbar button | Redundant — `bs_icon(title=)` already handles both a11y and hover | Remove the `tooltip()` wrapper |
+| Moving per-card filters into the sidebar because `resizable = TRUE` is used | Sidebar can shrink and occlude controls | Keep per-card filters in `card_header()` toolbars |
 
 ## Accessibility
 


### PR DESCRIPTION
## Summary

Updates `.claude/rules/dashboard-filter-placement.md` with six patterns from the bslib 0.11.0 toolbar release that the rule previously missed.

**Patterns added:**

1. **`input_submit_textarea()`** — message-composer textarea with attachment / priority / clear toolbar embedded in the label. Concrete example for AI chat / LLM-output UIs.
2. **Reactive updates via `update_toolbar_input_button()`** — icon flip after save, disabled toggle. Concrete `observeEvent()` worked example with a 2-second re-enable.
3. **Reactive updates via `update_toolbar_input_select()`** — dynamic choices from server. Concrete `observe()` worked example.
4. **Tooltips on icon-only toolbar buttons** — shows `bs_icon(title=)` providing both `aria-label` (screen readers) and browser hover tooltip. Forbids redundant `tooltip()` wrapper.
5. **`align = "right"` / `align = "left"`** — added to Toolbar API table with a "when to right-align" prose note and code example.
6. **`sidebar(resizable = TRUE)` interaction** — one-liner note in the sidebar section: sidebar can shrink so per-card filters must stay in `card_header()` toolbars.

**Also added:**
- Forbidden Patterns: "page-level `selectInput()` for a filter that only affects one card" anti-pattern (two rows: generic and page-sidebar-specific).
- `toolbar_spacer()` concrete worked example (label-left / buttons-right inside a `numericInput` label).
- Decision Table: `toolbar_spacer()` row + `sidebar(resizable = TRUE)` row.

**Not changed:**
- `bslib (>= 0.11.0)` version reference — confirmed correct per issue #558.

## Test plan

- [ ] Visual diff: verify all 6 patterns present in the updated rule
- [ ] No broken markdown: `grep -c '^\`\`\`' .claude/rules/dashboard-filter-placement.md` returns an even number (fenced code blocks balanced)
- [ ] No broken internal links: `Related` section references unchanged — `dashboard-table-styling`, `uniform-typography`, `accessibility`, `shiny-bslib` all still present
- [ ] Version reference unchanged: `grep "0.11.0"` shows only the original references, no new version strings introduced

Closes #558 (doc changes only; per-project adoption is tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
