### PR TITLE
fix(#615): bws_launcher — catch network failures, fall back to flat env file

### DIFF
--- a/.claude/scripts/bws_launcher.sh
+++ b/.claude/scripts/bws_launcher.sh
@@ -53,22 +53,32 @@ if [[ "${BW_AVAILABLE}" -eq 1 ]]; then
         exit 0
     fi
     export BWS_ACCESS_TOKEN
-    exec "${BWS_BIN}" run -- "${TARGET}" "$@"
-else
-    # Fallback: source flat env file if provided, then exec the target directly
-    FALLBACK="${BW_FALLBACK_ENV:-}"
-    if [[ -n "${FALLBACK}" ]] && [[ -f "${FALLBACK}" ]]; then
-        log "WARN: bws unavailable — sourcing flat file ${FALLBACK}"
-        set -a
-        # shellcheck disable=SC1090
-        source "${FALLBACK}"
-        set +a
-    else
-        log "WARN: bws unavailable and no BW_FALLBACK_ENV — running ${TARGET} with current env"
-    fi
-    if [[ "${BW_DRYRUN:-0}" == "1" ]]; then
-        echo "[DRYRUN] exec ${TARGET} $*"
+    # Run bws without exec so we can catch network/auth failures and fall back.
+    # bws spawns TARGET as a subprocess; on success we exit with its code.
+    set +e
+    "${BWS_BIN}" run -- "${TARGET}" "$@"
+    bws_exit=$?
+    set -e
+    if [[ $bws_exit -eq 0 ]]; then
         exit 0
     fi
-    exec "${TARGET}" "$@"
+    log "WARN: bws run failed (exit ${bws_exit}) — network timeout or auth error; falling back to flat file"
 fi
+
+# Fallback: source flat env file if provided, then exec the target directly.
+# Reached when: (a) bws binary/token unavailable, or (b) bws run failed above.
+FALLBACK="${BW_FALLBACK_ENV:-}"
+if [[ -n "${FALLBACK}" ]] && [[ -f "${FALLBACK}" ]]; then
+    log "WARN: sourcing flat file ${FALLBACK}"
+    set -a
+    # shellcheck disable=SC1090
+    source "${FALLBACK}"
+    set +a
+else
+    log "WARN: no BW_FALLBACK_ENV — running ${TARGET} with current env"
+fi
+if [[ "${BW_DRYRUN:-0}" == "1" ]]; then
+    echo "[DRYRUN] exec ${TARGET} $*"
+    exit 0
+fi
+exec "${TARGET}" "$@"


### PR DESCRIPTION
## Summary

- **Root cause:** `exec "${BWS_BIN}" run -- "$@"` replaced the launcher shell process. When `bws` failed at 06:30 with a network timeout (WiFi not yet up), the exit code propagated directly to launchd with no fallback — the overnight email was never sent.
- **Fix:** Replace `exec` with a non-exec call that captures `bws_exit`. On exit 0, we exit cleanly. On any non-zero exit we log a WARN and fall through to the existing flat-file fallback path (same path used when `bws` is unavailable at startup).
- **Scope:** Single file `.claude/scripts/bws_launcher.sh`, execute-block only.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| bws succeeds | `exec` → bws owns the process | Non-exec call, `exit 0` |
| bws network timeout | Process dies, launchd records failure, no fallback | WARN logged, falls through to flat-file path |
| bws binary/token missing | Fallback path (unchanged) | Fallback path (unchanged) |

## Test plan

- [x] `grep 'exec "${BWS_BIN}"'` returns no lines (exec removed)
- [x] `grep 'bws_exit'` returns lines 60, 62, 65 (new pattern present)
- [x] `BW_DRYRUN=1 bash .claude/scripts/bws_launcher.sh /bin/echo test` prints `[DRYRUN] BWS_ACCESS_TOKEN=<redacted> ...` (smoke test passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)