### PR TITLE
fix(#617): destructive_fs_guard — strip heredoc bodies, exempt agent worktrees

### DIFF
--- a/.claude/hooks/destructive_fs_guard.sh
+++ b/.claude/hooks/destructive_fs_guard.sh
@@ -14,19 +14,22 @@
 
 set -euo pipefail
 
-# Get the command from Claude's tool input
-# Claude passes tool input as JSON to stdin for hooks
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+# In selftest mode, skip stdin reading — functions are defined below, selftest runs after them
+if [ "${CLAUDE_HOOK_SELFTEST:-0}" != "1" ]; then
+  # Get the command from Claude's tool input
+  # Claude passes tool input as JSON to stdin for hooks
+  INPUT=$(cat)
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
 
-# Fallback: check environment variable (older hook interface)
-if [ -z "$COMMAND" ]; then
-  COMMAND="${CLAUDE_TOOL_INPUT:-}"
-fi
+  # Fallback: check environment variable (older hook interface)
+  if [ -z "$COMMAND" ]; then
+    COMMAND="${CLAUDE_TOOL_INPUT:-}"
+  fi
 
-# If still empty, allow (can't parse command)
-if [ -z "$COMMAND" ]; then
-  exit 0
+  # If still empty, allow (can't parse command)
+  if [ -z "$COMMAND" ]; then
+    exit 0
+  fi
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -71,12 +74,102 @@ generate_expected_code() {
   echo "$hash" | grep -oE '[0-9]' | head -4 | tr -d '\n'
 }
 
+strip_heredoc_bodies() {
+  # Remove heredoc body content before destructive pattern matching (#617).
+  # Prevents false positives when a command writes a script file that happens
+  # to contain rm/git commands inside the heredoc body.
+  printf '%s\n' "$1" | awk '
+    /<</ {
+      line = $0
+      after = $0; sub(/.*<<[-]?[ \t]*/, "", after)
+      gsub(/^'"'"'|^"/, "", after)
+      split(after, a, /[ \t'"'"'"]/)
+      delim = a[1]
+      if (length(delim) > 0) {
+        in_here = 1
+        sub(/[ \t]*<<.*$/, "", line)
+        print line
+        next
+      }
+    }
+    in_here {
+      stripped = $0; sub(/^[ \t]+/, "", stripped)
+      if (stripped == delim || $0 == delim) { in_here = 0 }
+      next
+    }
+    { print }
+  '
+}
+
+is_own_worktree_path() {
+  # Agent harness worktrees (.claude/worktrees/agent-*) are sandboxed by
+  # isolation:"worktree" and should not be blocked by PROTECTED_PATHS (#617).
+  echo "$1" | grep -qE '\.claude/worktrees/agent-[a-f0-9]+'
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SELF-TEST (CLAUDE_HOOK_SELFTEST=1)
+# ═══════════════════════════════════════════════════════════════════════════
+
+if [ "${CLAUDE_HOOK_SELFTEST:-0}" = "1" ]; then
+  PASS=0; FAIL=0
+  assert_destructive() {
+    local desc="$1" cmd="$2"
+    local surface; surface=$(strip_heredoc_bodies "$cmd")
+    if is_destructive "$surface" && targets_protected "$cmd" && ! is_own_worktree_path "$cmd"; then
+      PASS=$((PASS+1)); echo "PASS: $desc"
+    else
+      FAIL=$((FAIL+1)); echo "FAIL: $desc"
+    fi
+  }
+  assert_allowed() {
+    local desc="$1" cmd="$2"
+    local surface; surface=$(strip_heredoc_bodies "$cmd")
+    local would_block=0
+    is_destructive "$surface" && targets_protected "$cmd" && ! is_own_worktree_path "$cmd" && would_block=1
+    if [ "$would_block" -eq 0 ]; then
+      PASS=$((PASS+1)); echo "PASS: $desc"
+    else
+      FAIL=$((FAIL+1)); echo "FAIL: $desc"
+    fi
+  }
+
+  # Should BLOCK
+  assert_destructive "rm -rf .claude/rules/" "rm -rf .claude/rules/"
+  assert_destructive "git reset --hard with .claude/ arg" "git reset --hard .claude/scripts/"
+  assert_destructive "git clean -fdx on _targets/" "git clean -fdx _targets/"
+
+  # Should ALLOW — heredoc body with rm inside (#617 fix 1)
+  assert_allowed "heredoc with rm inside body" "$(printf '%s\n' \
+    "cat > /tmp/foo.sh << 'SCRIPT'" \
+    "rm -rf \"\$tmp\"" \
+    "SCRIPT")"
+  assert_allowed "heredoc writing to .claude/scripts/ with rm body" "$(printf '%s\n' \
+    "cat > .claude/scripts/foo.sh << 'EOF'" \
+    "#!/bin/bash" \
+    "rm -rf \"\$build_dir\"" \
+    "EOF")"
+
+  # Should ALLOW — agent harness worktree path (#617 fix 2)
+  assert_allowed "rm in own harness worktree" \
+    "rm -rf .claude/worktrees/agent-abc1234567890abc/"
+
+  echo "$((PASS+FAIL)) tests: $PASS PASS, $FAIL FAIL"
+  exit $([ "$FAIL" -eq 0 ] && echo 0 || echo 1)
+fi
+
 # ═══════════════════════════════════════════════════════════════════════════
 # MAIN LOGIC
 # ═══════════════════════════════════════════════════════════════════════════
 
-# Check if command is destructive AND targets protected path
-if is_destructive "$COMMAND" && targets_protected "$COMMAND"; then
+# Check if command is destructive AND targets protected path.
+# Strip heredoc bodies first so script content doesn't trigger the check (#617).
+COMMAND_SURFACE=$(strip_heredoc_bodies "$COMMAND")
+if is_destructive "$COMMAND_SURFACE" && targets_protected "$COMMAND"; then
+  # Exempt agent harness worktrees — they are already sandboxed (#617).
+  if is_own_worktree_path "$COMMAND"; then
+    exit 0
+  fi
 
   # Extract any provided confirmation code
   PROVIDED_CODE=$(extract_confirm_code "$COMMAND")

--- a/.claude/rules/_companions/auto-delegation-dispatch-details.md
+++ b/.claude/rules/_companions/auto-delegation-dispatch-details.md
@@ -75,6 +75,17 @@ at the hook level; the self-check here provides early warning before you reach
 the push call.
 ```
 
+**Prefix 3 — Progress markers for long-running operations** (closes llm#541):
+
+```
+**CRITICAL — Stream-watchdog:** The harness fires a 600s stream-watchdog if no
+output appears. Before every operation that may take >30s (nix-shell builds,
+duckdb queries, devtools::check, tar_make), emit a one-line progress marker:
+  echo "PROGRESS: starting nix-shell build for <reason>"
+  echo "PROGRESS: running duckdb migration"
+This prevents false-positive watchdog kills on legitimate long-running work.
+```
+
 Orchestrator responsibilities when dispatching:
 
 1. Compute the worktree path the harness will create (typically `.claude/worktrees/agent-<id>/`) and inject it as the literal `$WORKTREE_PATH` value — OR instruct the agent to capture its own `pwd` at startup (more robust since the agent ID is generated at dispatch time)

--- a/.claude/scripts/burn_rate_check.sh
+++ b/.claude/scripts/burn_rate_check.sh
@@ -73,6 +73,9 @@ days_elapsed=$(( days_since + 1 ))  # inclusive of today
 week_start_ymd=$(date -v-"${days_since}"d +%Y%m%d 2>/dev/null \
   || date -d "-${days_since} days" +%Y%m%d)
 
+# GNU timeout absent on macOS and under launchd PATH (llm#420)
+TIMEOUT_CMD=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)
+
 # Cache: reuse if < 5 minutes old AND for the same week window
 CACHE_FILE="/tmp/ccusage_burnweek_${week_start_ymd}_cache.json"
 CACHE_MAX_AGE=300
@@ -89,7 +92,7 @@ if [ "$use_cache" = true ]; then
   daily_json=$(cat "$CACHE_FILE")
 else
   err_tmp=$(mktemp /tmp/burn_rate_err_XXXXXX)
-  daily_json=$(timeout 30 npx ccusage daily \
+  daily_json=$(${TIMEOUT_CMD:+$TIMEOUT_CMD 30} npx ccusage daily \
     --since "$week_start_ymd" \
     --timezone "$TZ_NAME" \
     --json --offline 2>"$err_tmp") || {


### PR DESCRIPTION
## Summary

- **Root cause 1**: `is_destructive()` matched `rm -rf` inside a heredoc BODY, not the actual command being executed. Any agent writing a shell script containing cleanup code was falsely blocked.
- **Root cause 2**: `targets_protected()` matched `.claude/` in agent harness worktree paths (`.claude/worktrees/agent-*/`). These paths are already sandboxed by `isolation: "worktree"` and should not be treated as protected config paths.

## Changes

- `strip_heredoc_bodies()` — awk function that strips content between `<<DELIM` and `DELIM` before pattern matching. Only the command surface (the line with `<<`) is checked.
- `is_own_worktree_path()` — exempts `.claude/worktrees/agent-*` paths from the PROTECTED_PATHS block.
- `COMMAND_SURFACE=$(strip_heredoc_bodies "$COMMAND")` — used for destructive check; full `$COMMAND` still used for protected-path check.
- Worktree exemption applied inside the `if is_destructive && targets_protected` block.
- Added `CLAUDE_HOOK_SELFTEST=1` mode: 6 tests (3 block, 3 allow). Run: `CLAUDE_HOOK_SELFTEST=1 bash .claude/hooks/destructive_fs_guard.sh`

## Test plan

- [ ] `CLAUDE_HOOK_SELFTEST=1 bash .claude/hooks/destructive_fs_guard.sh` → `6 tests: 6 PASS, 0 FAIL`
- [ ] Dispatch a fixer agent that writes a shell script with cleanup code — should not be blocked
- [ ] `rm -rf .claude/rules/` still blocked (real protected path)

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)