### PR TITLE
fix(session_init): wrap Phase 5 Rscript calls in nix-shell (#562)

### DIFF
--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -377,10 +377,21 @@ phase_ctx_audit() {
   [ -f "DESCRIPTION" ] || { echo "No DESCRIPTION file — skipping ctx audit"; return; }
   [ -d "$ctx_cache" ] || { echo "No ctx cache dir — skipping"; return; }
 
-  # Use R to parse DESCRIPTION and check version-stamped ctx files
+  # Guard: nix-shell must be available; sessions outside Nix shell would silently
+  # time out (old R:timeout banner). Fail explicitly instead (#562).
+  if ! command -v nix-shell >/dev/null 2>&1; then
+    echo "ctx audit: WARN nix-shell missing — skipped"
+    return
+  fi
+
+  local _llm_nix="$HOME/docs_gh/llm/default.nix"
+
+  # Use R to parse DESCRIPTION and check version-stamped ctx files.
+  # R code written to a temp file to avoid quoting complexity with nix-shell --run (#562).
   # Output: one line per package as "STATUS:pkg" (OK, STALE, MISSING)
-  local audit_output
-  audit_output=$(timeout 10 Rscript -e '
+  local _audit_r
+  _audit_r=$(mktemp /tmp/ctx_audit_XXXXXX.R)
+  cat > "$_audit_r" << 'REOF'
     d <- read.dcf("DESCRIPTION", fields = c("Imports","Suggests","Depends"))
     raw <- paste(na.omit(as.character(d)), collapse = ",")
     p <- trimws(unlist(strsplit(raw, ",")))
@@ -396,13 +407,17 @@ phase_ctx_audit() {
         age <- as.numeric(difftime(Sys.time(), file.mtime(f), units = "days"))
         cat(if (age > 30) paste0("STALE:", pkg) else paste0("OK:", pkg), "\n")
       } else {
-        # Check for any version
-        any_ver <- list.files(cache, pattern = paste0("^", gsub("\\\\.", "\\\\\\\\.", pkg), "@"), full.names = TRUE)
+        any_ver <- list.files(cache, pattern = paste0("^", gsub("\\.", "\\\\.", pkg), "@"), full.names = TRUE)
         if (length(any_ver) > 0) cat(paste0("OTHER_VER:", pkg), "\n")
         else cat(paste0("MISSING:", pkg), "\n")
       }
     }
-  ' 2>/dev/null) || true
+REOF
+
+  # Foreground audit: timeout bumped 10->30s to accommodate nix-shell entry cost (#562)
+  local audit_output
+  audit_output=$(timeout 30 nix-shell "$_llm_nix" --run "Rscript '$_audit_r'" 2>/dev/null) || true
+  rm -f "$_audit_r"
   [ -z "$audit_output" ] && { echo "Could not parse DESCRIPTION"; return; }
 
   # Count statuses (avoid pipe subshell — background jobs die in subshells)
@@ -420,15 +435,19 @@ phase_ctx_audit() {
   [ "$n_missing" -gt 0 ] && echo "  Missing:$missing_list"
 
   # Auto-launch background ctx_sync (OUTSIDE pipe — survives hook exit)
+  # Wrapped in nix-shell so it works regardless of whether the session entered Nix (#562)
   if [ "$((n_missing + n_stale + n_other))" -gt 0 ] && [ -f "DESCRIPTION" ]; then
     echo "  Launching background ctx_sync..."
-    nohup timeout 600 Rscript -e 'source("~/docs_gh/llm/R/tar_plans/plan_pkgctx.R"); ctx_sync("DESCRIPTION")' \
+    nohup timeout 600 nix-shell "$_llm_nix" --run \
+      "Rscript -e 'source(\"~/docs_gh/llm/R/tar_plans/plan_pkgctx.R\"); ctx_sync(\"DESCRIPTION\")'" \
       > /tmp/ctx_sync_$$.log 2>&1 &
     echo "  Background PID $! — log at /tmp/ctx_sync_$$.log"
   fi
 
   # Auto-launch background local_ctx_sync — ingests sibling-project ctx.yaml files (#207)
-  nohup timeout 120 Rscript -e 'source("~/docs_gh/llm/R/tar_plans/plan_pkgctx.R"); local_ctx_sync(dry_run = FALSE)' \
+  # Wrapped in nix-shell so it works regardless of whether the session entered Nix (#562)
+  nohup timeout 120 nix-shell "$_llm_nix" --run \
+    "Rscript -e 'source(\"~/docs_gh/llm/R/tar_plans/plan_pkgctx.R\"); local_ctx_sync(dry_run = FALSE)'" \
     > /tmp/local_ctx_sync_$$.log 2>&1 &
 }
 
@@ -1161,11 +1180,14 @@ if echo "${burn_output:-}" | grep -qE "CRITICAL|WARN"; then
 fi
 
 # Background ctx_sync if missing packages detected
+# Wrapped in nix-shell so it works regardless of whether the session entered Nix (#562)
 if [ -f "DESCRIPTION" ]; then
   ctx_miss=$(echo "$ctx_part" | cut -d: -f2 | cut -d/ -f3)
   ctx_miss=$(as_int_or_zero "$ctx_miss")
   if [ "${ctx_miss:-0}" -gt 0 ]; then
-    nohup timeout 600 Rscript -e 'source("~/docs_gh/llm/R/tar_plans/plan_pkgctx.R"); ctx_sync("DESCRIPTION")' \
+    _llm_nix_bg="$HOME/docs_gh/llm/default.nix"
+    nohup timeout 600 nix-shell "$_llm_nix_bg" --run \
+      "Rscript -e 'source(\"~/docs_gh/llm/R/tar_plans/plan_pkgctx.R\"); ctx_sync(\"DESCRIPTION\")'" \
       > /tmp/ctx_sync_$$.log 2>&1 &
     echo "ctx_sync: $ctx_miss missing, generating in background (PID $!)"
   fi

--- a/.claude/rules/session-init-phases.md
+++ b/.claude/rules/session-init-phases.md
@@ -17,7 +17,7 @@ Update this table in the same commit.
 | 2 | Mapping Validation | Skills/Rules/Commands/Hooks/Memory consistency | Summary line + warnings |
 | 3 | Size Audit | Line counts for CLAUDE.md, MEMORY.md, dir summaries | Per-file lines + WARN/FAIL |
 | 4 | Skill Token Audit | Skills dir line counts vs 500-line limit | Summary + per-skill WARN |
-| 5 | ctx.yaml Cache Audit | Dependency ctx cache freshness (via Rscript) | `ctx:N_ok/N_other/N_miss` |
+| 5 | ctx.yaml Cache Audit | Dependency ctx cache freshness. All three Rscript calls (1 foreground + 2 background) are wrapped in `nix-shell ~/docs_gh/llm/default.nix --run` so sessions launched outside Nix still reach R (#562). Foreground timeout bumped 10→30s for nix-shell entry cost. If `nix-shell` absent: emits WARN and returns early. | `ctx:N_ok/N_other/N_miss`; `ctx audit: WARN nix-shell missing — skipped` when nix-shell absent |
 | 6 | R-universe Build Status | Checks johngavin.r-universe.dev/api/packages | `R-universe: N OK, N failed` |
 | 7 | Worktree Context | Detects worktree session, stale agent/git worktrees | Contextual output + warnings |
 | 7f | Worktree Auto-GC | Auto-removes agent worktrees where PID-dead AND lock-age >14d (current project only). Skipped if `CLAUDE_SESSION_INIT_WORKTREE_GC=0`. Logs to `~/.claude/logs/session_init_worktree_gc.log`. Never exits non-zero. | Silent when N=0; one line `Worktree GC: removed N stale (>14d, PID-dead)` when N>0 |


### PR DESCRIPTION
## Summary

Fixes #562. `session_init.sh` Phase 5 (`phase_ctx_audit`) called `Rscript` directly, but `Rscript` is only on PATH inside the Nix shell. Sessions launched outside the Nix shell silently timed out on Phase 5, accumulating 150 stale ctx files over 30 days.

**Three call sites fixed + one diagnostic added:**

### Call site 1 — Foreground audit (timeout 10→30s)

**Before:**
```bash
audit_output=$(timeout 10 Rscript -e '
  d <- read.dcf("DESCRIPTION", ...)
  ...
' 2>/dev/null) || true
```

**After:**
```bash
# Guard at top of phase_ctx_audit():
if ! command -v nix-shell >/dev/null 2>&1; then
  echo "ctx audit: WARN nix-shell missing — skipped"
  return
fi

_audit_r=$(mktemp /tmp/ctx_audit_XXXXXX.R)
cat > "$_audit_r" << 'REOF'
  d <- read.dcf("DESCRIPTION", ...)
  ...
REOF

# Timeout bumped 10→30s for nix-shell entry cost (~3s overhead)
audit_output=$(timeout 30 nix-shell "$_llm_nix" --run "Rscript '$_audit_r'" 2>/dev/null) || true
rm -f "$_audit_r"
```

The R code is written to a temp file to avoid quoting complexity with multi-line R inside `nix-shell --run`.

### Call site 2 — Background ctx_sync

**Before:**
```bash
nohup timeout 600 Rscript -e 'source("~/docs_gh/llm/R/tar_plans/plan_pkgctx.R"); ctx_sync("DESCRIPTION")' \
  > /tmp/ctx_sync_$$.log 2>&1 &
```

**After:**
```bash
nohup timeout 600 nix-shell "$_llm_nix" --run \
  "Rscript -e 'source(\"~/docs_gh/llm/R/tar_plans/plan_pkgctx.R\"); ctx_sync(\"DESCRIPTION\")'" \
  > /tmp/ctx_sync_$$.log 2>&1 &
```

### Call site 3 — Background local_ctx_sync

**Before:**
```bash
nohup timeout 120 Rscript -e 'source("~/docs_gh/llm/R/tar_plans/plan_pkgctx.R"); local_ctx_sync(dry_run = FALSE)' \
  > /tmp/local_ctx_sync_$$.log 2>&1 &
```

**After:**
```bash
nohup timeout 120 nix-shell "$_llm_nix" --run \
  "Rscript -e 'source(\"~/docs_gh/llm/R/tar_plans/plan_pkgctx.R\"); local_ctx_sync(dry_run = FALSE)'" \
  > /tmp/local_ctx_sync_$$.log 2>&1 &
```

### Call site 4 — Second background ctx_sync (~line 1168)

Same treatment as call site 2. Uses a separate `_llm_nix_bg` variable since `_llm_nix` is not in scope at that call site (it lives outside `phase_ctx_audit()`).

### Timeout bump note

The foreground audit timeout was bumped from 10s → 30s. `nix-shell` entry costs ~3s on first invocation. The old 10s limit left only 7s for R execution itself, which was tight enough to trigger timeouts even when nix-shell was available.

### Diagnostic WARN

When `nix-shell` is not on PATH (truly outside any Nix-capable environment), the phase now emits:
```
ctx audit: WARN nix-shell missing — skipped
```
instead of the previous silent `R:timeout` banner entry.

### Rule update

`session-init-phases.md` Phase 5 row updated to document the nix-shell wrap and the new WARN output behaviour.

## Test plan

- [ ] Launch `claude` WITHOUT entering Nix shell first (no `caffeinate -i default.sh`)
- [ ] Verify Phase 5 banner shows `ctx:N_ok/N_other/N_miss` (not `R:timeout`)
- [ ] Verify `/tmp/ctx_sync_<pid>.log` shows successful `Rscript` execution
- [ ] When `nix-shell` is not on PATH at all (bare macOS), verify Phase 5 shows `ctx audit: WARN nix-shell missing — skipped`
- [ ] `bash -n .claude/hooks/session_init.sh` exits 0 (syntax check passes)
- [ ] One-week observation: stale ctx file count drops from 150 toward 0

## Related

- Closes #562
- #559 — companion env-inheritance failure (same "R not reachable" family)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
