### PR TITLE
chore(skills): replace hardcoded model IDs with tier-role comments

### DIFF
--- a/.claude/skills/claude-api/SKILL.md
+++ b/.claude/skills/claude-api/SKILL.md
@@ -48,7 +48,7 @@ PAYLOAD=$(jq -n \
     --arg system_text "$SYSTEM_TEXT" \
     --arg user_content "$DYNAMIC_INPUT" \
     '{
-        model: "claude-opus-4-7",
+        model: "claude-opus-4-7",  # orchestrator-tier — check auto-delegation rule'"'"'s Model Tier Lookup for latest ID
         max_tokens: 2048,
         system: [
             {
@@ -83,7 +83,7 @@ client = anthropic.Anthropic()
 SYSTEM_INSTRUCTIONS = "You are a code reviewer. <long static block ...>"
 
 response = client.messages.create(
-    model="claude-opus-4-7",
+    model="claude-opus-4-7",  # orchestrator-tier — check auto-delegation rule's Model Tier Lookup for latest ID
     max_tokens=2048,
     system=[
         {
@@ -110,7 +110,7 @@ library(httr2)
 SYSTEM_TEXT <- "You are a code reviewer. <long static block ...>"
 
 payload <- list(
-  model = "claude-opus-4-7",
+  model = "claude-opus-4-7",  # orchestrator-tier — check auto-delegation rule's Model Tier Lookup for latest ID
   max_tokens = 2048L,
   system = list(
     list(
@@ -163,6 +163,7 @@ When upgrading Claude models:
 
 | Old model | New model | Notes |
 |-----------|-----------|-------|
+| _For current IDs_ | _See `auto-delegation` rule's Model Tier Lookup table_ | _Single source of truth_ |
 | `claude-opus-4-5-20251101` | `claude-opus-4-7` | Drop date suffix; shorter ID |
 | `claude-sonnet-4-5-20251015` | `claude-sonnet-4-6` | Drop date suffix |
 | `claude-haiku-4-5-20251001` | `claude-haiku-4-6` | Drop date suffix |

--- a/.claude/skills/knowledge-base-wiki/SKILL.md
+++ b/.claude/skills/knowledge-base-wiki/SKILL.md
@@ -139,7 +139,7 @@ consensus_level: strong                  # unanimous | strong | split | divergen
 sources:
   - flirting-with-models-faheem-osman-commodity-qis.md
   - flirting-with-models-gerald-rushton-commodity-strategies.md
-compiled_by: claude-opus-4-6
+compiled_by: orchestrator-tier  # do not hardcode model IDs — see auto-delegation rule
 compiled_on: 2026-04-09
 ---
 ```


### PR DESCRIPTION
## Summary

Companion to auto-delegation.md model tier rewrite. Adds tier comments to code examples in claude-api and knowledge-base-wiki skills. Model IDs stay (they're valid API values) but are annotated with their tier role and a pointer to the lookup table.

- `.claude/skills/claude-api/SKILL.md`: added `# orchestrator-tier — check auto-delegation rule's Model Tier Lookup for latest ID` comment to all three code-block model lines (bash/jq, Python SDK, R httr2); added a note row at the top of the Model Version Migration table pointing to the lookup table
- `.claude/skills/knowledge-base-wiki/SKILL.md`: changed `compiled_by: claude-opus-4-6` in the YAML frontmatter example to `compiled_by: orchestrator-tier  # do not hardcode model IDs — see auto-delegation rule`

## Test plan

- [ ] Confirm diff is limited to the two SKILL.md files
- [ ] No code or hook behaviour changed — skill files are markdown only
- [ ] Verify comments render correctly in the skill files