### PR TITLE
fix(etl): NA_Date_ is invalid — replace with as.Date(NA_character_)

### DIFF
--- a/.claude/scripts/skill_usage_etl.R
+++ b/.claude/scripts/skill_usage_etl.R
@@ -116,7 +116,7 @@ parse_file <- function(path) {
   project_enc <- basename(dirname(as.character(path)))
   project     <- sub("^-", "/", gsub("-", "/", project_enc))
   session_id  <- tools::file_path_sans_ext(basename(as.character(path)))
-  session_date <- NA_Date_
+  session_date <- as.Date(NA_character_)
 
   all_skills  <- character()
   all_agents  <- list()
@@ -127,7 +127,7 @@ parse_file <- function(path) {
     if (is.null(msg)) next
     if (is.na(session_date) && !is.null(msg$timestamp))
       session_date <- tryCatch(as.Date(substr(msg$timestamp, 1L, 10L)),
-                               error = function(e) NA_Date_)
+                               error = function(e) as.Date(NA_character_))
     if (!identical(msg$type, "assistant")) next
     r <- extract_tool_calls(msg, session_id, session_date %||% Sys.Date(), project)
     if (is.null(r)) next


### PR DESCRIPTION
## Summary

- `NA_Date_` is not a valid R constant (unlike `NA_character_`, `NA_integer_`, `NA_real_`, `NA_complex_`)
- Caused a runtime error (`object 'NA_Date_` not found`) on first ETL run of `skill_usage_etl.R`
- Fixed both occurrences in `parse_file`: initial `session_date` assignment and the `tryCatch` error fallback

## Changes

`.claude/scripts/skill_usage_etl.R`: 2 lines changed — `NA_Date_` → `as.Date(NA_character_)`

## Test plan

- [x] `parse(file=...)` syntax check passes with no errors
- [x] Both occurrences (line 119 and line 130) corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)