### PR TITLE
fix(#596): launchd crons use GC-rooted nix drv — no runtime network

### DIFF
--- a/.claude/scripts/nix_gcroot_refresh.sh
+++ b/.claude/scripts/nix_gcroot_refresh.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# nix_gcroot_refresh.sh — keep a GC-rooted store derivation for a project's
+# nix shell so launchd crons can run `nix-shell <drv>` with ZERO evaluation
+# and ZERO network (llm#596).
+#
+# Why: default.nix pins nixpkgs via an unhashed fetchTarball URL. Evaluating
+# it (any plain `nix-shell default.nix` call) re-downloads the tarball once
+# the tarball TTL lapses — and the launchd environment cannot resolve
+# github.com, so kb_digest/config_digest crons died before doing any work.
+# Instantiating once (here, where network is available) and GC-rooting both
+# the .drv and its realized outputs removes evaluation from cron runtime.
+#
+# Usage: nix_gcroot_refresh.sh [/abs/path/to/default.nix] [--force]
+#   default nix file: /Users/johngavin/docs_gh/llm/default.nix
+#   Skips work when the drv root is newer than the nix file (unless --force).
+# Exit 0 = root fresh or refreshed (or stale-but-usable after a failed
+# refresh); exit 1 = no usable root exists and refresh failed.
+#
+# Callers: bin/kb_digest_daily_cron.sh, bin/config_digest_cron.sh (best-effort
+# pre-step); safe to run interactively after editing default.nix.
+set -euo pipefail
+
+NIX_FILE="/Users/johngavin/docs_gh/llm/default.nix"
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+        *) NIX_FILE="$arg" ;;
+    esac
+done
+
+GCROOT_DIR="${HOME}/.claude/nix-gcroots"
+LOG_FILE="${HOME}/.claude/logs/nix_gcroot_refresh.log"
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$LOG_FILE"; }
+
+if [ ! -f "$NIX_FILE" ]; then
+    log "ERROR: nix file not found: $NIX_FILE"
+    echo "nix_gcroot_refresh: nix file not found: $NIX_FILE" >&2
+    exit 1
+fi
+
+# Root name derived from the project directory: .../llm/default.nix -> llm-shell
+PROJECT="$(basename "$(dirname "$NIX_FILE")")"
+DRV_ROOT="${GCROOT_DIR}/${PROJECT}-shell.drv"
+OUT_ROOT="${GCROOT_DIR}/${PROJECT}-shell-out"
+# Freshness stamp: the drv root is a symlink into /nix/store where every file
+# has mtime=1970, so `-nt` against the root itself always reads stale. The
+# stamp is touched after each successful refresh and carries the real time.
+STAMP="${DRV_ROOT}.stamp"
+
+mkdir -p "$GCROOT_DIR"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# Fresh enough? (stamp newer than the nix file that produced the drv)
+if [ "$FORCE" -eq 0 ] && [ -e "$DRV_ROOT" ] && [ -e "$STAMP" ] && [ "$STAMP" -nt "$NIX_FILE" ]; then
+    log "fresh: $STAMP newer than $NIX_FILE — skipping"
+    echo "$DRV_ROOT"
+    exit 0
+fi
+
+log "refresh: instantiating $NIX_FILE -A shell (root: $DRV_ROOT)"
+if nix-instantiate "$NIX_FILE" -A shell --indirect --add-root "$DRV_ROOT" >> "$LOG_FILE" 2>&1; then
+    log "refresh: instantiate OK"
+    if nix-store --realise "$DRV_ROOT" --indirect --add-root "$OUT_ROOT" >> "$LOG_FILE" 2>&1; then
+        log "refresh: realise OK (outputs rooted at $OUT_ROOT)"
+    else
+        log "WARN: realise failed — drv rooted but outputs unprotected against GC"
+    fi
+    touch "$STAMP"
+    echo "$DRV_ROOT"
+    exit 0
+fi
+
+# Instantiate failed (typically: no network for the fetchTarball)
+if [ -e "$DRV_ROOT" ]; then
+    log "WARN: refresh failed — keeping existing (possibly stale) root $DRV_ROOT"
+    echo "$DRV_ROOT"
+    exit 0
+fi
+log "ERROR: refresh failed and no existing root at $DRV_ROOT"
+echo "nix_gcroot_refresh: refresh failed, no usable root" >&2
+exit 1

--- a/bin/config_digest_cron.sh
+++ b/bin/config_digest_cron.sh
@@ -113,6 +113,32 @@ if ! command -v nix-shell > /dev/null 2>&1; then
   exit 1
 fi
 
+# ── Resolve nix target: GC-rooted drv preferred (llm#596) ─────────────────────
+# Evaluating ${LLM_NIX} re-fetches the unhashed nixpkgs tarball once the
+# tarball TTL lapses; the launchd environment cannot resolve github.com, so
+# the job dies before doing any work. `nix-shell <drv>` skips evaluation
+# entirely — no network at runtime. The drv root is maintained by
+# .claude/scripts/nix_gcroot_refresh.sh (best-effort refresh below; a stale
+# root still runs the previously-pinned shell, which beats dying).
+GCROOT_DRV="${HOME}/.claude/nix-gcroots/llm-shell.drv"
+GCROOT_STAMP="${GCROOT_DRV}.stamp"
+# Freshness compares against the .stamp file, NOT the drv symlink — store
+# paths have mtime=1970 so the symlink always reads stale.
+if [ ! -e "${GCROOT_DRV}" ] || [ ! -e "${GCROOT_STAMP}" ] || [ "${LLM_NIX}" -nt "${GCROOT_STAMP}" ]; then
+  "${REPO_ROOT}/.claude/scripts/nix_gcroot_refresh.sh" "${LLM_NIX}" >> "${LOG_FILE}" 2>&1 || true
+fi
+if [ -e "${GCROOT_DRV}" ]; then
+  NIX_TARGET="${GCROOT_DRV}"
+  if [ -e "${GCROOT_STAMP}" ] && [ "${LLM_NIX}" -nt "${GCROOT_STAMP}" ]; then
+    log "nix WARN: gcroot stale — running stale-but-cached shell (llm#596)"
+  else
+    log "nix: using GC-rooted drv (no network needed)"
+  fi
+else
+  NIX_TARGET="${LLM_NIX}"
+  log "nix WARN: no gcroot — falling back to nix-shell evaluation (needs network, llm#596)"
+fi
+
 # ── DuckDB availability check (llm#552) ───────────────────────────────────────
 # Gracefully skip all DB writes when duckdb binary or unified.duckdb is absent.
 # Same defensive pattern as worktree_gc.sh.
@@ -160,13 +186,17 @@ if [ -z "${SINCE}" ]; then
 fi
 log "  since=${SINCE}"
 
-nix-shell "${LLM_NIX}" --run \
+nix-shell "${NIX_TARGET}" --run \
   "Rscript '${AGGREGATOR}' --since '${SINCE}' --out '${DIGEST_PATH}'" \
   >> "${LOG_FILE}" 2>&1
 STEP1_EXIT=$?
 
+_step1_failed=0
 if [ "${STEP1_EXIT}" -ne 0 ]; then
   log "WARNING: config_change_digest.R exited ${STEP1_EXIT} — continuing"
+  # Final housekeeping_runs row must not read 'ok' when the digest step
+  # failed (llm#596 item 3) — Step 3 downgrades it to 'partial'.
+  _step1_failed=1
 fi
 log "Step 1 done (exit=${STEP1_EXIT})"
 
@@ -255,7 +285,7 @@ if [ ! -f "${EMAIL_SCRIPT}" ]; then
   exit 1
 fi
 
-nix-shell "${LLM_NIX}" --run \
+nix-shell "${NIX_TARGET}" --run \
   "CONFIG_DIGEST_PATH='${DIGEST_PATH}' CONFIG_DIGEST_SINCE='${SINCE}' Rscript '${EMAIL_SCRIPT}'" \
   >> "${LOG_FILE}" 2>&1
 STEP2_EXIT=$?
@@ -280,13 +310,16 @@ log "Step 2 done"
 # ── Step 3: Update housekeeping_runs end row ──────────────────────────────────
 if [ "${_duckdb_ok}" = "1" ]; then
   _run_ended="$(python3 -c 'import datetime; print(datetime.datetime.utcnow().isoformat() + "Z")')"
+  _final_status="ok"
+  [ "${_step1_failed}" = "1" ] && _final_status="partial"
   duckdb "${UNIFIED_DB}" "
     UPDATE housekeeping_runs
     SET ended_at = TIMESTAMPTZ '${_run_ended}',
+        status = '${_final_status}',
         rows_written = ${_EVENTS_WRITTEN}
     WHERE id = '${_run_id}';
   " 2>/dev/null || log "duckdb WARN: housekeeping_runs UPDATE failed (non-fatal)"
-  log "Step 3: housekeeping_runs updated (rows_written=${_EVENTS_WRITTEN})"
+  log "Step 3: housekeeping_runs updated (status=${_final_status} rows_written=${_EVENTS_WRITTEN})"
 fi
 
 log "=== config_digest_cron.sh done ==="

--- a/bin/kb_digest_daily_cron.sh
+++ b/bin/kb_digest_daily_cron.sh
@@ -134,6 +134,32 @@ if ! command -v nix-shell > /dev/null 2>&1; then
   exit 1
 fi
 
+# ── Resolve nix target: GC-rooted drv preferred (llm#596) ─────────────────────
+# Evaluating ${LLM_NIX} re-fetches the unhashed nixpkgs tarball once the
+# tarball TTL lapses; the launchd environment cannot resolve github.com, so
+# the job dies before doing any work. `nix-shell <drv>` skips evaluation
+# entirely — no network at runtime. The drv root is maintained by
+# .claude/scripts/nix_gcroot_refresh.sh (best-effort refresh below; a stale
+# root still runs the previously-pinned shell, which beats dying).
+GCROOT_DRV="${HOME}/.claude/nix-gcroots/llm-shell.drv"
+GCROOT_STAMP="${GCROOT_DRV}.stamp"
+# Freshness compares against the .stamp file, NOT the drv symlink — store
+# paths have mtime=1970 so the symlink always reads stale.
+if [ ! -e "${GCROOT_DRV}" ] || [ ! -e "${GCROOT_STAMP}" ] || [ "${LLM_NIX}" -nt "${GCROOT_STAMP}" ]; then
+  "${REPO_ROOT}/.claude/scripts/nix_gcroot_refresh.sh" "${LLM_NIX}" >> "${LOG_FILE}" 2>&1 || true
+fi
+if [ -e "${GCROOT_DRV}" ]; then
+  NIX_TARGET="${GCROOT_DRV}"
+  if [ -e "${GCROOT_STAMP}" ] && [ "${LLM_NIX}" -nt "${GCROOT_STAMP}" ]; then
+    log "nix WARN: gcroot stale — running stale-but-cached shell (llm#596)"
+  else
+    log "nix: using GC-rooted drv (no network needed)"
+  fi
+else
+  NIX_TARGET="${LLM_NIX}"
+  log "nix WARN: no gcroot — falling back to nix-shell evaluation (needs network, llm#596)"
+fi
+
 # ── DuckDB availability check (llm#553) ───────────────────────────────────────
 # Gracefully skip all DB writes when duckdb binary or unified.duckdb is absent.
 # Same defensive pattern as config_digest_cron.sh (merged via #566).
@@ -190,7 +216,7 @@ fi
 log "  since=${SINCE}"
 
 if [ "${DRYRUN}" = "1" ]; then
-  log "  DRYRUN: would run nix-shell ${LLM_NIX} --run 'Rscript ${DIGEST_SCRIPT}'"
+  log "  DRYRUN: would run nix-shell ${NIX_TARGET} --run 'Rscript ${DIGEST_SCRIPT}'"
   # Create minimal stub for email script to consume
   printf '## Knowledge Base Digest — %s\n\n_DRYRUN mode — no actual KB analysis performed._\n' \
     "$(date +%Y-%m-%d)" > "${DIGEST_TMPFILE}"
@@ -199,7 +225,7 @@ else
   SINCE_ARG=""
   [ -n "${KB_SINCE}" ] && SINCE_ARG="--since ${KB_SINCE}"
 
-  nix-shell "${LLM_NIX}" --run \
+  nix-shell "${NIX_TARGET}" --run \
     "Rscript '${DIGEST_SCRIPT}' --knowledge-repo '${KB_KNOWLEDGE_REPO}' ${SINCE_ARG} --out '${DIGEST_TMPFILE}'" \
     >> "${LOG_FILE}" 2>&1
   STEP1_EXIT=$?
@@ -317,16 +343,16 @@ if [ ! -f "${EMAIL_SCRIPT}" ]; then
 fi
 
 if [ "${DRYRUN}" = "1" ]; then
-  log "  DRYRUN: would run nix-shell ${LLM_NIX} --run 'Rscript ${EMAIL_SCRIPT}'"
+  log "  DRYRUN: would run nix-shell ${NIX_TARGET} --run 'Rscript ${EMAIL_SCRIPT}'"
   STEP2_EXIT=0
 elif [ "${EMAIL_DRY_RUN}" = "1" ]; then
   log "  EMAIL_DRY_RUN=1: running script in dry-run mode (body to stdout only)"
   KB_DIGEST_FILE="${DIGEST_TMPFILE}" \
-    nix-shell "${LLM_NIX}" --run "Rscript '${EMAIL_SCRIPT}'" >> "${LOG_FILE}" 2>&1
+    nix-shell "${NIX_TARGET}" --run "Rscript '${EMAIL_SCRIPT}'" >> "${LOG_FILE}" 2>&1
   STEP2_EXIT=$?
 else
   KB_DIGEST_FILE="${DIGEST_TMPFILE}" \
-    nix-shell "${LLM_NIX}" --run "Rscript '${EMAIL_SCRIPT}'" >> "${LOG_FILE}" 2>&1
+    nix-shell "${NIX_TARGET}" --run "Rscript '${EMAIL_SCRIPT}'" >> "${LOG_FILE}" 2>&1
   STEP2_EXIT=$?
 fi
 


### PR DESCRIPTION
## Root cause (#596)

`default.nix:18` pins nixpkgs with an unhashed `fetchTarball` URL. Any `nix-shell default.nix` call re-evaluates and — once the tarball TTL lapses — re-downloads the tarball. The launchd environment cannot resolve `github.com` ("Could not resolve host" in `kb_digest.log`), so kb_digest failed 06-09/10/11 and config_digest failed 06-10 before doing any work.

## Fix (issue direction 2: exec the resolved derivation, no evaluation)

- **`.claude/scripts/nix_gcroot_refresh.sh`** (new): `nix-instantiate default.nix -A shell --indirect --add-root ~/.claude/nix-gcroots/llm-shell.drv`, then `nix-store --realise --add-root …-out` so outputs survive GC without `keep-outputs`. A `.stamp` file carries freshness — store paths have mtime=1970, so `-nt` against the symlink always reads stale. A failed refresh (no network) keeps the prior root: stale-but-cached beats dying.
- **Both cron wrappers**: best-effort refresh, then `NIX_TARGET` = the GC-rooted drv when present (`nix-shell <drv>` performs **zero evaluation and zero network**); falls back to `default.nix` evaluation with a WARN when no root exists.
- **config_digest** (issue item 3): a Step-1 digest failure now downgrades the final `housekeeping_runs` row to `status='partial'` (previously ended `'ok'`); the Step-2 `'failed'` path was already correct, mirroring kb_digest.

## Verification

- `nix-shell ~/.claude/nix-gcroots/llm-shell.drv --run 'Rscript --version'` → R 4.5.2, no "unpacking" line (validated interactively before authoring)
- refresh script: fresh-skip and re-instantiate paths both exercised (log lines in `nix_gcroot_refresh.log`)
- `SKIP_CRON_PULL=1 DRYRUN=1 bash bin/kb_digest_daily_cron.sh` → exit 0, logs `nix: using GC-rooted drv (no network needed)`, both DRYRUN lines show the drv target
- `bash -n` on all three files
- config_digest has no DRYRUN mode; changes are the same mechanical pattern as kb_digest + the status downgrade

Process note: a fixer dispatch for this task died in autocompact thrash (third dispatch failure today — evidence logged on #590), so this shipped via orchestrator worktree per pivot-signal.

Refs #596, #553, #552, #510, #590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
