### PR TITLE
feat(#584): enforce color-scheme: dark — Clause 0 + mermaid Step 0 + global check script (8/8 selftest)

### DIFF
--- a/.claude/rules/accessibility.md
+++ b/.claude/rules/accessibility.md
@@ -56,6 +56,35 @@ format:
 
 ## Part 2: Dark Mode Completeness
 
+### Clause 0: `color-scheme: dark` is mandatory (supersedes all other clauses)
+
+Every dark-mode dashboard/vignette MUST include BOTH:
+
+```html
+<meta name="color-scheme" content="dark" />
+```
+
+```css
+:root, html, body { color-scheme: dark; }
+```
+
+Without this, **Chrome's "Auto Dark Mode for Web Contents" (default-on
+since v96, late 2021)** mis-classifies intentionally-dark pages as light
+and silently inverts the page's lightness — black backgrounds → white,
+deep palettes → pastels, in plots, tables AND diagrams. Safari/Edge/Brave
+are unaffected, so the breakage is Chrome-only and easy to miss.
+
+Worked example (premortem issue 0027): **5 merged iterations** fixed the
+wrong layer (mermaid theme override, CSS catch-all, vendored mermaid 10,
+per-diagram `%%{init}%%`, http-server workaround) before the meta tag was
+identified as the root cause. Check this clause FIRST, before any other
+dark-mode debugging.
+
+Verification: `~/.claude/scripts/check_dashboard_color_scheme.sh <dir>`
+(greps every rendered HTML for both signals; exit 1 on any miss). Wire it
+into the project's Quarto `post-render` alongside `check_dark_contrast.sh`.
+See llm#584.
+
 ### CRITICAL: Black = `#000000`. White = `#ffffff`.
 
 `var(--card-bg)`, `#16213e`, `#1a1a2e` are NOT black. They are dark blue.

--- a/.claude/rules/mermaid-dashboard-pattern.md
+++ b/.claude/rules/mermaid-dashboard-pattern.md
@@ -35,6 +35,24 @@ losing game. **Bypass it entirely.**
 
 ## The Six-Step Pattern
 
+### Step 0 — Page-level `color-scheme: dark` (check FIRST)
+
+The most common failure mode for Chrome dashboard diagrams is NOT mermaid
+theme inversion or CSS catch-all gaps; it's **Chrome's Auto Dark Mode for
+Web Contents** (default-on since v96) auto-inverting the whole page —
+black subgraphs render white, the palette goes pastel, and only in Chrome.
+Before spending ANY time on mermaid theme overrides or vendored bundles,
+verify the page declares:
+
+```html
+<meta name="color-scheme" content="dark" />
+```
+
+plus `:root, html, body { color-scheme: dark; }` in CSS. See
+`accessibility` rule Part 2 Clause 0 (origin: premortem issue 0027 — five
+merged iterations on the wrong layer). Automated check:
+`~/.claude/scripts/check_dashboard_color_scheme.sh <output-dir>` (llm#584).
+
 ### Step 1 — Use the external-module approach
 
 Create `<dashboard>/<your-diagrams>.js` modelled on the reference template

--- a/.claude/scripts/check_dashboard_color_scheme.sh
+++ b/.claude/scripts/check_dashboard_color_scheme.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# check_dashboard_color_scheme.sh — fail the build when a dark dashboard
+# is missing the `color-scheme: dark` declaration.
+#
+# Why: Chrome ships "Auto Dark Mode for Web Contents" enabled by default
+# since v96. Its heuristic mis-classifies intentionally-dark pages as
+# light and inverts the page's lightness (black backgrounds → white,
+# deep palettes → pastels) — in Chrome ONLY. The fix is declaring the
+# page's colour scheme so Chrome's auto-dark leaves it alone:
+#   <meta name="color-scheme" content="dark">   (head)
+#   :root { color-scheme: dark; }               (CSS, redundant belt)
+#
+# Origin: premortem issue 0027 (5 merged iterations on the wrong layer),
+# llm#584. See `accessibility` rule Part 2 Clause 0 and
+# `mermaid-dashboard-pattern` Step 0.
+#
+# Usage:
+#   check_dashboard_color_scheme.sh <dir>     # scan every *.html under <dir>
+#   check_dashboard_color_scheme.sh --selftest
+#
+# Wire into Quarto (_quarto.yml):
+#   project:
+#     post-render:
+#       - bash /Users/johngavin/docs_gh/llm/.claude/scripts/check_dashboard_color_scheme.sh docs
+#
+# Exit codes: 0 all HTML files carry both signals (or no HTML found);
+#             1 at least one file is missing a signal; 2 usage error.
+
+set -euo pipefail
+
+# Both greps are intentionally permissive about quoting and whitespace:
+#   meta:  name="color-scheme" ... content="dark"  (either attribute order)
+#   css:   color-scheme: dark  (with or without space, inline or stylesheet)
+META_RE='name=["'\'']color-scheme["'\''][^>]*content=["'\'']dark["'\'']|content=["'\'']dark["'\''][^>]*name=["'\'']color-scheme["'\'']'
+CSS_RE='color-scheme[[:space:]]*:[[:space:]]*dark'
+
+check_file() {
+  # Returns 0 when BOTH signals present, prints what is missing otherwise.
+  local f="$1" missing=""
+  grep -qiE "$META_RE" "$f" || missing="meta"
+  grep -qiE "$CSS_RE"  "$f" || missing="${missing:+$missing+}css"
+  if [ -n "$missing" ]; then
+    echo "MISSING(${missing}): $f"
+    return 1
+  fi
+  return 0
+}
+
+check_dir() {
+  local dir="$1" fails=0 total=0
+  if [ ! -d "$dir" ]; then
+    echo "check_dashboard_color_scheme: directory not found: $dir" >&2
+    return 2
+  fi
+  while IFS= read -r f; do
+    total=$((total + 1))
+    check_file "$f" || fails=$((fails + 1))
+  done < <(find "$dir" -name "*.html" -type f \
+             -not -path "*/site_libs/*" -not -path "*/_freeze/*" 2>/dev/null)
+  if [ "$total" -eq 0 ]; then
+    echo "check_dashboard_color_scheme: no HTML files under $dir — nothing to check"
+    return 0
+  fi
+  if [ "$fails" -gt 0 ]; then
+    echo ""
+    echo "check_dashboard_color_scheme: $fails of $total HTML file(s) missing color-scheme signals."
+    echo "Remediation (accessibility rule Part 2 Clause 0, llm#584):"
+    echo '  head:  <meta name="color-scheme" content="dark" />'
+    echo '  css:   :root, html, body { color-scheme: dark; }'
+    echo "Without these, Chrome's Auto Dark Mode silently inverts the page."
+    return 1
+  fi
+  echo "check_dashboard_color_scheme: OK — $total HTML file(s) declare color-scheme: dark"
+  return 0
+}
+
+selftest() {
+  local tmp pass=0 fail=0
+  tmp=$(mktemp -d /tmp/ccs_selftest_XXXXXX)
+
+  _case() { # name expected_rc dir
+    local name="$1" want="$2" dir="$3" got=0
+    check_dir "$dir" >/dev/null 2>&1 || got=$?
+    if [ "$got" = "$want" ]; then
+      pass=$((pass + 1)); echo "  PASS  $name"
+    else
+      fail=$((fail + 1)); echo "  FAIL  $name (want rc=$want got rc=$got)"
+    fi
+  }
+
+  # Good: both signals, double quotes
+  mkdir -p "$tmp/good"
+  cat > "$tmp/good/index.html" <<'HTML'
+<html><head><meta name="color-scheme" content="dark"></head>
+<body><style>:root, html, body { color-scheme: dark; }</style></body></html>
+HTML
+  _case "both signals present → 0" 0 "$tmp/good"
+
+  # Good: single quotes + spaced CSS
+  mkdir -p "$tmp/good2"
+  cat > "$tmp/good2/index.html" <<'HTML'
+<html><head><meta name='color-scheme' content='dark'></head>
+<body><style>html { color-scheme : dark; }</style></body></html>
+HTML
+  _case "single-quoted meta + spaced css → 0" 0 "$tmp/good2"
+
+  # Bad: meta missing
+  mkdir -p "$tmp/nometa"
+  cat > "$tmp/nometa/index.html" <<'HTML'
+<html><head></head><body><style>:root { color-scheme: dark; }</style></body></html>
+HTML
+  _case "meta missing → 1" 1 "$tmp/nometa"
+
+  # Bad: css missing
+  mkdir -p "$tmp/nocss"
+  cat > "$tmp/nocss/index.html" <<'HTML'
+<html><head><meta name="color-scheme" content="dark"></head><body></body></html>
+HTML
+  _case "css missing → 1" 1 "$tmp/nocss"
+
+  # Bad: one good + one bad file in same dir
+  mkdir -p "$tmp/mixed"
+  cp "$tmp/good/index.html" "$tmp/mixed/a.html"
+  cat > "$tmp/mixed/b.html" <<'HTML'
+<html><head></head><body></body></html>
+HTML
+  _case "one bad file among good → 1" 1 "$tmp/mixed"
+
+  # Neutral: site_libs excluded
+  mkdir -p "$tmp/libs/site_libs/bootstrap"
+  cat > "$tmp/libs/site_libs/bootstrap/junk.html" <<'HTML'
+<html><head></head><body>vendored</body></html>
+HTML
+  _case "site_libs excluded, no other HTML → 0" 0 "$tmp/libs"
+
+  # Neutral: empty dir
+  mkdir -p "$tmp/empty"
+  _case "no HTML files → 0" 0 "$tmp/empty"
+
+  # Usage: missing dir
+  _case "missing directory → 2" 2 "$tmp/does-not-exist"
+
+  rm -rf "$tmp"
+  echo ""
+  echo "check_dashboard_color_scheme selftest: ${pass} pass, ${fail} fail"
+  [ "$fail" -eq 0 ]
+}
+
+case "${1:-}" in
+  --selftest) selftest ;;
+  "")         echo "usage: $(basename "$0") <output-dir> | --selftest" >&2; exit 2 ;;
+  *)          check_dir "$1" ;;
+esac


### PR DESCRIPTION
Implements the llm-side scope of #584 (user authorised 2026-06-12: "dark mode should be enforced including the background colour in plots, tables and diagrams").

## The lesson this enforces

Chrome ships **Auto Dark Mode for Web Contents enabled by default since v96** (late 2021). Its heuristic mis-classifies intentionally-dark pages as light and inverts the page's lightness — black subgraph backgrounds → white, deep palettes → pastels, across plots, tables and diagrams. Safari/Edge/Brave are unaffected, so the breakage is Chrome-only. Premortem issue 0027 burned **5 merged iterations** on the wrong layers before the root cause was found. The fix is `<meta name="color-scheme" content="dark">` + `:root { color-scheme: dark; }`.

## Changes (acceptance items 1–3)

1. **`accessibility.md` Part 2 — Clause 0** (the consolidated home of the former `dark-mode-completeness` rule): the meta + CSS declaration is mandatory and supersedes all other dark-mode clauses; includes the 0027 worked example and verification command.
2. **`mermaid-dashboard-pattern.md` — Step 0** sign-post: check the page-level declaration before any mermaid theme debugging.
3. **`~/.claude/scripts/check_dashboard_color_scheme.sh`**: scans every `*.html` under a directory (excluding `site_libs/`, `_freeze/`) for both signals — meta in either attribute order/quote style, CSS with/without spaces — exits 1 with a remediation message on any miss. `--selftest` synthesises good/bad/mixed/excluded cases: **8/8 PASS**. Wire via Quarto `post-render` alongside `check_dark_contrast.sh`.

## Remaining acceptance items (not this PR)

- **Project wiring demo** (item 4): premortem already runs its project-local equivalent end-to-end (Phase 1 closed at premortem `01de734`, per the issue comment). Switching premortem to this global script is own-tree premortem work — next premortem session.
- **Phase 2 PostToolUse hook** (item 5, optional): design exists in the issue; defer per the issue's own recommendation until the post-render pattern proves insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
