### PR TITLE
feat(#582): canonical worktree location → ~/docs_gh/worktrees/<project>/<branch>/

### DIFF
--- a/.claude/hooks/file_protection.sh
+++ b/.claude/hooks/file_protection.sh
@@ -193,7 +193,7 @@ case "$TARGET_PATH" in
         ;;
     esac
 
-    # (b) Linked worktree (session sibling, ~/worktrees/<proj>/<branch>/):
+    # (b) Linked worktree (session sibling, ~/docs_gh/worktrees/<proj>/<branch>/):
     #     its .claude/ is a branch COPY — edits land on that branch and ship
     #     via PR, never directly into the canonical config. A checkout is a
     #     linked worktree iff git-dir != git-common-dir. Only paths already

--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -132,7 +132,8 @@ phase_scope() {
 }
 
 # ── Phase 1e: Worktree-Parent CWD Detection (advisory) ───────────────
-# Detects when cwd is under ~/worktrees/<project>/ but is NOT itself a git
+# Detects when cwd is under a worktree-parent dir (~/docs_gh/worktrees/
+# canonical per llm#582, ~/worktrees/ legacy) but is NOT itself a git
 # worktree (only contains worktree subdirs). Lists active worktrees so the
 # user can cd into one, or back to the canonical main checkout.
 # See rule: worktree-location
@@ -140,7 +141,7 @@ phase_worktree_parent() {
   local cwd
   cwd=$(pwd 2>/dev/null) || return 0
   case "$cwd" in
-    "$HOME/worktrees"/*) : ;;
+    "$HOME/docs_gh/worktrees"/*|"$HOME/worktrees"/*) : ;;
     *) return 0 ;;
   esac
   # If we're in an actual git repo / worktree, Phase 7 handles it.
@@ -156,7 +157,7 @@ phase_worktree_parent() {
     found_any=1
   done < <(find "$cwd" -mindepth 1 -maxdepth 2 -type d 2>/dev/null)
   if [ "$found_any" -eq 0 ]; then
-    echo "WORKTREE-PARENT: cwd is under ~/worktrees/ but no active worktrees found here."
+    echo "WORKTREE-PARENT: cwd is a worktree-parent dir but no active worktrees found here."
     echo "  Try: cd ~/docs_gh/<project>/  (canonical main checkout)"
     return 0
   fi
@@ -166,7 +167,7 @@ phase_worktree_parent() {
   local proj
   proj=$(basename "$cwd")
   if [ -d "$HOME/docs_gh/$proj" ]; then
-    echo "  Either: cd ~/worktrees/$proj/<one above>"
+    echo "  Either: cd into one of the worktrees listed above"
     echo "      or: cd ~/docs_gh/$proj  (canonical main checkout)"
   fi
 }

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -72,7 +72,8 @@
 - Check CURRENT_WORK.md + git status + open issues at start
 
 ## Worktree Location Convention (see rules/worktree-location.md)
-- All new worktrees go under ~/worktrees/<project>/<branch>/ — NOT as siblings in ~/docs_gh/
+- All new worktrees go under ~/docs_gh/worktrees/<project>/<branch>/ (llm#582, decided 2026-06-12) — NOT as siblings in ~/docs_gh/
+- Legacy ~/worktrees/ is transitional read-only — existing worktrees finish their lifecycle there, no new ones
 - Use ~/.claude/scripts/cc-worktree.sh <project> <branch> [base] to create them
 - Harness-internal worktrees (.claude/worktrees/agent-*) are unaffected by this convention
 

--- a/.claude/rules/worktree-location.md
+++ b/.claude/rules/worktree-location.md
@@ -1,5 +1,5 @@
 ---
-description: Convention for where to create git worktrees — ~/worktrees/<project>/<branch>/ — and the cc-worktree.sh helper for programmatic enforcement
+description: Convention for where to create git worktrees — ~/docs_gh/worktrees/<project>/<branch>/ — and the cc-worktree.sh helper for programmatic enforcement
 ---
 # Rule: Worktree Location Convention
 
@@ -10,38 +10,50 @@ orchestrators, agents, and manual shell work. Convention is forward-looking —
 existing sibling worktrees are migrated as a separate follow-up, not as part of
 this rule.
 
-## CRITICAL: All New Worktrees Go Under `~/worktrees/<project>/<branch>/`
+## CRITICAL: All New Worktrees Go Under `~/docs_gh/worktrees/<project>/<branch>/`
 
 ## Why
 
 Sibling worktrees (`~/docs_gh/<proj>-<branch>/`) pollute the project-parent
 directory. When `ls ~/docs_gh/` grows to include `llm`, `llm-fix-foo`,
 `llm-feat-bar`, `mycare`, `mycare-fix-baz`, the signal-to-noise ratio
-collapses. `~/worktrees/` separates ephemeral workspaces from canonical
-checkouts.
+collapses. `~/docs_gh/worktrees/` separates ephemeral workspaces from canonical
+checkouts while keeping the whole docs_gh tree a single unit (one path to
+back up, find, and grep across all project worktrees — llm#582).
 
 Benefits:
 
-- `ls ~/docs_gh/` shows canonical repos only
-- `ls ~/worktrees/llm/` shows all active worktrees for one project
-- `ls ~/worktrees/` shows which projects have active worktrees
+- `ls ~/docs_gh/` shows canonical repos plus exactly one `worktrees/` dir
+- `ls ~/docs_gh/worktrees/llm/` shows all active worktrees for one project
+- `ls ~/docs_gh/worktrees/` shows which projects have active worktrees
+- Worktrees live next to the projects, not at home root — easier backup
+  and discovery
 - Path is off the project directory, so nix `default.nix` paths and
   `_targets.R` relative paths stay unambiguous
+
+## Transition (llm#582, decided 2026-06-12)
+
+The previous convention was `~/worktrees/<project>/<branch>/`. Existing
+worktrees there remain valid until they finish their lifecycle — do NOT
+mass-migrate live worktrees. No NEW worktrees go to the legacy base.
+`worktree_gc.sh` sweeps both bases; `cc.sh`'s worktree-parent redirect and
+session-init Phase 1e recognise both. The `~/worktrees/` references die
+with the last legacy worktree.
 
 ## Required Pattern
 
 ```bash
-# CORRECT: worktree goes under ~/worktrees/<project>/<branch>/
-git -C ~/docs_gh/llm worktree add ~/worktrees/llm/feat/fix-foo -b feat/fix-foo
+# CORRECT: worktree goes under ~/docs_gh/worktrees/<project>/<branch>/
+git -C ~/docs_gh/llm worktree add ~/docs_gh/worktrees/llm/feat/fix-foo -b feat/fix-foo
 
 # Using the wrapper script (preferred)
 ~/.claude/scripts/cc-worktree.sh llm feat/fix-foo
 ```
 
-The path form is always: `~/worktrees/<project-name>/<branch-name>/`
+The path form is always: `~/docs_gh/worktrees/<project-name>/<branch-name>/`
 
 Branch names with slashes are kept as-is in the path, e.g.
-`~/worktrees/llm/feat/fix-foo/` (the `feat/` prefix becomes a sub-directory).
+`~/docs_gh/worktrees/llm/feat/fix-foo/` (the `feat/` prefix becomes a sub-directory).
 
 ## Wrapper Script
 
@@ -49,7 +61,7 @@ Branch names with slashes are kept as-is in the path, e.g.
 
 - Resolves project path by searching under `~/docs_gh/` for a git repo root
   whose basename matches `<project-name>`
-- Creates worktree at `~/worktrees/<project-name>/<branch-name>/`
+- Creates worktree at `~/docs_gh/worktrees/<project-name>/<branch-name>/`
 - Calls `git worktree add -b <branch-name> <path> <base-branch>`
 - Re-applies overlays if `default.post.sh` exists in the new worktree
   (per `nix-agent-shell-protocol` rule)
@@ -64,8 +76,8 @@ See the script source at `.claude/scripts/cc-worktree.sh`.
 
 | Pattern | Why wrong | Fix |
 |---------|-----------|-----|
-| `git worktree add ../llm-feat-foo -b feat/foo` | Sibling pollutes `~/docs_gh/` listing | Use `~/worktrees/llm/feat/foo/` |
-| `git worktree add .claude/worktrees/agent-123` | Internal harness path, not for manual/orchestrator use | Use `~/worktrees/<project>/<branch>/` |
+| `git worktree add ../llm-feat-foo -b feat/foo` | Sibling pollutes `~/docs_gh/` listing | Use `~/docs_gh/worktrees/llm/feat/foo/` |
+| `git worktree add .claude/worktrees/agent-123` | Internal harness path, not for manual/orchestrator use | Use `~/docs_gh/worktrees/<project>/<branch>/` |
 | Relative worktree path | Breaks when cwd differs between creation and use | Always absolute path |
 | `cd ~/docs_gh/llm && git worktree add` | Compound-command ban — triggers hook rejection | `git -C ~/docs_gh/llm worktree add ...` |
 
@@ -76,7 +88,7 @@ See the script source at `.claude/scripts/cc-worktree.sh`.
 git -C ~/docs_gh/llm worktree list
 
 # Remove a finished worktree
-git -C ~/docs_gh/llm worktree remove ~/worktrees/llm/feat/fix-foo
+git -C ~/docs_gh/llm worktree remove ~/docs_gh/worktrees/llm/feat/fix-foo
 
 # Prune stale worktree references
 git -C ~/docs_gh/llm worktree prune
@@ -84,7 +96,7 @@ git -C ~/docs_gh/llm worktree prune
 
 ## Never start a session in the worktree-parent dir
 
-`~/worktrees/<project>/` (and `~/worktrees/<project>/feat/`, `.../fix/`, etc.)
+`~/docs_gh/worktrees/<project>/` (and `~/docs_gh/worktrees/<project>/feat/`, `.../fix/`, etc.)
 are parent directories, not checkouts. They contain no `.git`, no source code —
 only the actual worktrees nested beneath. Starting a Claude session there loads
 the full project context (via `additionalDirectories` in `settings.json`) plus
@@ -94,13 +106,13 @@ to nothing useful.
 Valid session-start cwds:
 
 - `~/docs_gh/<project>/` — canonical main checkout (default for everyday work)
-- `~/worktrees/<project>/<branch>/` — a specific worktree (only when deliberately
+- `~/docs_gh/worktrees/<project>/<branch>/` — a specific worktree (only when deliberately
   working on that branch in isolation)
 
 Two layers enforce this:
 
 1. **`cc.sh` auto-redirect (primary).** If launched anywhere under
-   `~/worktrees/<project>/` that is not a real worktree, the wrapper `cd`s to
+   `~/docs_gh/worktrees/<project>/` that is not a real worktree, the wrapper `cd`s to
    `~/docs_gh/<project>/` and prints a one-line note before exec'ing `claude`.
    Set `CC_NO_REDIRECT=1` to skip (rarely needed).
 2. **`session_init.sh` Phase 1e (backstop).** If a session somehow starts in a

--- a/.claude/scripts/cc-worktree.sh
+++ b/.claude/scripts/cc-worktree.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# cc-worktree.sh — Create a git worktree at ~/worktrees/<project>/<branch>/
+# cc-worktree.sh — Create a git worktree at ~/docs_gh/worktrees/<project>/<branch>/
 #
 # Usage: cc-worktree.sh [--dry-run] <project-name> <branch-name> [base-branch]
 #
@@ -10,8 +10,10 @@
 #   branch-name    Branch to create (will be created from base-branch)
 #   base-branch    Branch to base new branch on (default: main)
 #
-# Convention (worktree-location rule):
-#   All worktrees go under ~/worktrees/<project>/<branch>/
+# Convention (worktree-location rule, llm#582):
+#   All worktrees go under ~/docs_gh/worktrees/<project>/<branch>/
+#   (legacy location ~/worktrees/ is read-only transitional — no new
+#   worktrees are created there)
 #
 # Logs to: ~/.claude/logs/cc-worktree.log
 #
@@ -28,7 +30,7 @@ set -euo pipefail
 # ── Constants ──────────────────────────────────────────────────────────────────
 LOG_DIR="$HOME/.claude/logs"
 LOG_FILE="$LOG_DIR/cc-worktree.log"
-WORKTREES_BASE="$HOME/worktrees"
+WORKTREES_BASE="$HOME/docs_gh/worktrees"
 DOCS_BASE="$HOME/docs_gh"
 SEARCH_MAXDEPTH=3
 PROJECTS_CONF="${HOME}/.config/cc-worktree/projects.conf"

--- a/.claude/scripts/cc.sh
+++ b/.claude/scripts/cc.sh
@@ -450,11 +450,11 @@ offer_worktree() {
     y|Y) answer="feat/cc-$(date +%Y%m%d-%H%M%S)" ;;
   esac
 
-  # Central worktree location (worktree-location rule):
-  # ~/worktrees/<project>/<branch>/ — slashes in the branch name become
-  # sub-directories, so no sanitisation is needed.
+  # Central worktree location (worktree-location rule, llm#582):
+  # ~/docs_gh/worktrees/<project>/<branch>/ — slashes in the branch name
+  # become sub-directories, so no sanitisation is needed.
   local branch="$answer"
-  local wt_path="$HOME/worktrees/${repo_name}/${branch}"
+  local wt_path="$HOME/docs_gh/worktrees/${repo_name}/${branch}"
   mkdir -p "$(dirname "$wt_path")"
 
   if [ -d "$wt_path" ]; then
@@ -540,20 +540,23 @@ done
 # ---------------------------------------------------------------------------
 # Worktree-parent redirect
 # ---------------------------------------------------------------------------
-# If launched from anywhere under ~/worktrees/<proj>/ that is NOT itself a
-# git worktree (i.e. ~/worktrees/llm, ~/worktrees/llm/feat, etc.), redirect
-# to ~/docs_gh/<proj>/ (canonical main checkout). The parent dirs contain
-# no source code and starting there loads project context with no useful
-# cwd, wasting tokens. Set CC_NO_REDIRECT=1 to skip.
+# If launched from anywhere under a worktree-parent dir that is NOT itself a
+# git worktree (e.g. ~/docs_gh/worktrees/llm, ~/docs_gh/worktrees/llm/feat),
+# redirect to ~/docs_gh/<proj>/ (canonical main checkout). The parent dirs
+# contain no source code and starting there loads project context with no
+# useful cwd, wasting tokens. Set CC_NO_REDIRECT=1 to skip.
+# Covers the canonical base ~/docs_gh/worktrees/ (llm#582) AND the legacy
+# base ~/worktrees/ until existing worktrees migrate.
 if [ "${CC_NO_REDIRECT:-0}" != "1" ]; then
   case "$PWD" in
-    "$HOME/worktrees"/*)
+    "$HOME/docs_gh/worktrees"/*|"$HOME/worktrees"/*)
       if ! git rev-parse --git-dir >/dev/null 2>&1; then
-        _wp_rel="${PWD#$HOME/worktrees/}"
+        _wp_rel="${PWD#$HOME/docs_gh/worktrees/}"
+        [ "$_wp_rel" = "$PWD" ] && _wp_rel="${PWD#$HOME/worktrees/}"
         _wp_proj="${_wp_rel%%/*}"
         _wp_target="$HOME/docs_gh/$_wp_proj"
         if [ -d "$_wp_target/.git" ]; then
-          echo "cc: cwd was $PWD (under ~/worktrees/ but not a worktree)"
+          echo "cc: cwd was $PWD (under a worktree-parent dir but not a worktree)"
           echo "cc: redirecting to $_wp_target  (set CC_NO_REDIRECT=1 to skip)"
           cd "$_wp_target"
         else

--- a/.claude/scripts/worktree_gc.sh
+++ b/.claude/scripts/worktree_gc.sh
@@ -50,7 +50,10 @@ AGE_DAYS_AGENT="${AGE_DAYS_AGENT:-14}"         # harness agent worktrees (matche
 AGE_DAYS_CONVENTION="${AGE_DAYS_CONVENTION:-30}"  # ~/worktrees/*/* convention
 
 DOCS_GH="${DOCS_GH:-$HOME/docs_gh}"
-WORKTREES_BASE="${WORKTREES_BASE:-$HOME/worktrees}"
+# Canonical base (llm#582) + legacy base (transitional — existing worktrees
+# remain there until migrated; GC sweeps both).
+WORKTREES_BASE="${WORKTREES_BASE:-$HOME/docs_gh/worktrees}"
+WORKTREES_BASE_LEGACY="${WORKTREES_BASE_LEGACY:-$HOME/worktrees}"
 UNIFIED_DB="${UNIFIED_DB_PATH:-$HOME/.claude/logs/unified.duckdb}"
 LOG_FILE="$HOME/.claude/logs/worktree_gc.log"
 APPLY=0
@@ -60,6 +63,7 @@ SWEEP_PATTERNS=(
   "${DOCS_GH}/*-*|siblings"
   "${DOCS_GH}/*/.claude/worktrees/agent-*|agent"
   "${WORKTREES_BASE}/*/*/*|convention"
+  "${WORKTREES_BASE_LEGACY}/*/*/*|convention"
 )
 
 for arg in "$@"; do

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -306,6 +306,9 @@
       "Edit(//Users/johngavin/worktrees/**)",
       "Write(//Users/johngavin/worktrees/**)",
       "NotebookEdit(//Users/johngavin/worktrees/**)",
+      "Edit(//Users/johngavin/docs_gh/worktrees/**)",
+      "Write(//Users/johngavin/docs_gh/worktrees/**)",
+      "NotebookEdit(//Users/johngavin/docs_gh/worktrees/**)",
       "Edit(//tmp/**)",
       "Write(//tmp/**)"
     ],


### PR DESCRIPTION
Implements the location decision on #582 (user, 2026-06-12): canonical worktree base is **`~/docs_gh/worktrees/<project>/<branch>/`**.

## Changes

| Surface | Change |
|---|---|
| `cc-worktree.sh` | `WORKTREES_BASE` → new base; header comments updated |
| `cc.sh` `offer_worktree()` | session worktrees created at new base |
| `cc.sh` worktree-parent redirect | recognises new **and** legacy bases |
| `worktree_gc.sh` | sweep patterns cover both bases |
| `session_init.sh` Phase 1e | worktree-parent detection covers both bases |
| `settings.json` | #599 Edit/Write/NotebookEdit allowlist extended to new base (legacy retained) |
| `worktree-location` rule | paths updated + Transition section (no mass migration; legacy is read-only transitional) |
| `memory/MEMORY.md` | convention bullet updated |

## Transition policy

Existing worktrees under `~/worktrees/` finish their lifecycle in place — GC, redirects, and the permission allowlist keep handling them. No new worktrees are created there. Legacy handling is removed once that dir is empty.

## Verified

- `bash -n` on all touched scripts; `settings.json` parses
- `cc-worktree.sh --dry-run llm feat/582-smoke-test` → `mkdir -p /Users/johngavin/docs_gh/worktrees/llm/feat` + `git worktree add` at the new path

## Not in this PR (stays open on #582)

- Per-project tidiness session-init phase (the Phase 1f proposal in the issue)
- Removal of legacy-base handling (after `~/worktrees/` empties)
- `session-init-phases.md` row update if/when Phase 1f lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
