### PR TITLE
fix(etl): config_inventory CREATE OR REPLACE — schema changes always apply

### DIFF
--- a/.claude/scripts/skill_usage_etl.R
+++ b/.claude/scripts/skill_usage_etl.R
@@ -325,7 +325,7 @@ ensure_tables <- function(con) {
       accesses INTEGER, etl_run_at TIMESTAMP
     )")
   dbExecute(con, "
-    CREATE TABLE IF NOT EXISTS config_inventory (
+    CREATE OR REPLACE TABLE config_inventory (
       item_type TEXT, name TEXT, file_path TEXT,
       file_size_bytes INTEGER, last_modified DATE,
       has_paths_scope BOOLEAN, is_mandatory BOOLEAN, etl_run_at TIMESTAMP


### PR DESCRIPTION
config_inventory is fully truncated and reloaded on every run, so CREATE OR REPLACE is correct and allows DDL changes (like adding is_mandatory) to take effect without manual ALTER TABLE.