### PR TITLE
feat(permissions): pre-approve file tools in ~/worktrees + /tmp (option B, #572 follow-up)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -302,7 +302,12 @@
       "WebFetch(domain:www.wesleyjohnson.co.uk)",
       "WebFetch(domain:www.which.co.uk)",
       "WebSearch",
-      "Write"
+      "Write",
+      "Edit(//Users/johngavin/worktrees/**)",
+      "Write(//Users/johngavin/worktrees/**)",
+      "NotebookEdit(//Users/johngavin/worktrees/**)",
+      "Edit(//tmp/**)",
+      "Write(//tmp/**)"
     ],
     "deny": [
       "Bash(rm -rf:*)",


### PR DESCRIPTION
Option B from the 2026-06-11 permission-stall analysis. Background agents cannot answer permission prompts, so every file-writing dispatch into a pre-created worktree stalled (4 of 6 dispatches that day). These five allow rules pre-approve Edit/Write/NotebookEdit ONLY under `~/worktrees/**` (the canonical worktree root per the worktree-location rule) and `/tmp/**` — the same zones `permission-discipline` already designates for `bypassPermissions`. Blast radius: worktree content is branch-isolated, PR-gated, and git-recoverable; main-checkout protection is unchanged. Pairs with #579 (file_protection worktree-aware), merged earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
