### PR TITLE
feat(cron): nightly skill usage ETL → unified.duckdb

### DIFF
--- a/.claude/launchd/com.claude.skill-usage-etl.plist
+++ b/.claude/launchd/com.claude.skill-usage-etl.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.claude.skill-usage-etl.plist
+     Nightly ETL: parse conversation JSONL → skill_usage table in unified.duckdb.
+     Runs at 03:30 local time — after roborev-metrics-etl (02:00) and
+     unified-duckdb-backup (03:00), before any morning read jobs.
+
+     Install:
+       cp ~/.claude/launchd/com.claude.skill-usage-etl.plist \
+          ~/Library/LaunchAgents/com.claude.skill-usage-etl.plist
+       launchctl load ~/Library/LaunchAgents/com.claude.skill-usage-etl.plist
+
+     Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.claude.skill-usage-etl.plist
+       rm ~/Library/LaunchAgents/com.claude.skill-usage-etl.plist
+
+     Manual dry-run:
+       ~/.claude/scripts/skill_usage_etl.sh
+
+     Manual apply:
+       ~/.claude/scripts/skill_usage_etl.sh --apply
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.skill-usage-etl</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/.claude/scripts/skill_usage_etl.sh</string>
+        <string>--apply</string>
+    </array>
+
+    <!-- Nightly at 03:30 local time -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/skill_usage_etl.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/skill_usage_etl.log</string>
+
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+</dict>
+</plist>

--- a/.claude/scripts/skill_usage_etl.R
+++ b/.claude/scripts/skill_usage_etl.R
@@ -1,0 +1,147 @@
+#!/usr/bin/env Rscript
+# skill_usage_etl.R — parse ~/.claude/projects/**/*.jsonl for Skill tool calls
+# and write per-session-skill counts to unified.duckdb (skill_usage table).
+#
+# Args:
+#   --apply              write to DB (default: dry-run)
+#   --since YYYY-MM-DD   only scan JSONL files modified on or after this date
+#                        (default: yesterday)
+#   --db PATH            path to DuckDB file
+#                        (default: ~/.claude/logs/unified.duckdb)
+#   --all                scan ALL JSONL files regardless of mtime
+#
+# Schema (skill_usage table):
+#   session_id   TEXT    — UUID from JSONL filename
+#   session_date DATE    — date of first timestamped message in session
+#   project      TEXT    — decoded project path from directory name
+#   skill_name   TEXT    — value of Skill tool input.skill
+#   invocations  INTEGER — count of Skill calls for this skill in this session
+#   etl_run_at   TIMESTAMP
+
+suppressPackageStartupMessages({
+  library(jsonlite)
+  library(dplyr)
+  library(duckdb)
+  library(purrr)
+  library(fs)
+  library(tibble)
+})
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+args      <- commandArgs(trailingOnly = TRUE)
+dry_run   <- !"--apply" %in% args
+scan_all  <- "--all" %in% args
+since_idx <- which(args == "--since") + 1
+since     <- if (length(since_idx) > 0 && since_idx <= length(args))
+               as.Date(args[since_idx]) else Sys.Date() - 1
+db_idx    <- which(args == "--db") + 1
+db_path   <- if (length(db_idx) > 0 && db_idx <= length(args))
+               args[db_idx] else path.expand("~/.claude/logs/unified.duckdb")
+
+projects_dir <- path.expand("~/.claude/projects")
+
+# ── Discover JSONL files ───────────────────────────────────────────────────────
+jsonl_files <- dir_ls(projects_dir, recurse = TRUE, glob = "*.jsonl")
+if (!scan_all) {
+  mtimes <- file_info(jsonl_files)$modification_time
+  jsonl_files <- jsonl_files[!is.na(mtimes) & mtimes >= as.POSIXct(since)]
+}
+cat(sprintf("Scanning %d JSONL files (since %s, scan_all=%s)\n",
+            length(jsonl_files), since, scan_all))
+
+# ── Parse one file ────────────────────────────────────────────────────────────
+parse_file <- function(path) {
+  lines <- tryCatch(readLines(path, warn = FALSE), error = function(e) character())
+  if (!length(lines)) return(NULL)
+
+  project_enc <- basename(dirname(as.character(path)))
+  # Decode directory name: leading "-" removed, remaining "-" → "/" except within
+  # UUID segments. Simple heuristic: replace leading hyphen-Users with /Users.
+  project <- sub("^-", "/", gsub("-", "/", project_enc))
+
+  session_id <- tools::file_path_sans_ext(basename(as.character(path)))
+
+  # Find the first timestamp in the file for session_date
+  session_date <- NA_character_
+  skill_rows   <- list()
+
+  for (line in lines) {
+    msg <- tryCatch(fromJSON(line, simplifyVector = FALSE), error = function(e) NULL)
+    if (is.null(msg)) next
+
+    if (is.na(session_date) && !is.null(msg$timestamp)) {
+      session_date <- substr(msg$timestamp, 1, 10)
+    }
+
+    if (!identical(msg$type, "assistant")) next
+    content <- msg$message$content
+    if (!is.list(content)) next
+
+    for (block in content) {
+      if (!identical(block$type, "tool_use")) next
+      if (!identical(block$name, "Skill"))    next
+      sn <- block$input$skill
+      if (is.null(sn) || !nzchar(sn)) sn <- "unknown"
+      skill_rows[[length(skill_rows) + 1]] <- sn
+    }
+  }
+
+  if (!length(skill_rows)) return(NULL)
+
+  sd <- tryCatch(as.Date(session_date), error = function(e) Sys.Date())
+  if (is.na(sd)) sd <- Sys.Date()
+
+  tibble(
+    session_id   = session_id,
+    session_date = sd,
+    project      = project,
+    skill_name   = unlist(skill_rows)
+  )
+}
+
+# ── Run over all files ─────────────────────────────────────────────────────────
+results <- map(jsonl_files, parse_file)
+df      <- bind_rows(compact(results))
+
+if (nrow(df) == 0) {
+  cat("No skill invocations found in scan window — nothing to do.\n")
+  quit(status = 0)
+}
+
+# ── Aggregate ─────────────────────────────────────────────────────────────────
+agg <- df |>
+  count(session_date, project, skill_name, session_id, name = "invocations") |>
+  mutate(etl_run_at = Sys.time())
+
+cat(sprintf("\nFound %d records (%d unique skills, %d sessions):\n",
+            nrow(agg), n_distinct(agg$skill_name), n_distinct(agg$session_id)))
+agg |>
+  count(skill_name, wt = invocations, name = "total") |>
+  arrange(desc(total)) |>
+  print(n = 50)
+
+if (dry_run) {
+  cat("\nDRY RUN — pass --apply to write to DB\n")
+  quit(status = 0)
+}
+
+# ── Write to DuckDB ───────────────────────────────────────────────────────────
+con <- dbConnect(duckdb(), db_path)
+on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+dbExecute(con, "
+  CREATE TABLE IF NOT EXISTS skill_usage (
+    session_id   TEXT      NOT NULL,
+    session_date DATE      NOT NULL,
+    project      TEXT      NOT NULL,
+    skill_name   TEXT      NOT NULL,
+    invocations  INTEGER   NOT NULL,
+    etl_run_at   TIMESTAMP NOT NULL
+  )
+")
+
+# Upsert: delete existing rows for this batch of sessions, then re-insert
+ids_sql <- paste0("'", unique(agg$session_id), "'", collapse = ", ")
+dbExecute(con, sprintf("DELETE FROM skill_usage WHERE session_id IN (%s)", ids_sql))
+dbAppendTable(con, "skill_usage", agg)
+cat(sprintf("Wrote %d rows to skill_usage in %s\n", nrow(agg), db_path))

--- a/.claude/scripts/skill_usage_etl.sh
+++ b/.claude/scripts/skill_usage_etl.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# skill_usage_etl.sh — bash wrapper for skill usage ETL.
+#
+# Flags:
+#   --dry-run   (default) print proposed records; no DB writes
+#   --apply     write to ~/.claude/logs/unified.duckdb
+#   --since YYYY-MM-DD  re-scan from this date (default: yesterday)
+#   --all       scan all JSONL files regardless of mtime
+#   --help      usage
+#
+# Runs nightly at 03:30 via com.claude.skill-usage-etl.plist.
+# Uses GC-rooted nix-shell (llm#596) — zero eval, zero network under launchd.
+
+export PATH="/usr/local/bin:/opt/homebrew/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+set -euo pipefail
+
+REPO_ROOT="/Users/johngavin/docs_gh/llm"
+LLM_NIX="${REPO_ROOT}/default.nix"
+ETL_SCRIPT="${REPO_ROOT}/.claude/scripts/skill_usage_etl.R"
+LOG_FILE="${HOME}/.claude/logs/skill_usage_etl.log"
+GCROOT_DRV="${HOME}/.claude/nix-gcroots/llm-shell.drv"
+GCROOT_STAMP="${GCROOT_DRV}.stamp"
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*" | tee -a "${LOG_FILE}"; }
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+APPLY_FLAG=""
+SINCE_FLAG=""
+ALL_FLAG=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --help)
+      echo "Usage: skill_usage_etl.sh [--apply] [--since YYYY-MM-DD] [--all]"
+      exit 0 ;;
+    --apply)     APPLY_FLAG="--apply" ;;
+    --dry-run)   ;;  # default
+    --all)       ALL_FLAG="--all" ;;
+    --since)     ;;  # handled by next arg
+    *)
+      if [ "${PREV:-}" = "--since" ]; then SINCE_FLAG="--since $arg"; fi ;;
+  esac
+  PREV="$arg"
+done
+
+log "skill_usage_etl START apply=${APPLY_FLAG:-dry-run} since=${SINCE_FLAG:-yesterday} all=${ALL_FLAG:-no}"
+
+# ── nix-shell target ──────────────────────────────────────────────────────────
+if ! command -v nix-shell > /dev/null 2>&1; then
+  log "ERROR: nix-shell not on PATH"
+  exit 1
+fi
+
+if [ "${LLM_NIX}" -nt "${GCROOT_STAMP}" ] 2>/dev/null || [ ! -e "${GCROOT_DRV}" ]; then
+  log "Refreshing GC root..."
+  "${REPO_ROOT}/.claude/scripts/nix_gcroot_refresh.sh" "${LLM_NIX}" >> "${LOG_FILE}" 2>&1 || true
+fi
+
+if [ -e "${GCROOT_DRV}" ]; then
+  NIX_TARGET="${GCROOT_DRV}"
+  log "Using GC-rooted drv: ${NIX_TARGET}"
+else
+  NIX_TARGET="${LLM_NIX}"
+  log "WARN: no gcroot — falling back to nix-shell evaluation (needs network, llm#596)"
+fi
+
+# ── Run ETL ───────────────────────────────────────────────────────────────────
+# shellcheck disable=SC2086
+nix-shell "${NIX_TARGET}" --run \
+  "Rscript '${ETL_SCRIPT}' ${APPLY_FLAG} ${SINCE_FLAG} ${ALL_FLAG}" \
+  >> "${LOG_FILE}" 2>&1
+
+log "skill_usage_etl END"


### PR DESCRIPTION
Parses ~/.claude/projects/**/*.jsonl nightly for Skill tool invocations → skill_usage table in unified.duckdb. Runs at 03:30 via launchd (GC-rooted nix-shell, llm#596). Incremental by default (--since yesterday). Install: copy plist to ~/Library/LaunchAgents/ and launchctl load.