### PR TITLE
feat(housekeeping): roborev SQLite -> unified.duckdb bridge (#555 Phase A+B+C)

### DIFF
--- a/.claude/launchd/com.claude.roborev-bridge.plist
+++ b/.claude/launchd/com.claude.roborev-bridge.plist
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.claude.roborev-bridge.plist
+     Daily roborev SQLite -> unified.duckdb bridge.
+     Runs at 06:00 local time, BEFORE the 06:30 overnight digest reads unified.duckdb.
+     Reads ~/.roborev/reviews.db; writes aggregate rows to roborev_daily_summary
+     in ~/.claude/logs/unified.duckdb. Never writes to roborev's own DB.
+
+     Manual dry-run:
+       BRIDGE_DRY_RUN=1 SKIP_CRON_PULL=1 bash \
+         ~/docs_gh/llm/.claude/scripts/roborev_bridge_to_unified.sh
+
+     Install (orchestrator step after PR merge):
+       cp .claude/launchd/com.claude.roborev-bridge.plist \
+          ~/Library/LaunchAgents/com.claude.roborev-bridge.plist
+       launchctl load -w ~/Library/LaunchAgents/com.claude.roborev-bridge.plist
+
+     Verify loaded:
+       launchctl list | grep roborev-bridge
+
+     Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.claude.roborev-bridge.plist
+       rm ~/Library/LaunchAgents/com.claude.roborev-bridge.plist
+
+     Tracked in llm#555 Phase C.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.roborev-bridge</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_bridge_to_unified.sh</string>
+    </array>
+
+    <!-- Daily at 06:00 local time (30 min before 06:30 overnight digest) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>6</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <!-- Do NOT run immediately on launchctl load -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- PATH must include nix stable profile so git and duckdb resolve.
+         sqlite3 is at /usr/bin/sqlite3 on macOS (system default). -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+        <key>NIX_SSL_CERT_FILE</key>
+        <string>/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/roborev_bridge_launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/roborev_bridge_launchd.log</string>
+
+    <!-- Retry once after 60 s if job exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+</dict>
+</plist>

--- a/.claude/scripts/housekeeping_schema_init.sql
+++ b/.claude/scripts/housekeeping_schema_init.sql
@@ -7,6 +7,7 @@
 --   config_events          -- one row per config-file change detected by config_digest_cron.sh
 --   kb_events              -- one row per knowledge-base change detected by kb_digest_daily_cron.sh
 --   launchd_health_events  -- one row per launchd plist's last-observed state (llm#554)
+--   roborev_daily_summary  -- per-project daily summary mirrored from roborev SQLite (llm#555)
 --
 -- All writers follow unified-observability-schema: id, session_id, source,
 -- action, reason, fired_at / started_at + task-specific columns.
@@ -14,7 +15,7 @@
 -- Apply with:
 --   bash .claude/scripts/housekeeping_schema_apply.sh
 --
--- Tracked in llm#550 Phase B, llm#552 Phase B, llm#553 Phase B, llm#554 Phase B.
+-- Tracked in llm#550 Phase B, llm#552 Phase B, llm#553 Phase B, llm#554 Phase B, llm#555 Phase B.
 
 CREATE TABLE IF NOT EXISTS worktree_gc_events (
   id                TEXT PRIMARY KEY,
@@ -77,7 +78,7 @@ CREATE TABLE IF NOT EXISTS kb_events (
 -- Queried by the 06:30 digest to surface the "Cron health (last fire)" section.
 -- A missing or stale row for any plist is the meta-check that flags broken cron jobs.
 -- Natural key is (plist_label, fired_at); uniqueness enforced by primary key on id.
--- TODO: consider UNIQUE (plist_label, fired_at) constraint — see llm#567.
+-- TODO: consider UNIQUE (plist_label, fired_at) constraint -- see llm#567.
 -- See llm#554 Phase B.
 CREATE TABLE IF NOT EXISTS launchd_health_events (
   id              TEXT PRIMARY KEY,
@@ -90,6 +91,44 @@ CREATE TABLE IF NOT EXISTS launchd_health_events (
   next_fire_at    TIMESTAMPTZ,             -- from launchctl print (NULL when not scheduled/parseable)
   detail          TEXT
 );
+
+-- roborev_daily_summary: per-project daily summary mirrored from roborev's
+-- own SQLite DB at ~/.roborev/reviews.db. Read-only bridge -- roborev keeps
+-- owning its data; we just mirror per-project aggregates here so the 06:30
+-- digest can render a roborev section without crossing DB boundaries.
+-- One row per (project, window_end) -- daily aggregation.
+--
+-- Severity values in roborev output text: High | Medium | Low (NOT Critical/Major/Minor).
+-- The issue body used critical/medium/low naming; this schema uses roborev's
+-- actual terminology (high_open, medium_open, low_open) to match the source.
+--
+-- Project canonical naming follows data-glossary-and-entity-resolution rule (#474):
+-- use repos.name from roborev (lowercase basename as stored by roborev itself).
+-- No alias translation needed -- roborev already owns the canonical name.
+-- Canonical names: llm, llmtelemetry, mycare, historical, etc.
+--
+-- Natural key is (project, window_end); uniqueness enforced via deterministic PK
+-- (md5("<project>:<window_date>") formatted as UUID).
+-- TODO: add UNIQUE (project, window_end) constraint -- see llm#567.
+-- See llm#555 Phase B.
+CREATE TABLE IF NOT EXISTS roborev_daily_summary (
+  id                          TEXT PRIMARY KEY,
+  fired_at                    TIMESTAMPTZ NOT NULL,       -- when the bridge ran
+  window_start                TIMESTAMPTZ NOT NULL,
+  window_end                  TIMESTAMPTZ NOT NULL,
+  project                     TEXT NOT NULL,              -- canonical project name from roborev repos.name
+  total_reviews_open          INTEGER,
+  total_reviews_closed_today  INTEGER,
+  high_open                   INTEGER,                    -- Severity: High (roborev actual terminology)
+  medium_open                 INTEGER,                    -- Severity: Medium
+  low_open                    INTEGER,                    -- Severity: Low
+  oldest_open_days            INTEGER,
+  autoclose_today             INTEGER,
+  source_db_path              TEXT NOT NULL,              -- which roborev DB was read
+  detail_json                 TEXT                        -- top-3 findings JSON for digest context
+);
+CREATE INDEX IF NOT EXISTS idx_roborev_daily_summary_fired_at ON roborev_daily_summary(fired_at);
+CREATE INDEX IF NOT EXISTS idx_roborev_daily_summary_project_window ON roborev_daily_summary(project, window_end);
 
 CREATE INDEX IF NOT EXISTS idx_worktree_gc_events_fired_at ON worktree_gc_events(fired_at);
 CREATE INDEX IF NOT EXISTS idx_housekeeping_runs_task_started ON housekeeping_runs(task, started_at);

--- a/.claude/scripts/housekeeping_schema_init.sql
+++ b/.claude/scripts/housekeeping_schema_init.sql
@@ -8,6 +8,7 @@
 --   config_events          -- one row per config-file change detected by config_digest_cron.sh
 --   kb_events              -- one row per knowledge-base change detected by kb_digest_daily_cron.sh
 --   launchd_health_events  -- one row per launchd plist's last-observed state (llm#554)
+--   roborev_daily_summary  -- per-project daily summary mirrored from roborev SQLite (llm#555)
 --
 -- All writers follow unified-observability-schema: id, session_id, source,
 -- action, reason, fired_at / started_at + task-specific columns.
@@ -15,7 +16,7 @@
 -- Apply with:
 --   bash .claude/scripts/housekeeping_schema_apply.sh
 --
--- Tracked in llm#550 Phase B, llm#552 Phase B, llm#553 Phase B, llm#554 Phase B, llm#585 Phase A.
+-- Tracked in llm#550 Phase B, llm#552 Phase B, llm#553 Phase B, llm#554 Phase B, llm#555 Phase B, llm#585 Phase A.
 
 CREATE TABLE IF NOT EXISTS worktree_gc_events (
   id                TEXT PRIMARY KEY,
@@ -104,7 +105,7 @@ CREATE TABLE IF NOT EXISTS kb_events (
 -- Queried by the 06:30 digest to surface the "Cron health (last fire)" section.
 -- A missing or stale row for any plist is the meta-check that flags broken cron jobs.
 -- Natural key is (plist_label, fired_at); uniqueness enforced by primary key on id.
--- TODO: consider UNIQUE (plist_label, fired_at) constraint — see llm#567.
+-- TODO: consider UNIQUE (plist_label, fired_at) constraint -- see llm#567.
 -- See llm#554 Phase B.
 CREATE TABLE IF NOT EXISTS launchd_health_events (
   id              TEXT PRIMARY KEY,
@@ -117,6 +118,44 @@ CREATE TABLE IF NOT EXISTS launchd_health_events (
   next_fire_at    TIMESTAMPTZ,             -- from launchctl print (NULL when not scheduled/parseable)
   detail          TEXT
 );
+
+-- roborev_daily_summary: per-project daily summary mirrored from roborev's
+-- own SQLite DB at ~/.roborev/reviews.db. Read-only bridge -- roborev keeps
+-- owning its data; we just mirror per-project aggregates here so the 06:30
+-- digest can render a roborev section without crossing DB boundaries.
+-- One row per (project, window_end) -- daily aggregation.
+--
+-- Severity values in roborev output text: High | Medium | Low (NOT Critical/Major/Minor).
+-- The issue body used critical/medium/low naming; this schema uses roborev's
+-- actual terminology (high_open, medium_open, low_open) to match the source.
+--
+-- Project canonical naming follows data-glossary-and-entity-resolution rule (#474):
+-- use repos.name from roborev (lowercase basename as stored by roborev itself).
+-- No alias translation needed -- roborev already owns the canonical name.
+-- Canonical names: llm, llmtelemetry, mycare, historical, etc.
+--
+-- Natural key is (project, window_end); uniqueness enforced via deterministic PK
+-- (md5("<project>:<window_date>") formatted as UUID).
+-- TODO: add UNIQUE (project, window_end) constraint -- see llm#567.
+-- See llm#555 Phase B.
+CREATE TABLE IF NOT EXISTS roborev_daily_summary (
+  id                          TEXT PRIMARY KEY,
+  fired_at                    TIMESTAMPTZ NOT NULL,       -- when the bridge ran
+  window_start                TIMESTAMPTZ NOT NULL,
+  window_end                  TIMESTAMPTZ NOT NULL,
+  project                     TEXT NOT NULL,              -- canonical project name from roborev repos.name
+  total_reviews_open          INTEGER,
+  total_reviews_closed_today  INTEGER,
+  high_open                   INTEGER,                    -- Severity: High (roborev actual terminology)
+  medium_open                 INTEGER,                    -- Severity: Medium
+  low_open                    INTEGER,                    -- Severity: Low
+  oldest_open_days            INTEGER,
+  autoclose_today             INTEGER,
+  source_db_path              TEXT NOT NULL,              -- which roborev DB was read
+  detail_json                 TEXT                        -- top-3 findings JSON for digest context
+);
+CREATE INDEX IF NOT EXISTS idx_roborev_daily_summary_fired_at ON roborev_daily_summary(fired_at);
+CREATE INDEX IF NOT EXISTS idx_roborev_daily_summary_project_window ON roborev_daily_summary(project, window_end);
 
 CREATE INDEX IF NOT EXISTS idx_worktree_gc_events_fired_at ON worktree_gc_events(fired_at);
 CREATE INDEX IF NOT EXISTS idx_branch_gc_events_fired_at ON branch_gc_events(fired_at);

--- a/.claude/scripts/roborev_bridge_to_unified.sh
+++ b/.claude/scripts/roborev_bridge_to_unified.sh
@@ -1,0 +1,353 @@
+#!/bin/bash
+# roborev_bridge_to_unified.sh -- Daily bridge: roborev SQLite -> unified.duckdb.
+#
+# Reads per-project aggregates from roborev's own SQLite DB (~/.roborev/reviews.db)
+# and writes summary rows to unified.duckdb. This is a READ-ONLY mirror --
+# roborev keeps owning its data; we never write to roborev's DB.
+#
+# Roborev SQLite schema observed 2026-06-08 (~/.roborev/reviews.db):
+#   repos(id, root_path, name, created_at, identity)
+#   review_jobs(id, repo_id, commit_id, git_ref, branch, status, finished_at, ...)
+#   reviews(id, job_id, agent, output, created_at, closed, verdict_bool, ...)
+#   closures(id, finding_id, closure_commit_sha, closure_type, created_at, ...)
+#
+# Key schema notes:
+#   - No dedicated severity column; severity is embedded in reviews.output text
+#     as markdown: "**Severity**: High|Medium|Low"
+#   - Canonical project name = repos.name (lowercase basename stored by roborev)
+#   - autoclose is identified by closures.closure_type = 'stale'
+#
+# Severity terminology (actual roborev values): High | Medium | Low
+#   (NOT Critical/Major/Minor -- issue #555 body used different names)
+#
+# Canonical project naming: data-glossary-and-entity-resolution rule (#474).
+#   We use repos.name directly from roborev (already canonical; no alias map needed).
+#
+# Steps:
+#   0. Write housekeeping_runs start row (if duckdb available)
+#   1. Locate and validate roborev SQLite DB (graceful skip if absent)
+#   2. Query per-project aggregates for the 24h window
+#   3. INSERT rows into roborev_daily_summary (INSERT OR IGNORE -- idempotent)
+#   4. Update housekeeping_runs end row
+#
+# UUID generation: uuidgen | tr '[:upper:]' '[:lower:]' (no python3, per llm#569)
+# ISO UTC: date -u +'%Y-%m-%dT%H:%M:%SZ'
+# Read-only from roborev: NEVER runs INSERT/UPDATE/DELETE on ROBOREV_DB.
+#
+# Log: ~/.claude/logs/roborev_bridge.log
+#
+# Manual dry-run (logs what would be inserted, no DB writes):
+#   BRIDGE_DRY_RUN=1 bash .claude/scripts/roborev_bridge_to_unified.sh
+#
+# Skip git pull:
+#   SKIP_CRON_PULL=1 BRIDGE_DRY_RUN=1 bash .claude/scripts/roborev_bridge_to_unified.sh
+#
+# Tracked in llm#555 Phase A.
+
+set -uo pipefail
+
+# -- PATH (launchd runs with a bare PATH) -------------------------------------
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# -- Recursion guard ----------------------------------------------------------
+: "${ROBOREV_BRIDGE_DEPTH:=0}"
+if (( ROBOREV_BRIDGE_DEPTH > 0 )); then
+  echo "[roborev_bridge] ERROR: recursion detected (depth=${ROBOREV_BRIDGE_DEPTH}). Abort." >&2
+  exit 1
+fi
+export ROBOREV_BRIDGE_DEPTH=$(( ROBOREV_BRIDGE_DEPTH + 1 ))
+
+# -- Paths --------------------------------------------------------------------
+# SCRIPT_DIR resolves through symlinks so REPO_ROOT is correct whether called
+# via ~/.claude/scripts/ symlink or directly from the worktree path.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOG_FILE="${HOME}/.claude/logs/roborev_bridge.log"
+LOCK_FILE="/tmp/roborev_bridge_to_unified.lock"
+UNIFIED_DB="${UNIFIED_DB_PATH:-${HOME}/.claude/logs/unified.duckdb}"
+ROBOREV_DB="${ROBOREV_DB_PATH:-${HOME}/.roborev/reviews.db}"
+
+BRIDGE_DRY_RUN="${BRIDGE_DRY_RUN:-0}"
+
+# -- Logging ------------------------------------------------------------------
+mkdir -p "$(dirname "${LOG_FILE}")"
+
+log() {
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  printf '%s: %s\n' "${ts}" "$1" | tee -a "${LOG_FILE}"
+}
+
+log "=== roborev_bridge_to_unified.sh starting (BRIDGE_DRY_RUN=${BRIDGE_DRY_RUN}) ==="
+
+# -- Lock ---------------------------------------------------------------------
+if [ -f "${LOCK_FILE}" ]; then
+  existing_pid="$(cat "${LOCK_FILE}" 2>/dev/null || true)"
+  if [ -n "${existing_pid}" ] && kill -0 "${existing_pid}" 2>/dev/null; then
+    log "SKIP: another instance running (PID ${existing_pid})"
+    exit 0
+  fi
+fi
+printf '%d' "$$" > "${LOCK_FILE}"
+trap 'rm -f "${LOCK_FILE}"' EXIT
+
+# -- Deploy: pull latest main (cron-auto-pull-discipline, llm#510) ------------
+# Without this step every gh pr merge ships nothing to the cron.
+if [ -z "${SKIP_CRON_PULL:-}" ]; then
+    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
+    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
+        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+    else
+        log "deploy WARN: ff-only failed -- running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+    fi
+fi
+log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
+
+# -- DuckDB availability check ------------------------------------------------
+# Gracefully skip all DB writes when duckdb binary or unified.duckdb is absent.
+# Same defensive pattern as config_digest_cron.sh (PR #566).
+_duckdb_ok=0
+if command -v duckdb >/dev/null 2>&1 && [ -f "${UNIFIED_DB}" ]; then
+  _duckdb_ok=1
+  log "duckdb: available at ${UNIFIED_DB}"
+else
+  log "duckdb: not available -- skipping DB writes"
+fi
+
+# Run ID and timestamps (bash-native, no python3 per llm#569)
+_run_id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+_run_started="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+# -- Step 0: Write housekeeping_runs start row --------------------------------
+if [ "${_duckdb_ok}" = "1" ] && [ "${BRIDGE_DRY_RUN}" != "1" ]; then
+  _script_abs="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P)/$(basename "${BASH_SOURCE[0]}")"
+  duckdb "${UNIFIED_DB}" "
+    INSERT OR IGNORE INTO housekeeping_runs
+      (id, task, source_script, started_at, status, rows_written)
+    VALUES (
+      '${_run_id}',
+      'roborev_bridge',
+      '${_script_abs}',
+      TIMESTAMPTZ '${_run_started}',
+      'ok',
+      0
+    );
+  " 2>/dev/null || log "duckdb WARN: housekeeping_runs INSERT failed (non-fatal)"
+fi
+
+# Helper: update housekeeping_runs on failure and exit
+_fail_and_exit() {
+  local _msg="$1"
+  local _exit_code="${2:-1}"
+  log "ERROR: ${_msg}"
+  if [ "${_duckdb_ok}" = "1" ] && [ "${BRIDGE_DRY_RUN}" != "1" ]; then
+    local _ended
+    _ended="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    local _msg_sql="${_msg//"'"/"''"}"
+    duckdb "${UNIFIED_DB}" "
+      UPDATE housekeeping_runs
+      SET ended_at = TIMESTAMPTZ '${_ended}',
+          status = 'failed',
+          error_text = '${_msg_sql}'
+      WHERE id = '${_run_id}';
+    " 2>/dev/null || true
+  fi
+  exit "${_exit_code}"
+}
+
+# -- Step 1: Locate and validate roborev SQLite DB ---------------------------
+log "Step 1: checking roborev SQLite at ${ROBOREV_DB}..."
+
+if [ ! -f "${ROBOREV_DB}" ]; then
+  # Graceful skip: roborev not installed or DB path differs.
+  # Update housekeeping_runs with partial status so the digest can detect the gap.
+  log "Step 1 SKIP: roborev DB not found at ${ROBOREV_DB} -- nothing to mirror"
+  if [ "${_duckdb_ok}" = "1" ] && [ "${BRIDGE_DRY_RUN}" != "1" ]; then
+    _run_ended="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    duckdb "${UNIFIED_DB}" "
+      UPDATE housekeeping_runs
+      SET ended_at = TIMESTAMPTZ '${_run_ended}',
+          status = 'partial',
+          error_text = 'roborev DB not found'
+      WHERE id = '${_run_id}';
+    " 2>/dev/null || true
+  fi
+  log "=== roborev_bridge_to_unified.sh done (skip: no DB) ==="
+  exit 0
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  _fail_and_exit "sqlite3 not on PATH -- cannot read ${ROBOREV_DB}"
+fi
+
+# Sanity check: DB is readable and has the repos table
+_db_repo_count="$(sqlite3 "${ROBOREV_DB}" "SELECT COUNT(*) FROM repos;" 2>&1)"
+_db_exit=$?
+if [ "${_db_exit}" -ne 0 ]; then
+  _fail_and_exit "roborev DB not readable (sqlite3 exit=${_db_exit}): ${_db_repo_count}"
+fi
+log "Step 1 done: roborev DB readable, ${_db_repo_count} repos"
+
+# -- Step 2+3: Query per-project aggregates and INSERT rows ------------------
+# Window: 24h ending now.
+_now_ts="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+_since_ts="$(date -u -v -24H +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '24 hours ago' +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u +'%Y-%m-%dT00:00:00Z')"
+_window_date="$(date -u +'%Y-%m-%d')"
+
+log "Step 2: querying roborev per-project aggregates (window: ${_since_ts} -> ${_now_ts})..."
+
+_ROWS_WRITTEN=0
+_ROWS_ATTEMPTED=0
+
+# Aggregation SQL.
+# Severity is embedded in reviews.output as markdown: "**Severity**: High|Medium|Low".
+# autoclose_today = closures with closure_type='stale' in last 24h.
+# oldest_open_days = max age in days of any open finding via review_jobs.finished_at.
+# Only returns projects with open reviews OR recent activity.
+_SQLITE_QUERY="
+SELECT
+  r.name AS project,
+  COALESCE(SUM(CASE WHEN rv.closed = 0 THEN 1 ELSE 0 END), 0) AS total_open,
+  COALESCE(SUM(CASE
+    WHEN rv.closed = 1
+     AND datetime(rv.created_at) >= datetime('now', '-1 day')
+    THEN 1 ELSE 0 END), 0) AS closed_today,
+  COALESCE(SUM(CASE
+    WHEN rv.closed = 0
+     AND (rv.output LIKE '%Severity**: High%'
+       OR rv.output LIKE '%severity**: high%'
+       OR rv.output LIKE '%**Severity**: High%')
+    THEN 1 ELSE 0 END), 0) AS high_open,
+  COALESCE(SUM(CASE
+    WHEN rv.closed = 0
+     AND (rv.output LIKE '%Severity**: Medium%'
+       OR rv.output LIKE '%severity**: medium%'
+       OR rv.output LIKE '%**Severity**: Medium%')
+    THEN 1 ELSE 0 END), 0) AS medium_open,
+  COALESCE(SUM(CASE
+    WHEN rv.closed = 0
+     AND (rv.output LIKE '%Severity**: Low%'
+       OR rv.output LIKE '%severity**: low%'
+       OR rv.output LIKE '%**Severity**: Low%')
+    THEN 1 ELSE 0 END), 0) AS low_open,
+  COALESCE(MAX(CASE
+    WHEN rv.closed = 0 AND rj.finished_at IS NOT NULL
+    THEN CAST((julianday('now') - julianday(rj.finished_at)) AS INTEGER)
+    ELSE 0 END), 0) AS oldest_open_days,
+  COALESCE(SUM(CASE
+    WHEN cl.closure_type = 'stale'
+     AND datetime(cl.created_at) >= datetime('now', '-1 day')
+    THEN 1 ELSE 0 END), 0) AS autoclose_today
+FROM repos r
+LEFT JOIN review_jobs rj ON rj.repo_id = r.id
+LEFT JOIN reviews rv ON rv.job_id = rj.id
+LEFT JOIN closures cl ON cl.finding_id = rv.id
+GROUP BY r.name
+HAVING total_open > 0 OR closed_today > 0 OR autoclose_today > 0
+ORDER BY total_open DESC;
+"
+
+log "Step 3: INSERTing roborev_daily_summary rows to unified.duckdb..."
+
+while IFS='|' read -r _project _total_open _closed_today _high _medium _low _oldest_days _autoclose; do
+  [ -z "${_project}" ] && continue
+  _ROWS_ATTEMPTED=$(( _ROWS_ATTEMPTED + 1 ))
+
+  # Deterministic PK from md5("<project>:<window_date>") formatted as UUID.
+  # Ensures INSERT OR IGNORE is a true no-op on re-runs within the same day.
+  _pk_seed="${_project}:${_window_date}"
+  if command -v md5sum >/dev/null 2>&1; then
+    _pk_hex="$(printf '%s' "${_pk_seed}" | md5sum | cut -c1-32)"
+  elif command -v md5 >/dev/null 2>&1; then
+    _pk_hex="$(printf '%s' "${_pk_seed}" | md5 | cut -c1-32)"
+  else
+    # Fallback: random UUID (loses within-day idempotency, but safe)
+    _pk_hex="$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')"
+  fi
+  _row_id="${_pk_hex:0:8}-${_pk_hex:8:4}-${_pk_hex:12:4}-${_pk_hex:16:4}-${_pk_hex:20:12}"
+
+  # SQL-escape single quotes in project name
+  _project_sql="${_project//"'"/"''"}"
+
+  # Top-3 findings snippet for digest context (highest severity first)
+  _detail_json="null"
+  _top3_output="$(sqlite3 "${ROBOREV_DB}" "
+    SELECT substr(rv.output, 1, 200)
+    FROM reviews rv
+    JOIN review_jobs rj ON rv.job_id = rj.id
+    JOIN repos r ON rj.repo_id = r.id
+    WHERE r.name = '${_project}' AND rv.closed = 0
+    ORDER BY
+      CASE
+        WHEN rv.output LIKE '%Severity**: High%' OR rv.output LIKE '%severity**: high%' THEN 1
+        WHEN rv.output LIKE '%Severity**: Medium%' OR rv.output LIKE '%severity**: medium%' THEN 2
+        ELSE 3
+      END,
+      rv.created_at DESC
+    LIMIT 3;
+  " 2>/dev/null || true)"
+
+  if [ -n "${_top3_output}" ]; then
+    _top3_clean="$(printf '%s' "${_top3_output}" | tr '\n' ' ' | sed 's/"/\\"/g' | cut -c1-500)"
+    _detail_json="\"${_top3_clean}\""
+  fi
+
+  if [ "${BRIDGE_DRY_RUN}" = "1" ]; then
+    log "  DRY-RUN: project=${_project} open=${_total_open} high=${_high} med=${_medium} low=${_low} oldest=${_oldest_days}d autoclose=${_autoclose}"
+    _ROWS_WRITTEN=$(( _ROWS_WRITTEN + 1 ))
+    continue
+  fi
+
+  if [ "${_duckdb_ok}" = "1" ]; then
+    duckdb "${UNIFIED_DB}" "
+      INSERT OR IGNORE INTO roborev_daily_summary
+        (id, fired_at, window_start, window_end, project,
+         total_reviews_open, total_reviews_closed_today,
+         high_open, medium_open, low_open,
+         oldest_open_days, autoclose_today,
+         source_db_path, detail_json)
+      VALUES (
+        '${_row_id}',
+        TIMESTAMPTZ '${_now_ts}',
+        TIMESTAMPTZ '${_since_ts}',
+        TIMESTAMPTZ '${_now_ts}',
+        '${_project_sql}',
+        ${_total_open},
+        ${_closed_today},
+        ${_high},
+        ${_medium},
+        ${_low},
+        ${_oldest_days},
+        ${_autoclose},
+        '${ROBOREV_DB}',
+        ${_detail_json}
+      );
+    " 2>/dev/null || log "  WARN: INSERT failed for project=${_project} (INSERT OR IGNORE -- non-fatal)"
+    _ROWS_WRITTEN=$(( _ROWS_WRITTEN + 1 ))
+    log "  inserted: project=${_project} open=${_total_open} high=${_high} med=${_medium} low=${_low} oldest=${_oldest_days}d"
+  else
+    log "  SKIP (duckdb unavailable): project=${_project} open=${_total_open}"
+  fi
+done < <(sqlite3 "${ROBOREV_DB}" "${_SQLITE_QUERY}" 2>/dev/null || true)
+
+log "Step 3 done: attempted=${_ROWS_ATTEMPTED} written=${_ROWS_WRITTEN}"
+
+# Anomaly detection: warn if DB has repos but zero active projects found.
+# Signals roborev's own writer may be broken.
+if [ "${_ROWS_ATTEMPTED}" = "0" ] && [ "${_db_repo_count:-0}" != "0" ]; then
+  log "WARN: roborev DB has ${_db_repo_count} repos but zero active projects -- roborev writer may be broken"
+fi
+
+# -- Step 4: Update housekeeping_runs end row ---------------------------------
+if [ "${_duckdb_ok}" = "1" ] && [ "${BRIDGE_DRY_RUN}" != "1" ]; then
+  _run_ended="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  duckdb "${UNIFIED_DB}" "
+    UPDATE housekeeping_runs
+    SET ended_at = TIMESTAMPTZ '${_run_ended}',
+        rows_written = ${_ROWS_WRITTEN}
+    WHERE id = '${_run_id}';
+  " 2>/dev/null || log "duckdb WARN: housekeeping_runs UPDATE failed (non-fatal)"
+  log "Step 4: housekeeping_runs updated (rows_written=${_ROWS_WRITTEN})"
+fi
+
+log "=== roborev_bridge_to_unified.sh done ==="


### PR DESCRIPTION
## Summary

Implements llm#555 Phase A+B+C: the daily roborev SQLite → unified.duckdb bridge.

- **Phase B (Schema):** New `roborev_daily_summary` table in `housekeeping_schema_init.sql`
- **Phase A (Bridge script):** `.claude/scripts/roborev_bridge_to_unified.sh` — reads roborev's SQLite, writes aggregate rows to unified.duckdb. READ-ONLY from roborev. No python3 (llm#569 compliance).
- **Phase C (Plist):** `.claude/launchd/com.claude.roborev-bridge.plist` — daily at 06:00, 30 min before the 06:30 digest.

NOT included (deferred):
- Digest section for roborev (see snippet below — for the parallel sequencing PR)
- Retirement of `com.claude.roborev-daily-email` / `com.claude.roborev-weekly-rollup-email` (2-week soak)
- `.claude/scripts/send_overnight_self_review_email.R` not touched

---

## Roborev SQLite Schema (observed 2026-06-08, ~/.roborev/reviews.db)

Schema inspected via `sqlite3 ~/.roborev/reviews.db .schema` (read-only):

```
repos(id INTEGER, root_path TEXT UNIQUE, name TEXT, created_at TEXT, identity TEXT)
review_jobs(id INTEGER, repo_id REFERENCES repos, commit_id, git_ref TEXT,
            branch TEXT, status TEXT CHECK('queued','running','done','failed','canceled',
            'applied','rebased','skipped'), enqueued_at TEXT, started_at TEXT,
            finished_at TEXT, ...)
reviews(id INTEGER, job_id REFERENCES review_jobs, agent TEXT, output TEXT,
        created_at TEXT, closed INTEGER DEFAULT 0, verdict_bool INTEGER, ...)
closures(id INTEGER AUTOINCREMENT, finding_id REFERENCES reviews,
         closure_commit_sha TEXT, closure_type TEXT CHECK('approved','wontfix','manual','stale'),
         closure_reason TEXT, created_at TEXT)
```

Key findings from schema inspection:
- **No dedicated severity column** — severity is embedded in `reviews.output` as markdown text: `"**Severity**: High|Medium|Low"`
- **Actual severity values**: `High`, `Medium`, `Low` (NOT Critical/Major/Minor as the issue body assumed)
- **autoclose** = `closures.closure_type = 'stale'` (not a flag on reviews)
- **project name** = `repos.name` (lowercase basename, e.g. `llm`, `llmtelemetry`, `mycare`)
- Current data: 1,247 open reviews, 4,137 closed, across 10+ repos

Sample open review count by project:
| project | open | high | medium | low |
|---|---|---|---|---|
| test_repo | 279 | 0 | 0 | 1 |
| llmtelemetry | 188 | 188 | 185 | 56 |
| llm | 164 | 43 | 100 | 1 |
| historical | 123 | 14 | 58 | 51 |

---

## Aggregation SQL (with comments)

```sql
SELECT
  r.name AS project,
  -- total open: any review with closed=0
  COALESCE(SUM(CASE WHEN rv.closed = 0 THEN 1 ELSE 0 END), 0) AS total_open,
  -- closed today: reviews closed in last 24h (created_at used as proxy for closure time)
  COALESCE(SUM(CASE
    WHEN rv.closed = 1 AND datetime(rv.created_at) >= datetime('now', '-1 day')
    THEN 1 ELSE 0 END), 0) AS closed_today,
  -- severity: LIKE pattern on output text (no dedicated column in schema)
  COALESCE(SUM(CASE
    WHEN rv.closed = 0
     AND (rv.output LIKE '%Severity**: High%' OR rv.output LIKE '%severity**: high%'
          OR rv.output LIKE '%**Severity**: High%')
    THEN 1 ELSE 0 END), 0) AS high_open,
  -- ... medium_open, low_open follow same pattern ...
  -- oldest_open_days: max age via review_jobs.finished_at (when the job finished)
  COALESCE(MAX(CASE
    WHEN rv.closed = 0 AND rj.finished_at IS NOT NULL
    THEN CAST((julianday('now') - julianday(rj.finished_at)) AS INTEGER)
    ELSE 0 END), 0) AS oldest_open_days,
  -- autoclose_today: closures with type 'stale' in last 24h
  COALESCE(SUM(CASE
    WHEN cl.closure_type = 'stale'
     AND datetime(cl.created_at) >= datetime('now', '-1 day')
    THEN 1 ELSE 0 END), 0) AS autoclose_today
FROM repos r
LEFT JOIN review_jobs rj ON rj.repo_id = r.id
LEFT JOIN reviews rv ON rv.job_id = rj.id
LEFT JOIN closures cl ON cl.finding_id = rv.id
GROUP BY r.name
HAVING total_open > 0 OR closed_today > 0 OR autoclose_today > 0
ORDER BY total_open DESC;
```

---

## Schema Deviation from Issue Body

The issue body used `critical_open`, `medium_open`, `low_open` for column names. The actual schema uses `high_open`, `medium_open`, `low_open` because roborev uses `High/Medium/Low` terminology, not `Critical/Major/Minor`. This was discovered by inspecting actual review output text. The bridge mirrors roborev's actual language.

---

## Proposed Digest Section (for future sequencing PR — DO NOT include in this diff)

```r
# roborev section (Phase D of #555 -- add after sequencing PR lands)
# Add to send_overnight_self_review_email.R after other sections
#
# con <- DBI::dbConnect(duckdb::duckdb(), unified_db)
# on.exit(DBI::dbDisconnect(con), add = TRUE)
#
# roborev_rows <- dplyr::tbl(con, "roborev_daily_summary") |>
#   dplyr::filter(fired_at >= .env$since_ts) |>
#   dplyr::arrange(desc(total_reviews_open)) |>
#   dplyr::select(project, total_reviews_open, high_open, medium_open, low_open,
#                 oldest_open_days, autoclose_today) |>
#   dplyr::collect()
#
# if (nrow(roborev_rows) == 0) {
#   cat("## Roborev (24h)\n\n_Bridge ran but found no active projects_\n\n")
# } else {
#   cat("## Roborev (24h)\n\n")
#   cat(knitr::kable(roborev_rows, format = "pipe"), sep = "\n")
#   # Highlight anomaly: warn if total_reviews_open drops >= 80% day-over-day
#   # (signals roborev itself broke) -- compare yesterday's row from same table
#   cat("\n")
# }
```

---

## Manual Install Steps (Orchestrator — after PR merge)

```bash
# 1. Apply schema to unified.duckdb (adds roborev_daily_summary table)
bash /Users/johngavin/docs_gh/llm/.claude/scripts/housekeeping_schema_apply.sh

# 2. Verify table created
duckdb ~/.claude/logs/unified.duckdb "DESCRIBE roborev_daily_summary;"

# 3. Install launchd plist
cp /Users/johngavin/docs_gh/llm/.claude/launchd/com.claude.roborev-bridge.plist \
   ~/Library/LaunchAgents/com.claude.roborev-bridge.plist

launchctl load -w ~/Library/LaunchAgents/com.claude.roborev-bridge.plist

# 4. Verify loaded
launchctl list | grep roborev-bridge

# 5. Manual dry-run to verify
BRIDGE_DRY_RUN=1 SKIP_CRON_PULL=1 \
  bash /Users/johngavin/docs_gh/llm/.claude/scripts/roborev_bridge_to_unified.sh

# 6. Check log
tail -20 ~/.claude/logs/roborev_bridge.log
```

---

## 2-Week Retirement Plan for Standalone Roborev Email Jobs

Per #555 issue body:

| Week | Action |
|---|---|
| Week 1 (this PR) | Bridge ON, standalone roborev emails still running — validate `roborev_daily_summary` rows appear in DB |
| Week 2 | Verify bridge coverage matches standalone email content |
| Week 3 (2-week soak complete) | Disable `com.claude.roborev-daily-email`: `launchctl unload ~/Library/LaunchAgents/com.claude.roborev-daily-email.plist` |
| Week 5 (4-week soak complete) | Disable `com.claude.roborev-weekly-rollup-email` (weekly cadence requires longer soak) |

Silent crons NOT retired: `roborev-autoclose`, `roborev-agent-health`, `roborev-metrics-etl`, `roborev-poll-merges`, `roborev-severity-autoclose` — these are workers not emailers.

---

## Compliance Confirmation

- No python3 used: UUID via `uuidgen | tr '[:upper:]' '[:lower:]'`, timestamps via `date -u +'%Y-%m-%dT%H:%M:%SZ'` (llm#569)
- No writes to roborev's own DB (`~/.roborev/reviews.db`): all SQLite calls are SELECT-only
- `send_overnight_self_review_email.R` not modified (parallel sequencing PR)
- `launchctl` not invoked (install is manual orchestrator step)
- Follows `cron-auto-pull-discipline` rule: git fetch/ff-only before every cron run
- Follows `unified-observability-schema` rule: `housekeeping_runs` heartbeat in Step 0/4
- Follows `data-glossary-and-entity-resolution` rule: canonical project names from `repos.name`

## Test plan

- [ ] `bash .claude/scripts/housekeeping_schema_apply.sh` — verify `roborev_daily_summary` table created
- [ ] `BRIDGE_DRY_RUN=1 SKIP_CRON_PULL=1 bash .claude/scripts/roborev_bridge_to_unified.sh` — verify dry-run logs per-project rows
- [ ] After install: check `~/.claude/logs/roborev_bridge.log` shows correct project counts
- [ ] Check `housekeeping_runs` row with `task='roborev_bridge'` appears in unified.duckdb
- [ ] Verify `roborev_daily_summary` populated: `duckdb ~/.claude/logs/unified.duckdb "SELECT project, total_reviews_open, high_open FROM roborev_daily_summary ORDER BY total_reviews_open DESC;"`
- [ ] No rows in `~/.roborev/reviews.db` modified (read-only check: compare row count before/after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
