### PR TITLE
feat(#652): canonical audit — ephemeral bucket + 10 project aliases

### DIFF
--- a/.claude/data/canonical_project_aliases.csv
+++ b/.claude/data/canonical_project_aliases.csv
@@ -1,2 +1,12 @@
 slug,alias
 coMMpass,commpass
+coMMpass,data-coMMpass
+crypto,data-crypto
+crypto_solwatch,crypto-solwatch
+football,sport-football
+footbet,sport-footbet
+historical,data-historical
+irishbuoys,buoy-network
+irishbuoys,irish_buoy_network
+randomwalk,randomwalk-wiki
+randomwalk,simulations-randomwalk

--- a/.claude/data/canonical_project_aliases.csv
+++ b/.claude/data/canonical_project_aliases.csv
@@ -10,3 +10,4 @@ irishbuoys,buoy-network
 irishbuoys,irish_buoy_network
 randomwalk,randomwalk-wiki
 randomwalk,simulations-randomwalk
+t-demos,t_demos

--- a/.claude/data/canonical_projects.csv
+++ b/.claude/data/canonical_projects.csv
@@ -17,3 +17,5 @@ premortem,Premortem,JohnGavin/premortem,analysis,true,confirmed by user 2026-06-
 randomwalk,Random Walk,JohnGavin/randomwalk,analysis,true,
 rix.setup,rix Setup,JohnGavin/rix.setup,meta-config,true,
 urban_planning,Urban Planning,JohnGavin/urban_planning,analysis,true,
+eis6,EIS 6,,analysis,true,SENSITIVE — local git only; NEVER push to GitHub
+t-demos,T-lang demos (archived),,analysis,false,defunct; archived to proj/data/tlang/t_demos.zip 2026-06-20

--- a/.claude/scripts/canonical_projects_audit.sh
+++ b/.claude/scripts/canonical_projects_audit.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # canonical_projects_audit.sh — audit project-column values in unified.duckdb
-# Closes llm#535. References llm#528 (design), llm#540 (canonical_projects migration).
+# Closes llm#535. References llm#528 (design), llm#540 (migration), llm#652 (ephemeral bucket).
 #
 # Classifies every distinct value in source columns as:
 #   FIXTURE   — known test / fixture slug matching the fixture regex
+#   EPHEMERAL — runtime-generated token (agent worktree, session id, branch slug)
 #   CANONICAL — present in canonical_projects.slug or canonical_project_aliases.alias
-#   UNKNOWN   — neither FIXTURE nor CANONICAL (the set we care about)
+#   UNKNOWN   — none of the above (the actionable set we care about)
 #
 # Source columns audited:
 #   roborev_review_lifecycle.repo
@@ -16,7 +17,7 @@
 #   canonical_projects_audit.sh           # --quiet mode (default)
 #   canonical_projects_audit.sh --quiet   # one compact line; silent if fully clean
 #   canonical_projects_audit.sh --verbose # per-bucket detail to stdout
-#   canonical_projects_audit.sh --selftest # 6 fixture assertions then exit
+#   canonical_projects_audit.sh --selftest # assertions then exit
 #
 # Fail-open contract: never exits non-zero in normal operation; only selftest
 # may exit non-zero.  session_init.sh wraps with "|| true" regardless.
@@ -94,6 +95,55 @@ _is_fixture() {
     return 1
 }
 
+# ── ephemeral regex --------------------------------------------------------
+# Values matching this pattern are runtime-generated tokens (agent worktrees,
+# session IDs, branch slugs) — not real projects, not test fixtures.
+# Added llm#652 to cut UNKNOWN noise to genuine signal.
+_is_ephemeral() {
+    local v="$1"
+    # agent-<hex12+> — harness agent worktree dirs
+    case "$v" in
+        agent-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
+            return 0 ;;
+    esac
+    # worktree-<digits> and roborev-worktree-<digits>
+    case "$v" in
+        worktree-[0-9]*) return 0 ;;
+        roborev-worktree-[0-9]*) return 0 ;;
+    esac
+    # cc-YYYYMMDD-HHMMSS session IDs
+    case "$v" in
+        cc-2026[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]*) return 0 ;;
+        cc-2027[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]*) return 0 ;;
+        cc-2028[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]*) return 0 ;;
+    esac
+    # <proj>-feat-cc-… branch session dirs (e.g. llm-feat-cc-20260601-120000)
+    case "$v" in
+        *-feat-cc-20[0-9][0-9]*) return 0 ;;
+    esac
+    # <proj>-feat-<slug> and <proj>-fix-<slug> branch worktree dirs
+    case "$v" in
+        *-feat-[a-z0-9]*) return 0 ;;
+        *-fix-[a-z0-9]*) return 0 ;;
+        *-sonnet) return 0 ;;
+    esac
+    # ^<digits>- issue/PR branch slugs (e.g. 652-canonical-audit)
+    case "$v" in
+        [0-9]*-*) return 0 ;;
+    esac
+    # issue-<digits>- prefix
+    case "$v" in
+        issue-[0-9]*-*) return 0 ;;
+    esac
+    # selftest artefacts the fixture regex doesn't catch
+    case "$v" in
+        *_selftest*) return 0 ;;
+        branch_harvest_selftest*) return 0 ;;
+        kb_digest_selftest_*) return 0 ;;
+    esac
+    return 1
+}
+
 # ── selftest mode -----------------------------------------------------------
 if [ "$MODE" = "selftest" ]; then
     FIXTURE_DB="/tmp/canonical_projects_audit_test_$$.duckdb"
@@ -127,6 +177,7 @@ if [ "$MODE" = "selftest" ]; then
             ('hello_t');
     " > /dev/null 2>&1
 
+    # ── original fixture tests (preserved) ------------------------------------
     # Test 1: fixture regex — config_digest_git_fixture_
     _is_fixture "config_digest_git_fixture_abc123" && _r="FIXTURE" || _r="OTHER"
     _assert_eq "config_digest_git_fixture_ classifies as FIXTURE" "FIXTURE" "$_r"
@@ -147,12 +198,59 @@ if [ "$MODE" = "selftest" ]; then
     _count=$(_duck_scalar "$FIXTURE_DB" "SELECT COUNT(*) FROM canonical_projects;")
     _assert_eq "canonical_projects has 3 rows" "3" "$_count"
 
-    # Test 6: hello_t is UNKNOWN (not fixture, not canonical)
+    # Test 6: hello_t is UNKNOWN (not fixture, not canonical, not ephemeral)
     _is_fixture "hello_t" && _fi="y" || _fi="n"
+    _is_ephemeral "hello_t" && _ep="y" || _ep="n"
     _ca=$(_duck_scalar "$FIXTURE_DB" "SELECT COUNT(*) FROM canonical_projects WHERE slug='hello_t';")
     _al=$(_duck_scalar "$FIXTURE_DB" "SELECT COUNT(*) FROM canonical_project_aliases WHERE alias='hello_t';")
-    if [ "$_fi" = "n" ] && [ "$_ca" = "0" ] && [ "$_al" = "0" ]; then _r="UNKNOWN"; else _r="OTHER"; fi
+    if [ "$_fi" = "n" ] && [ "$_ep" = "n" ] && [ "$_ca" = "0" ] && [ "$_al" = "0" ]; then _r="UNKNOWN"; else _r="OTHER"; fi
     _assert_eq "hello_t classifies as UNKNOWN" "UNKNOWN" "$_r"
+
+    # ── new ephemeral tests (llm#652) -----------------------------------------
+    # Test 7: agent worktree hash
+    _is_ephemeral "agent-a095a135bf5b" && _r="EPHEMERAL" || _r="OTHER"
+    _assert_eq "agent-<hex12> classifies as EPHEMERAL" "EPHEMERAL" "$_r"
+
+    # Test 8: worktree-<digits>
+    _is_ephemeral "worktree-20260617" && _r="EPHEMERAL" || _r="OTHER"
+    _assert_eq "worktree-<digits> classifies as EPHEMERAL" "EPHEMERAL" "$_r"
+
+    # Test 9: roborev-worktree-<digits>
+    _is_ephemeral "roborev-worktree-1234" && _r="EPHEMERAL" || _r="OTHER"
+    _assert_eq "roborev-worktree-<digits> classifies as EPHEMERAL" "EPHEMERAL" "$_r"
+
+    # Test 10: cc-YYYYMMDD-HHMMSS session ID
+    _is_ephemeral "cc-20260617-114959" && _r="EPHEMERAL" || _r="OTHER"
+    _assert_eq "cc-20260617-114959 classifies as EPHEMERAL" "EPHEMERAL" "$_r"
+
+    # Test 11: <proj>-feat-cc-… branch worktree dir
+    _is_ephemeral "llm-feat-cc-20260601-120000" && _r="EPHEMERAL" || _r="OTHER"
+    _assert_eq "<proj>-feat-cc-... classifies as EPHEMERAL" "EPHEMERAL" "$_r"
+
+    # Test 12: <proj>-sonnet branch form
+    _is_ephemeral "mycare-sonnet" && _r="EPHEMERAL" || _r="OTHER"
+    _assert_eq "<proj>-sonnet classifies as EPHEMERAL" "EPHEMERAL" "$_r"
+
+    # Test 13: ^<digits>- issue slug
+    _is_ephemeral "652-canonical-audit" && _r="EPHEMERAL" || _r="OTHER"
+    _assert_eq "652-canonical-audit classifies as EPHEMERAL" "EPHEMERAL" "$_r"
+
+    # Test 14: issue-<digits>- prefix
+    _is_ephemeral "issue-652-canonical-audit" && _r="EPHEMERAL" || _r="OTHER"
+    _assert_eq "issue-<digits>-<slug> classifies as EPHEMERAL" "EPHEMERAL" "$_r"
+
+    # Test 15: *_selftest* not caught by _is_fixture
+    _is_fixture "branch_harvest_selftest_abc" && _fi="y" || _fi="n"
+    _is_ephemeral "branch_harvest_selftest_abc" && _r="EPHEMERAL" || _r="OTHER"
+    _assert_eq "branch_harvest_selftest_abc: _is_fixture=n, _is_ephemeral=EPHEMERAL" "EPHEMERAL" "$_r"
+
+    # Test 16: real project slug not classified as ephemeral
+    _is_ephemeral "irishbuoys" && _r="EPHEMERAL" || _r="NOT_EPHEMERAL"
+    _assert_eq "irishbuoys does not classify as EPHEMERAL" "NOT_EPHEMERAL" "$_r"
+
+    # Test 17: real project slug not classified as fixture
+    _is_fixture "irishbuoys" && _r="FIXTURE" || _r="NOT_FIXTURE"
+    _assert_eq "irishbuoys does not classify as FIXTURE" "NOT_FIXTURE" "$_r"
 
     rm -f "$FIXTURE_DB"
     echo ""
@@ -175,8 +273,7 @@ _is_canonical() {
 }
 
 # ── audit one table.column -------------------------------------------------
-# Writes results into caller-supplied variables via printf to a temp file,
-# to avoid subshell variable-scope issues when accumulating totals.
+# Returns 5 lines: n_canon, n_fixture, n_ephemeral, n_unknown, presence flag.
 # Prints per-column summary to stdout in verbose mode.
 _audit_column() {
     local tbl="$1" col="$2"
@@ -186,19 +283,21 @@ _audit_column() {
     tbl_exists=$(_duck_scalar "$LIVE_DB" "SELECT COUNT(*) FROM information_schema.tables WHERE table_name='${tbl}';") || tbl_exists="0"
     if [ "${tbl_exists:-0}" = "0" ]; then
         _log "table $tbl not found — skipping"
-        printf "0\n0\n0\nabsent\n"
+        printf "0\n0\n0\n0\nabsent\n"
         return 0
     fi
 
     local vals
     vals=$(_duck_run "$LIVE_DB" "SELECT DISTINCT ${col} FROM ${tbl} WHERE ${col} IS NOT NULL ORDER BY ${col};") || vals=""
 
-    local n_canon=0 n_fixture=0 n_unknown=0
+    local n_canon=0 n_fixture=0 n_ephemeral=0 n_unknown=0
     local unknown_list=""
     while IFS= read -r v; do
         [ -z "$v" ] && continue
         if _is_fixture "$v"; then
             n_fixture=$((n_fixture+1))
+        elif _is_ephemeral "$v"; then
+            n_ephemeral=$((n_ephemeral+1))
         elif _is_canonical "$v"; then
             n_canon=$((n_canon+1))
         else
@@ -208,34 +307,37 @@ _audit_column() {
     done <<< "$vals"
 
     if [ "$MODE" = "verbose" ]; then
-        echo "  ${tbl}.${col}: CANONICAL=$n_canon FIXTURE=$n_fixture UNKNOWN=$n_unknown" >&2
+        echo "  ${tbl}.${col}: CANONICAL=$n_canon FIXTURE=$n_fixture EPHEMERAL=$n_ephemeral UNKNOWN=$n_unknown" >&2
         if [ $n_unknown -gt 0 ]; then
             echo "    UNKNOWN: $unknown_list" >&2
         fi
     fi
 
-    printf "%d\n%d\n%d\npresent\n" "$n_canon" "$n_fixture" "$n_unknown"
+    printf "%d\n%d\n%d\n%d\npresent\n" "$n_canon" "$n_fixture" "$n_ephemeral" "$n_unknown"
 }
 
 # ── accumulate totals across all source columns ----------------------------
 _total_canon=0
 _total_fixture=0
+_total_ephemeral=0
 _total_unknown=0
 _detail_parts=""
 
-# Helper: parse _audit_column output into three named vars
+# Helper: parse _audit_column output (now 5 lines) into named vars
 _parse_result() {
     local result="$1" suffix="$2"
-    local c f u status
+    local c f e u status
     c=$(printf '%s\n' "$result" | sed -n '1p')
     f=$(printf '%s\n' "$result" | sed -n '2p')
-    u=$(printf '%s\n' "$result" | sed -n '3p')
-    status=$(printf '%s\n' "$result" | sed -n '4p')
+    e=$(printf '%s\n' "$result" | sed -n '3p')
+    u=$(printf '%s\n' "$result" | sed -n '4p')
+    status=$(printf '%s\n' "$result" | sed -n '5p')
 
     [ "$status" = "absent" ] && return 0
 
     _total_canon=$((_total_canon + ${c:-0}))
     _total_fixture=$((_total_fixture + ${f:-0}))
+    _total_ephemeral=$((_total_ephemeral + ${e:-0}))
     _total_unknown=$((_total_unknown + ${u:-0}))
 
     if [ "${u:-0}" -gt 0 ]; then
@@ -253,15 +355,15 @@ _r3=$(_audit_column "sessions" "project")
 _parse_result "$_r3" "sessions.project"
 
 # ── emit output ------------------------------------------------------------
-_log "audit: canon=$_total_canon fixture=$_total_fixture unknown=$_total_unknown (canonical_projects=$_canon_count)"
+_log "audit: canon=$_total_canon fixture=$_total_fixture ephemeral=$_total_ephemeral unknown=$_total_unknown (canonical_projects=$_canon_count)"
 
 if [ "$MODE" = "quiet" ]; then
     # Emit one compact line only when there are unknowns; silent if fully clean.
     if [ "${_total_unknown:-0}" -gt 0 ]; then
-        echo "canonical-projects-audit: UNKNOWN=${_total_unknown} CANONICAL=${_total_canon} FIXTURE=${_total_fixture} [${_detail_parts% }]"
+        echo "canonical-projects-audit: UNKNOWN=${_total_unknown} EPHEMERAL=${_total_ephemeral} CANONICAL=${_total_canon} FIXTURE=${_total_fixture} [${_detail_parts% }]"
     fi
 elif [ "$MODE" = "verbose" ]; then
-    echo "canonical-projects-audit: CANONICAL=${_total_canon} FIXTURE=${_total_fixture} UNKNOWN=${_total_unknown} (canonical_projects in DB: ${_canon_count})"
+    echo "canonical-projects-audit: UNKNOWN=${_total_unknown} EPHEMERAL=${_total_ephemeral} CANONICAL=${_total_canon} FIXTURE=${_total_fixture} (canonical_projects in DB: ${_canon_count})"
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

Closes llm#652. Two non-mutating fixes to reduce session-start `UNKNOWN=437` audit noise to genuine signal.

### Gap B — ephemeral bucket in `canonical_projects_audit.sh`

Added `_is_ephemeral()` helper and a new **EPHEMERAL** bucket. The classification order is now: FIXTURE → EPHEMERAL → CANONICAL → UNKNOWN.

Patterns now classified as EPHEMERAL (previously UNKNOWN):
- `agent-[0-9a-f]{12,}` — harness agent worktree hashes
- `worktree-<digits>`, `roborev-worktree-<digits>` — harness worktree dirs
- `cc-YYYYMMDD-HHMMSS` — session ID directories
- `<proj>-feat-cc-…` — branch/session worktree dirs
- `<proj>-feat-…`, `<proj>-fix-…`, `<proj>-sonnet` — branch form worktree dirs
- `^[0-9]+-` — issue/PR branch slugs (e.g. `652-canonical-audit`)
- `issue-[0-9]+-…` — issue-prefixed branch slugs
- `*_selftest*`, `branch_harvest_selftest.*`, `kb_digest_selftest_*` — selftest artefacts

Output line before:
```
canonical-projects-audit: UNKNOWN=437 CANONICAL=30 FIXTURE=303 [sessions.project:418]
```
Output line after (4-bucket form):
```
canonical-projects-audit: UNKNOWN=12 EPHEMERAL=420 CANONICAL=30 FIXTURE=303 [sessions.project:7]
```
(Exact numbers depend on live DB state at run time; approximate from issue analysis.)

### `--selftest` output (17 tests)

```
canonical_projects_audit selftest — fixture DB: /tmp/canonical_projects_audit_test_70141.duckdb
  PASS: config_digest_git_fixture_ classifies as FIXTURE
  PASS: roborev_pmhook_test_ classifies as FIXTURE
  PASS: repo1 classifies as FIXTURE
  PASS: llm does not classify as FIXTURE
  PASS: canonical_projects has 3 rows
  PASS: hello_t classifies as UNKNOWN
  PASS: agent-<hex12> classifies as EPHEMERAL
  PASS: worktree-<digits> classifies as EPHEMERAL
  PASS: roborev-worktree-<digits> classifies as EPHEMERAL
  PASS: cc-20260617-114959 classifies as EPHEMERAL
  PASS: <proj>-feat-cc-... classifies as EPHEMERAL
  PASS: <proj>-sonnet classifies as EPHEMERAL
  PASS: 652-canonical-audit classifies as EPHEMERAL
  PASS: issue-<digits>-<slug> classifies as EPHEMERAL
  PASS: branch_harvest_selftest_abc: _is_fixture=n, _is_ephemeral=EPHEMERAL
  PASS: irishbuoys does not classify as EPHEMERAL
  PASS: irishbuoys does not classify as FIXTURE

selftest: 17 tests — PASS=17 FAIL=0
```

`bash -n` passes on the updated script.

### Gap A — 10 alias rows in `canonical_project_aliases.csv`

Added mappings from observed raw `sessions.project` tokens to existing canonical slugs:

| raw token | → canonical slug |
|---|---|
| `irish_buoy_network` | `irishbuoys` |
| `buoy-network` | `irishbuoys` |
| `data-coMMpass` | `coMMpass` |
| `data-crypto` | `crypto` |
| `data-historical` | `historical` |
| `crypto-solwatch` | `crypto_solwatch` |
| `sport-football` | `football` |
| `sport-footbet` | `footbet` |
| `randomwalk-wiki` | `randomwalk` |
| `simulations-randomwalk` | `randomwalk` |

## FLAG: t-demos and eis6 — user decision needed

**`t-demos`** (1 session, 2026-04-04):
- Session ID: `-Users-johngavin-docs-gh-proj-data-tlang-t-demos`
- Path: `~/docs_gh/proj/data/tlang/t-demos/` (T language demo project)
- No obvious parent canonical slug. Options: add new canonical entry `t-demos` or `tlang`, or leave as UNKNOWN (only 1 session, low noise).

**`eis6`** (6 sessions, 2026-05-11 to 2026-05-14):
- Path: `~/docs_gh/proj/pers/eis6/` (personal EIS 6 project — no GitHub repo)
- No GH repo, so no existing canonical entry. Options: add new canonical entry `eis6` (private, `is_active=true`, `kind=personal`) or leave as UNKNOWN.
- 6 sessions across ~3 days suggests active work; probably worth a canonical entry.

Both are left unaliased in this PR. Please decide and either (a) add a row to `canonical_projects.csv` and/or `canonical_project_aliases.csv` directly, or (b) comment here with the decision and I'll add a follow-up commit.

## Post-merge step

After merging, run to apply the new aliases to the live DB:

```bash
~/.claude/scripts/canonical_projects_migrate.sh --apply
```

Then re-run the audit to see the new UNKNOWN count:

```bash
~/.claude/scripts/canonical_projects_audit.sh --verbose
```

## Files changed

- `.claude/scripts/canonical_projects_audit.sh` — Gap B (ephemeral bucket, 17-test selftest)
- `.claude/data/canonical_project_aliases.csv` — Gap A (10 new alias rows)

Refs llm#652.