### PR TITLE
fix(skill): replace remaining template URL in api-design-patterns.md

### DIFF
--- a/.claude/skills/static-api-deployment/references/api-design-patterns.md
+++ b/.claude/skills/static-api-deployment/references/api-design-patterns.md
@@ -76,7 +76,7 @@ Every JSON response includes `_meta`:
 
 ```r
 api_envelope <- function(data, endpoint_name, api_version = "v1") {
-  base_url <- "https://johngavin.github.io/llm/api"
+  base_url <- "https://<owner>.github.io/<repo>/api"
   list(
     `_meta` = list(
       api_version = api_version,


### PR DESCRIPTION
Companion to #624. Replaces base_url johngavin.github.io/llm/api (line 79) with <owner>.github.io/<repo>/api — illustrative template URL, endpoint does not exist.