### PR TITLE
fix(#586): worktree_gc launchd schedule — daily 09:00 not weekly Sunday 04:00

### DIFF
--- a/.claude/launchd/com.claude.worktree-gc.plist
+++ b/.claude/launchd/com.claude.worktree-gc.plist
@@ -2,15 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- Sweep stale worktrees across all repos under ~/docs_gh weekly.          -->
-    <!-- Dry-run only until the script's SOAK_END date (2026-06-02);             -->
-    <!-- after that date --apply removes merged+clean+old worktrees.             -->
-    <!-- Tracks: JohnGavin/llm#199.                                              -->
+    <!-- Sweep stale worktrees across all repos under ~/docs_gh daily 09:00.     -->
+    <!-- After the script's SOAK_END date (2026-06-02), --apply removes          -->
+    <!-- merged+clean+old worktrees. Before then, treated as dry-run.            -->
+    <!-- Tracks:        JohnGavin/llm#199.                                       -->
+    <!-- Schedule fix:  JohnGavin/llm#586 (was weekly Sun 04:00 — Mac asleep,    -->
+    <!--                job never auto-fired; moved to daily 09:00 when Mac is   -->
+    <!--                reliably awake).                                          -->
     <!--                                                                          -->
-    <!-- Install (do NOT install before SOAK_END):                               -->
+    <!-- Install / reload:                                                       -->
+    <!--   launchctl bootout gui/$(id -u)/com.claude.worktree-gc 2>/dev/null     -->
     <!--   cp .claude/launchd/com.claude.worktree-gc.plist                       -->
     <!--        ~/Library/LaunchAgents/                                           -->
-    <!--   launchctl load -w                                                      -->
+    <!--   launchctl bootstrap gui/$(id -u)                                      -->
     <!--        ~/Library/LaunchAgents/com.claude.worktree-gc.plist              -->
 
     <key>Label</key>
@@ -23,13 +27,11 @@
         <string>--apply</string>
     </array>
 
-    <!-- Weekly: Sunday 04:00 -->
+    <!-- Daily 09:00 (Mac reliably awake) -->
     <key>StartCalendarInterval</key>
     <dict>
-        <key>Weekday</key>
-        <integer>0</integer>
         <key>Hour</key>
-        <integer>4</integer>
+        <integer>9</integer>
         <key>Minute</key>
         <integer>0</integer>
     </dict>
@@ -39,6 +41,10 @@
 
     <key>StandardErrorPath</key>
     <string>/Users/johngavin/.claude/logs/worktree_gc.err</string>
+
+    <!-- Tolerate up to 30 s between retries if a minute is missed -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
 
     <!-- Do NOT run on load — only on the schedule. -->
     <key>RunAtLoad</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ Cumulative lab notes. Track completed work, **failed approaches**, accuracy chec
 
 Convention: newest entries at top. Each entry has a date, what was done, and why.
 
+## 2026-06-09 — fix(#586): worktree_gc launchd schedule
+
+### Completed
+
+- `.claude/launchd/com.claude.worktree-gc.plist` schedule moved from Weekly Sunday 04:00 → Daily 09:00; added `ThrottleInterval=30` so missed minutes don't tight-loop.
+- Root cause (diagnostic at llm#586 comment-4661743200): Mac reliably asleep at 04:00 Sunday + `RunAtLoad=false` + no `WakeUp` key → `last exit code = (never exited)` since load. Job has never auto-fired. Today's session manually removed 13 stale sibling worktrees (167 MB) that the cron should have caught.
+- `worktree_gc.sh` apply-gate logic is correct and unchanged; the plist did pass `--apply`, but the program never ran.
+
+### Manual post-merge reload (not automated — system-level launchctl)
+
+```bash
+launchctl bootout gui/$(id -u)/com.claude.worktree-gc 2>/dev/null
+cp .claude/launchd/com.claude.worktree-gc.plist ~/Library/LaunchAgents/
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude.worktree-gc.plist
+```
+
+### Verification (next day after reload)
+
+```bash
+launchctl print gui/$(id -u)/com.claude.worktree-gc | grep -E 'last exit|state'
+grep '^\[2026-06-10 09:' ~/.claude/logs/worktree_gc.log
+duckdb -readonly ~/.claude/logs/unified.duckdb \
+  "SELECT action, count(*) FROM worktree_gc_events WHERE fired_at >= current_date GROUP BY action"
+```
+
+Should show `action='removed'` rows once stale worktrees re-accumulate.
+
+Unblocks #585 (`branch_gc` automation, which reuses the same housekeeping plumbing).
+
 ## 2026-06-07 (later session — CLAUDE.md trim + housekeeping framework)
 
 ### Completed


### PR DESCRIPTION
## Summary

Fix #586 — `worktree_gc.sh` launchd schedule. Two-file mechanical change.

## Root cause

From the [#586 diagnostic comment](https://github.com/JohnGavin/llm/issues/586#issuecomment-4661743200):

- Plist scheduled `Weekday=0` (Sunday) at `04:00` weekly
- `RunAtLoad=false` + no `WakeUp` key → no catch-up on missed wake
- `launchctl print` showed `last exit code = (never exited)` — job has never auto-fired since load
- Today's session manually removed 13 stale sibling worktrees (167 MB) that the cron should have caught

`worktree_gc.sh` apply-gate logic is correct and unchanged; the plist did pass `--apply`, but the program never ran.

## Changes

| File | Change |
|---|---|
| `.claude/launchd/com.claude.worktree-gc.plist` | `StartCalendarInterval` weekly Sunday 04:00 → daily 09:00 (Mac reliably awake); add `ThrottleInterval=30`; update top comments + cite llm#586 |
| `CHANGELOG.md` | 2026-06-09 entry with manual post-merge reload steps |

## Manual post-merge reload (system-level launchctl)

Not automated — `launchctl bootout`/`bootstrap` write to `~/Library/LaunchAgents/` which is outside the repo:

```bash
launchctl bootout gui/$(id -u)/com.claude.worktree-gc 2>/dev/null
cp .claude/launchd/com.claude.worktree-gc.plist ~/Library/LaunchAgents/
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude.worktree-gc.plist
```

## Test plan

- [ ] Reload steps above completed locally
- [ ] Next morning (2026-06-10 09:00): `launchctl print gui/$(id -u)/com.claude.worktree-gc` shows non-`(never exited)` last exit code
- [ ] `~/.claude/logs/worktree_gc.log` shows `[2026-06-10 09:` entries
- [ ] `worktree_gc_events` table in `unified.duckdb` has `action='removed'` rows once stale worktrees re-accumulate

## Unblocks

#585 (`branch_gc` automation) — same housekeeping framework plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
