### PR TITLE
fix(#620): add mandatory Step 8b pkgdown deploy to 9-step PR workflow

### DIFF
--- a/.claude/skills/r-package-workflow/SKILL.md
+++ b/.claude/skills/r-package-workflow/SKILL.md
@@ -163,9 +163,19 @@ usethis::pr_push()
 *   `usethis::pr_merge_main()`
 *   `usethis::pr_finish()`
 
+### Step 8b: Deploy pkgdown site (MANDATORY — do not skip)
+**Goal:** Keep deployed docs in sync with `main`. Docs that are not deployed are invisible to users.
+*   `pkgdown::build_site()` — rebuild locally
+*   CI job (`.github/workflows/pkgdown.yml`) triggers automatically on merge to `main` once set up via `usethis::use_pkgdown_github_pages()`
+*   Spot-check 3 article URLs return HTTP 200 after deploy
+*   If CI job not yet configured: push `docs/` manually — `git -C <repo> subtree push --prefix docs origin gh-pages`
+*   See `pkgdown-deployment` skill for full setup and CI workflow template
+*   **Block issue close until deploy verified.** A 404 on a recently merged article is a deployment failure, not a cosmetic issue.
+
 ### Step 9: Verify & Cleanup
 **Goal:** Close loop.
 *   Verify issue is closed.
+*   Verify pkgdown site deployed — check at least the article added/changed in this PR returns HTTP 200.
 *   Delete log file (optional, or archive it).
 
 ## File Organization
@@ -193,6 +203,7 @@ package/
 *   **`quality-gates`**: Steps 4/6/8 scoring — Bronze (commit), Silver (PR), Gold (merge). Run `tar_make(names = starts_with("qa_"))` and check grade via `tar_read(qa_quality_gate)$grade`.
 *   **`systematic-debugging`**: Step 5 failure handling.
 *   **`nix-rix-r-environment`**: The required execution environment.
+*   **`pkgdown-deployment`**: Step 8b — build and deploy pkgdown site to gh-pages after every merge.
 
 ## Quality Gate Integration
 


### PR DESCRIPTION
## Summary

- Closes #620 — fatal workflow gap: pkgdown deployment was absent from all 9 steps of the `r-package-workflow` skill
- Inserts **Step 8b** (MANDATORY — do not skip) between Step 8 (Merge) and Step 9 (Verify & Cleanup)
- Updates Step 9 to include a pkgdown HTTP 200 spot-check as part of the cleanup loop
- Adds `pkgdown-deployment` to the Related Skills section

## What was missing

The 9-step PR workflow had no mention of pkgdown deployment anywhere. Every merged PR left deployed docs potentially out of sync with `main`. The gap was silent — no CI failure, no warning, just stale docs.

## What Step 8b requires

1. `pkgdown::build_site()` locally before declaring done
2. CI job (`.github/workflows/pkgdown.yml`) via `usethis::use_pkgdown_github_pages()` — triggers automatically on merge once configured
3. Spot-check 3 article URLs return HTTP 200 after deploy
4. Manual fallback (`git subtree push`) if CI job not yet configured
5. **Block issue close until deploy verified** — a 404 on a recently merged article is a deployment failure, not cosmetic

## Test plan

- [ ] Read Step 8b in the updated SKILL.md and confirm it is clear and actionable
- [ ] Confirm Step 9 now includes the pkgdown HTTP 200 check
- [ ] Confirm Related Skills includes `pkgdown-deployment`
- [ ] Verify the step is placed correctly between Step 8 and Step 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)