### PR TITLE
fix(#640): cron_catchup.sh double-log caused by tee + StandardOutPath

### DIFF
--- a/.claude/scripts/cron_catchup.sh
+++ b/.claude/scripts/cron_catchup.sh
@@ -22,7 +22,7 @@ mkdir -p "${STAMP_DIR}"
 mkdir -p "$(dirname "${LOG_FILE}")"
 
 log() {
-  printf '%s: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" | tee -a "${LOG_FILE}"
+  printf '%s: %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >> "${LOG_FILE}"
 }
 
 # Prevent concurrent runs


### PR DESCRIPTION
## Summary

- `log()` in `.claude/scripts/cron_catchup.sh` was piping through `tee -a "${LOG_FILE}"`, which wrote every line to both the file AND stdout
- The plist (`com.claude.cron-catchup.plist`) has `StandardOutPath` pointing to the same log file
- Result: every log line appeared twice in `~/.claude/logs/cron_catchup.log`

**Fix:** replace `| tee -a "${LOG_FILE}"` with `>> "${LOG_FILE}"` so log writes go only to the file, not stdout.

Closes #640.

## Test plan

- [ ] Verify `~/.claude/logs/cron_catchup.log` no longer shows duplicate lines after a catchup run
- [ ] Confirm the plist `StandardOutPath` can safely capture (empty) stdout without causing duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)