### PR TITLE
feat(#640): anacron-style catch-up for all launchd cron jobs (15 scripts)

### DIFF
--- a/.claude/launchd/com.claude.cron-catchup.plist
+++ b/.claude/launchd/com.claude.cron-catchup.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.cron-catchup</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/cron_catchup.sh</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>900</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/cron_catchup.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/cron_catchup.log</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+        <key>PATH</key>
+        <string>/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/.claude/scripts/branch_gc.sh
+++ b/.claude/scripts/branch_gc.sh
@@ -481,4 +481,9 @@ done
 log "[done] events=$EVENTS apply=$APPLY"
 
 hk_end "$RUN_ID" "ok" "$EVENTS" ""
+
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/branch-gc.stamp"
+
 exit 0

--- a/.claude/scripts/codex_overnight_learning.py
+++ b/.claude/scripts/codex_overnight_learning.py
@@ -546,6 +546,15 @@ def main() -> int:
     print(f"codex-overnight-learning: sessions={len(sessions)} signals={len(signals)} sha1={digest}")
     print(f"  json: {json_path}")
     print(f"  md:   {md_path}")
+
+    # Stamp for cron_catchup.sh catch-up detection
+    import datetime
+    _stamp_dir = pathlib.Path.home() / ".claude" / "logs" / "stamps"
+    _stamp_dir.mkdir(parents=True, exist_ok=True)
+    (_stamp_dir / "codex-overnight.stamp").write_text(
+        datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ") + "\n"
+    )
+
     return 0
 
 

--- a/.claude/scripts/cron_catchup.sh
+++ b/.claude/scripts/cron_catchup.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# cron_catchup.sh — Anacron-style catch-up for launchd jobs missed during sleep.
+#
+# macOS launchd skips StartCalendarInterval firings while the Mac is asleep.
+# This script runs every 15 min (StartInterval=900) and re-runs any job whose
+# stamp file is older than max_age_hours.
+#
+# Stamp files: ~/.claude/logs/stamps/<label>.stamp
+# Log: ~/.claude/logs/cron_catchup.log
+#
+# Tracked in llm#640.
+
+set -uo pipefail
+
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+STAMP_DIR="${HOME}/.claude/logs/stamps"
+LOG_FILE="${HOME}/.claude/logs/cron_catchup.log"
+BWS_LAUNCHER="/Users/johngavin/docs_gh/llm/.claude/scripts/bws_launcher.sh"
+
+mkdir -p "${STAMP_DIR}"
+mkdir -p "$(dirname "${LOG_FILE}")"
+
+log() {
+  printf '%s: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" | tee -a "${LOG_FILE}"
+}
+
+# Prevent concurrent runs
+LOCK_FILE="/tmp/cron_catchup.lock"
+if [[ -f "${LOCK_FILE}" ]]; then
+  existing_pid="$(cat "${LOCK_FILE}" 2>/dev/null || true)"
+  if [[ -n "${existing_pid}" ]] && kill -0 "${existing_pid}" 2>/dev/null; then
+    exit 0
+  fi
+fi
+printf '%d' "$$" > "${LOCK_FILE}"
+trap 'rm -f "${LOCK_FILE}"' EXIT
+
+# Returns 0 (true) if stamp is stale or missing
+is_stale() {
+  local label="$1" max_age_h="$2"
+  local stamp="${STAMP_DIR}/${label}.stamp"
+  if [[ ! -f "${stamp}" ]]; then
+    return 0
+  fi
+  local stamp_epoch file_epoch age_s max_s
+  file_epoch=$(date -r "${stamp}" +%s 2>/dev/null || stat -c %Y "${stamp}" 2>/dev/null || echo 0)
+  stamp_epoch=$(date +%s)
+  age_s=$(( stamp_epoch - file_epoch ))
+  max_s=$(( max_age_h * 3600 ))
+  (( age_s > max_s ))
+}
+
+write_stamp() {
+  local label="$1"
+  date -u +%Y-%m-%dT%H:%M:%SZ > "${STAMP_DIR}/${label}.stamp"
+}
+
+run_job() {
+  local label="$1" cmd="$2"
+  log "CATCHUP: running ${label}"
+  local start_s end_s rc
+  start_s=$(date +%s)
+  set +e
+  eval "${cmd}" >> "${LOG_FILE}" 2>&1
+  rc=$?
+  set -e
+  end_s=$(date +%s)
+  if [[ $rc -eq 0 ]]; then
+    write_stamp "${label}"
+    log "CATCHUP: ${label} OK ($(( end_s - start_s ))s)"
+  else
+    log "CATCHUP: ${label} FAILED (exit ${rc}, $(( end_s - start_s ))s)"
+  fi
+}
+
+# Registry: "label|max_age_hours|command"
+# max_age_hours: 26 for daily jobs (24h + 2h grace); 10 for 3x/day jobs
+REGISTRY=(
+  "self-review-stage1|26|/Users/johngavin/docs_gh/llm/.claude/scripts/self_review_stage1.sh"
+  "codex-overnight|26|python3 /Users/johngavin/docs_gh/llm/.claude/scripts/codex_overnight_learning.py"
+  "overnight-email|26|${BWS_LAUNCHER} /Users/johngavin/docs_gh/llm/bin/overnight_self_review_email_cron.sh"
+  "roborev-daily-email|26|/Users/johngavin/docs_gh/llm/bin/roborev_daily_cron.sh"
+  "kb-digest|26|/Users/johngavin/docs_gh/llm/bin/kb_digest_daily_cron.sh"
+  "config-digest|26|/Users/johngavin/docs_gh/llm/bin/config_digest_cron.sh"
+  "roborev-metrics-etl|26|/bin/bash /Users/johngavin/.claude/scripts/roborev_metrics_etl.sh --apply"
+  "roborev-daily-backlog|26|/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_daily_backlog_aggregator.sh"
+  "branch-gc|26|/Users/johngavin/docs_gh/llm/.claude/scripts/branch_gc.sh"
+  "worktree-gc|26|/Users/johngavin/docs_gh/llm/.claude/scripts/worktree_gc.sh"
+  "unified-duckdb-backup|26|/Users/johngavin/.claude/scripts/unified_duckdb_backup.sh"
+  "config-pulse|26|/Users/johngavin/docs_gh/llm/.claude/scripts/config_pulse.sh"
+  "knowledge-pulse|26|/Users/johngavin/docs_gh/llm/.claude/scripts/knowledge_pulse.sh"
+  "wiki-health-pulse|26|/Users/johngavin/docs_gh/llm/.claude/scripts/wiki_health_check.sh"
+  "pr-status-pulse|10|/Users/johngavin/docs_gh/llm/.claude/scripts/pr_status_pulse.sh"
+)
+
+CHECKED=0
+STALE=0
+RAN=0
+
+for entry in "${REGISTRY[@]}"; do
+  IFS='|' read -r label max_age cmd <<< "${entry}"
+  (( CHECKED++ ))
+  if is_stale "${label}" "${max_age}"; then
+    (( STALE++ ))
+    run_job "${label}" "${cmd}"
+    (( RAN++ ))
+  fi
+done
+
+if (( STALE > 0 )); then
+  log "SUMMARY: checked=${CHECKED} stale=${STALE} ran=${RAN}"
+fi

--- a/.claude/scripts/pr_status_pulse.sh
+++ b/.claude/scripts/pr_status_pulse.sh
@@ -60,4 +60,8 @@ for p in prs:
   echo
 } >> "$LOG" 2>&1
 
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/pr-status-pulse.stamp"
+
 exit 0

--- a/.claude/scripts/roborev_daily_backlog_aggregator.sh
+++ b/.claude/scripts/roborev_daily_backlog_aggregator.sh
@@ -366,5 +366,9 @@ out_file="${OUT_DIR}/${TODAY}.md"
 written=$(_write_global_summary "$out_file" "$summary_rows")
 log "summary written: $written"
 
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/roborev-daily-backlog.stamp"
+
 echo "roborev_daily_backlog_aggregator: processed=$processed skipped=$skipped summary=$written"
 exit 0

--- a/.claude/scripts/roborev_metrics_etl.sh
+++ b/.claude/scripts/roborev_metrics_etl.sh
@@ -354,5 +354,12 @@ fi
 
 EXIT_CODE=$ROBOREV_EXIT
 log "end: exit=${EXIT_CODE}"
+
+# Stamp for cron_catchup.sh catch-up detection (only on success)
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  mkdir -p "${HOME}/.claude/logs/stamps"
+  date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/roborev-metrics-etl.stamp"
+fi
+
 echo "roborev_metrics_etl: exit=${EXIT_CODE}"
 exit $EXIT_CODE

--- a/.claude/scripts/self_review_stage1.sh
+++ b/.claude/scripts/self_review_stage1.sh
@@ -224,3 +224,7 @@ else
     run_write "${DB}"
     log "INFO: Done."
 fi
+
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/self-review-stage1.stamp"

--- a/.claude/scripts/unified_duckdb_backup.sh
+++ b/.claude/scripts/unified_duckdb_backup.sh
@@ -396,4 +396,8 @@ if [ "$DO_PRUNE" = "1" ]; then
   prune_old_backups "$BACKUP_ROOT" "$APPLY"
 fi
 
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/unified-duckdb-backup.stamp"
+
 log "unified_duckdb_backup: done"

--- a/.claude/scripts/wiki_health_check.sh
+++ b/.claude/scripts/wiki_health_check.sh
@@ -335,4 +335,9 @@ fi
 
 [ $errors -gt 0 ] && exit 2
 [ $warnings -gt 0 ] && exit 1
+
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/wiki-health-pulse.stamp"
+
 exit 0

--- a/.claude/scripts/worktree_gc.sh
+++ b/.claude/scripts/worktree_gc.sh
@@ -395,6 +395,10 @@ fi
 
 log "[done] candidates=$CANDIDATES would-remove=$WOULD_REMOVE removed=$REMOVED kept=$KEPT events=$EVENTS_WRITTEN apply=$APPLY soak-past=$_past_soak"
 
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/worktree-gc.stamp"
+
 # Update housekeeping_runs end row
 if [ "$_duckdb_ok" = "1" ]; then
   _run_ended=$(python3 -c "import datetime; print(datetime.datetime.utcnow().isoformat() + 'Z')")

--- a/bin/config_digest_cron.sh
+++ b/bin/config_digest_cron.sh
@@ -322,4 +322,8 @@ if [ "${_duckdb_ok}" = "1" ]; then
   log "Step 3: housekeeping_runs updated (status=${_final_status} rows_written=${_EVENTS_WRITTEN})"
 fi
 
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/config-digest.stamp"
+
 log "=== config_digest_cron.sh done ==="

--- a/bin/kb_digest_daily_cron.sh
+++ b/bin/kb_digest_daily_cron.sh
@@ -385,4 +385,8 @@ if [ "${_duckdb_ok}" = "1" ]; then
   log "Step 3: housekeeping_runs updated (rows_written=${_EVENTS_WRITTEN})"
 fi
 
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/kb-digest.stamp"
+
 log "=== kb_digest_daily_cron.sh done ==="

--- a/bin/overnight_self_review_email_cron.sh
+++ b/bin/overnight_self_review_email_cron.sh
@@ -129,6 +129,9 @@ rc=$?
 set -e
 
 if [ $rc -eq 0 ]; then
+  # Stamp for cron_catchup.sh catch-up detection
+  mkdir -p "${HOME}/.claude/logs/stamps"
+  date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/overnight-email.stamp"
   log "=== overnight_self_review_email_cron.sh completed OK ==="
 else
   log "=== overnight_self_review_email_cron.sh FAILED (exit ${rc}) ==="

--- a/bin/roborev_daily_cron.sh
+++ b/bin/roborev_daily_cron.sh
@@ -191,4 +191,8 @@ if [ "${STEP3_EXIT}" -ne 0 ]; then
 fi
 log "Step 3 done"
 
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/roborev-daily-email.stamp"
+
 log "=== roborev_daily_cron.sh done ==="


### PR DESCRIPTION
## Summary

- macOS launchd skips `StartCalendarInterval` jobs when the Mac is asleep; there is no built-in catch-up
- `cron_catchup.sh` runs every 15 min and re-runs any job whose stamp is >max_age_hours old
- 14 cron scripts (bash) + 1 Python script now write a stamp on success
- This also answers "how do I know if a pulse job ran?" — `ls -la ~/.claude/logs/stamps/` shows last-run for every job

## Catch-up registry (15 jobs)

| Label | Max age | Normal schedule |
|-------|---------|----------------|
| self-review-stage1 | 26h | 02:30 |
| codex-overnight | 26h | 06:10 |
| overnight-email | 26h | 06:30 |
| roborev-daily-email | 26h | 08:00 |
| kb-digest | 26h | 08:05 |
| config-digest | 26h | 08:05 |
| roborev-metrics-etl | 26h | 02:00 |
| roborev-daily-backlog | 26h | 02:15 |
| branch-gc | 26h | 09:08 |
| worktree-gc | 26h | 09:00 |
| unified-duckdb-backup | 26h | 03:00 |
| config-pulse | 26h | 09:00 |
| knowledge-pulse | 26h | 09:05 |
| wiki-health-pulse | 26h | 09:45 |
| pr-status-pulse | 10h | 09:30, 12:30, 16:30 |

## Install (user action required after merge)

```bash
cp .claude/launchd/com.claude.cron-catchup.plist ~/Library/LaunchAgents/
launchctl load ~/Library/LaunchAgents/com.claude.cron-catchup.plist
```

## Test plan

- [ ] `ls -la ~/.claude/logs/stamps/` — initially empty (no jobs have run with new code)
- [ ] Manually run one script, verify stamp appears
- [ ] `bash .claude/scripts/cron_catchup.sh` — should detect stale stamps and re-run
- [ ] Re-run catchup — stamps now fresh, no re-runs

## Notes

- `config_pulse.sh` and `knowledge_pulse.sh` are symlinks to `llmtelemetry/inst/scripts/`; those files were edited at their real paths (cross-project authority)
- `wiki_health_check.sh` exits 2 (errors) or 1 (warnings) — stamp only written on clean exit 0
- `roborev_metrics_etl.sh` stamp is gated on `EXIT_CODE -eq 0`

🤖 Generated with Claude Code