### PR TITLE
chore(rules): add YAML frontmatter to 14 rule files

### DIFF
--- a/.claude/rules/branch-harvest-on-fork.md
+++ b/.claude/rules/branch-harvest-on-fork.md
@@ -1,3 +1,7 @@
+---
+description: Session-start audit of unmerged feat branches — triage harvest/archive/discard before new work begins
+---
+
 # Rule: Branch Harvest on Fork (Mandatory, All Projects)
 
 ## When This Applies

--- a/.claude/rules/cron-auto-pull-discipline.md
+++ b/.claude/rules/cron-auto-pull-discipline.md
@@ -1,3 +1,7 @@
+---
+description: Every cron wrapper must ff-only pull origin/main before running and log the HEAD SHA
+---
+
 # Rule: Cron Auto-Pull Discipline
 
 ## Source

--- a/.claude/rules/cross-cutting-rename.md
+++ b/.claude/rules/cross-cutting-rename.md
@@ -1,3 +1,7 @@
+---
+description: User-facing label renames go through a single source of truth + audit grep, never ad-hoc search-and-replace
+---
+
 # Rule: Cross-Cutting Rename Discipline (Mandatory, All Projects)
 
 ## When This Applies

--- a/.claude/rules/dashboard-filter-placement.md
+++ b/.claude/rules/dashboard-filter-placement.md
@@ -1,3 +1,7 @@
+---
+description: Filters live near their data — bslib toolbar() in card headers/footers; sidebar only for page-wide filters
+---
+
 # Rule: Dashboard Filter Placement
 
 ## When This Applies

--- a/.claude/rules/dashboard-table-styling.md
+++ b/.claude/rules/dashboard-table-styling.md
@@ -1,3 +1,7 @@
+---
+description: HTML tables shrink to content width, left-aligned in container, right-justified cells
+---
+
 # Rule: Dashboard Table Styling (Mandatory, All Projects)
 
 ## When This Applies

--- a/.claude/rules/data-glossary-and-entity-resolution.md
+++ b/.claude/rules/data-glossary-and-entity-resolution.md
@@ -1,3 +1,7 @@
+---
+description: Every join key has one canonical form — glossary + entity-resolution map applied before any join or aggregation
+---
+
 # Rule: Data Glossary and Entity Resolution (Mandatory)
 
 ## When This Applies

--- a/.claude/rules/external-code-zero-trust.md
+++ b/.claude/rules/external-code-zero-trust.md
@@ -1,3 +1,7 @@
+---
+description: Never copy code from external sources — read for ideas, re-implement in our own style
+---
+
 # Rule: External Code Zero Trust
 
 ## When This Applies

--- a/.claude/rules/housekeeping-framework.md
+++ b/.claude/rules/housekeeping-framework.md
@@ -1,3 +1,7 @@
+---
+description: 5-point template for recurring housekeeping tasks — script, launchd plist, events table, digest section, session-init phase
+---
+
 # Rule: Housekeeping Framework (Convention)
 
 ## When This Applies

--- a/.claude/rules/hover-popup-standard.md
+++ b/.claude/rules/hover-popup-standard.md
@@ -1,3 +1,7 @@
+---
+description: Hover popups use Tippy.js via the shared partial — never bare abbr title attributes
+---
+
 # Rule: Hover-Popup Standard (All Vignettes, All Projects)
 
 ## When This Applies

--- a/.claude/rules/human-in-the-loop-decision-points.md
+++ b/.claude/rules/human-in-the-loop-decision-points.md
@@ -1,3 +1,7 @@
+---
+description: 5-class decision taxonomy — Classes A/B/C stop for the human; D/E proceed automatically
+---
+
 # Rule: Human-in-the-Loop Decision Points (Mandatory)
 
 ## Origin

--- a/.claude/rules/llm-portability-statement.md
+++ b/.claude/rules/llm-portability-statement.md
@@ -1,3 +1,7 @@
+---
+description: Visible lock-in inventory of Claude/Anthropic-specific dependencies (advisory, not a constraint)
+---
+
 # Rule: LLM Portability Statement (Advisory)
 
 ## When This Applies

--- a/.claude/rules/mermaid-dashboard-pattern.md
+++ b/.claude/rules/mermaid-dashboard-pattern.md
@@ -1,3 +1,7 @@
+---
+description: Mermaid in dashboards bypasses Quarto's loader — external JS module + mount divs, never mermaid chunks in tabsets
+---
+
 # Rule: Mermaid Diagrams in Dashboards (Mandatory, All Projects)
 
 ## When This Applies

--- a/.claude/rules/session-init-phases.md
+++ b/.claude/rules/session-init-phases.md
@@ -1,3 +1,7 @@
+---
+description: Phase inventory for session_init.sh — update the table in the same commit as any phase change
+---
+
 # Rule: session_init.sh Phase Inventory
 
 ## When This Applies

--- a/.claude/rules/uniform-typography.md
+++ b/.claude/rules/uniform-typography.md
@@ -1,3 +1,7 @@
+---
+description: One body font size everywhere in dashboards and vignettes — no per-element overrides
+---
+
 # Rule: Uniform Typography in Dashboards and Vignettes (Mandatory)
 
 ## When This Applies


### PR DESCRIPTION
Clears this morning's session-init Phase 2 warning:

```
Rules FM: WARN: 14 missing frontmatter: branch-harvest-on-fork.md cron-auto-pull-discipline.md ...
```

Adds the house 3-line YAML frontmatter block (`---` / `description: <one-liner>` / `---`) to all 14 rule files, matching the format of `accessibility.md` / `bash-safety.md`. No other content changed (56 insertions, 0 deletions).

Verification: the Phase 2 check loop (`head -1 | grep '^---$'`) now returns zero offenders across all rules.

Note: originally dispatched to a fixer agent, which was blocked by the `file_protection` hook on worktree `.claude/` paths — a recurrence of #572. Completed orchestrator-direct instead; evidence added to #572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
