### PR TITLE
feat(#656): Phase 0 — read-only audit script for scheduled GH Actions workflows

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -150,3 +150,8 @@
 - `ENOENT posix_spawn /bin/sh` on every hook = session cwd was deleted (NOT a missing shell/hook bug)
 - Recovery: end session, `cd ~/docs_gh/<project>`, relaunch via cc.sh (in-session cd unreliable)
 - Prevent: don't run from /tmp or ephemeral worktrees; never force-remove the cwd/ancestor (llm#647)
+
+## Stale PTY-Spare 100% CPU (see stale-pty-spare-cpu.md)
+- Orphaned Claude Code `--bg-pty-host`/`--bg-spare` daemons from an OLD version busy-loop at 100% CPU for days after a harness upgrade (PPID 1)
+- NOT Bash bg jobs, NOT user config — harness bug (orphaned-spare-after-upgrade). Observed 2026-06-23: two 2.1.168 spares stuck 16d while session ran 2.1.186
+- Kill any bg-pty-host whose version != running `claude`: `cur=$(readlink ~/.local/bin/claude | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'); pgrep -fl bg-pty-host | grep -v "$cur" | awk '{print $1}' | xargs -r kill`

--- a/.claude/memory/stale-pty-spare-cpu.md
+++ b/.claude/memory/stale-pty-spare-cpu.md
@@ -1,0 +1,25 @@
+---
+name: stale-pty-spare-cpu
+description: Orphaned Claude Code spare PTY-host daemons from an old version can busy-loop at 100% CPU for days after a harness upgrade — detect by version mismatch and kill
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 795fc0df-186f-44dc-b042-e97d0a67d842
+---
+
+Symptom: one or more processes pegged at ~100% CPU for days, command like
+`/Users/<u>/.local/share/claude/versions/<OLD_VER> --bg-pty-host /tmp/cc-daemon-*/spare/*.pty.sock ... --bg-spare ...`, with PPID 1 (orphaned/reparented to init).
+
+Cause: Claude Code's harness pre-spawns "spare" background PTY-host daemons to
+speed up launching background shells. On a harness **version upgrade** (e.g.
+2.1.168 → 2.1.186) the OLD version's spares can be orphaned instead of reaped,
+and a wedged spare busy-loops at 100% indefinitely. NOT caused by Bash
+background jobs (those exit cleanly) and NOT a user-config issue — it's a
+harness bug (orphaned-spare-after-upgrade). Observed 2026-06-23: two 2.1.168
+spares stuck at 100% for 16 days while the live session ran 2.1.186.
+
+Detect + kill stale spares (any spare whose version != the currently-running `claude`):
+```bash
+cur=$(readlink ~/.local/bin/claude 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'); pgrep -fl "bg-pty-host" | grep -v "${cur:-NOPE}" | awk '{print $1}' | xargs -r kill
+```
+Or simpler triage: `ps -Ao pid,etime,command -r | grep bg-pty-host` — kill any with multi-day ELAPSED. Graceful `kill` (TERM) suffices; the live session (`~/.local/bin/claude`, current version) is independent and unaffected. The current-version spares are idle and must be LEFT alone.

--- a/.claude/scripts/audit_scheduled_workflows.sh
+++ b/.claude/scripts/audit_scheduled_workflows.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# audit_scheduled_workflows.sh — Phase 0 audit for issue #656
+#
+# Finds all on:schedule GitHub Actions workflows across JohnGavin repos.
+# Classifies each as SAFE (self-committing) or AT-RISK (non-committing).
+# Reports enabled/disabled state.
+#
+# PURE READ-ONLY: no writes to any repo, no workflow enable/disable.
+#
+# Usage:
+#   ./audit_scheduled_workflows.sh [--quiet]
+#
+# Flags:
+#   --quiet   Print table only (suppress progress messages)
+#
+# Requirements: gh (authenticated), jq, base64
+#
+# Exit codes:
+#   0   Success (even if AT-RISK workflows found)
+#   1   Hard failure (gh not found, not authenticated, jq missing, etc.)
+#
+# Portability: \s is NOT portable in grep -E on macOS (BSD grep).
+# Always use [[:space:]] for whitespace character classes.
+
+set -euo pipefail
+
+QUIET=0
+for arg in "$@"; do
+  case "$arg" in
+    --quiet) QUIET=1 ;;
+  esac
+done
+
+log() {
+  if [ "$QUIET" -eq 0 ]; then
+    printf '%s\n' "$*" >&2
+  fi
+}
+
+# ──────────────────────────────────────────────
+# 0. Verify prerequisites
+# ──────────────────────────────────────────────
+if ! command -v gh >/dev/null 2>&1; then
+  printf 'ERROR: gh not found in PATH\n' >&2
+  exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  printf 'ERROR: gh not authenticated\n' >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'ERROR: jq not found in PATH\n' >&2
+  exit 1
+fi
+if ! command -v base64 >/dev/null 2>&1; then
+  printf 'ERROR: base64 not found in PATH\n' >&2
+  exit 1
+fi
+
+# ──────────────────────────────────────────────
+# 1. Build repo list
+# ──────────────────────────────────────────────
+SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
+# The script lives at <worktree>/.claude/scripts/ — navigate up to repo root
+LLM_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CANONICAL_CSV="$LLM_ROOT/.claude/data/canonical_projects.csv"
+
+declare -A SEEN_REPOS
+
+# Seed from canonical_projects.csv (column 3 = repo, skip header)
+if [ -f "$CANONICAL_CSV" ]; then
+  log "[1/3] Reading canonical projects from $CANONICAL_CSV"
+  while IFS=',' read -r _slug _display_name repo _kind _is_active _notes; do
+    # Skip header and blank lines
+    [ "$repo" = "repo" ] && continue
+    [ -z "$repo" ] && continue
+    # Only include repos with JohnGavin/ prefix (skip local-only entries)
+    case "$repo" in
+      JohnGavin/*) SEEN_REPOS["$repo"]=1 ;;
+    esac
+  done < "$CANONICAL_CSV"
+else
+  log "[1/3] canonical_projects.csv not found at $CANONICAL_CSV, using gh list only"
+fi
+
+log "[1/3] Canonical repos loaded: ${#SEEN_REPOS[@]}"
+
+# Union with repos pushed within last 90 days (non-archived)
+log "[2/3] Querying repos pushed in last 90 days..."
+
+# Portable date: try GNU date first, then BSD date (macOS)
+NINETY_DAYS_AGO=""
+if date -u -d '90 days ago' '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+  NINETY_DAYS_AGO="$(date -u -d '90 days ago' '+%Y-%m-%dT%H:%M:%SZ')"
+elif date -u -v-90d '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+  NINETY_DAYS_AGO="$(date -u -v-90d '+%Y-%m-%dT%H:%M:%SZ')"
+fi
+
+gh repo list JohnGavin --limit 200 \
+  --json name,pushedAt,isArchived \
+  2>/dev/null > /tmp/_aw_repolist.json
+
+if [ -n "$NINETY_DAYS_AGO" ]; then
+  jq -r --arg cutoff "$NINETY_DAYS_AGO" \
+    '.[] | select(.isArchived == false) | select(.pushedAt >= $cutoff) | "JohnGavin/" + .name' \
+    /tmp/_aw_repolist.json 2>/dev/null
+else
+  # Fallback: no date filtering, just skip archived
+  log "[2/3] WARNING: could not compute 90-day cutoff date; scanning all non-archived repos"
+  jq -r '.[] | select(.isArchived == false) | "JohnGavin/" + .name' \
+    /tmp/_aw_repolist.json 2>/dev/null
+fi > /tmp/_aw_active_repos.txt
+
+while IFS= read -r repo; do
+  [ -z "$repo" ] && continue
+  SEEN_REPOS["$repo"]=1
+done < /tmp/_aw_active_repos.txt
+
+log "[2/3] Total unique repos to scan: ${#SEEN_REPOS[@]}"
+
+# ──────────────────────────────────────────────
+# 2. Scan each repo for on:schedule workflows
+# ──────────────────────────────────────────────
+log "[3/3] Scanning workflows..."
+
+# Print table header
+printf '%-30s | %-40s | %-30s | %-22s | %s\n' \
+  "REPO" "WORKFLOW" "SCHEDULE(cron)" "STATE" "CLASS"
+printf -- '%.0s-' $(seq 1 130)
+printf '\n'
+
+TOTAL_SCHEDULED=0
+SAFE_COUNT=0
+ATRISK_COUNT=0
+DISABLED_COUNT=0
+ATRISK_LIST=""
+DISABLED_LIST=""
+UNCLASSIFIABLE=""
+
+for repo in "${!SEEN_REPOS[@]}"; do
+  repo_short="${repo#JohnGavin/}"
+
+  # List workflow files (404 = no .github/workflows dir — skip gracefully)
+  files_json=$(gh api "repos/$repo/contents/.github/workflows" \
+    --header "Accept: application/vnd.github.v3+json" \
+    2>/dev/null) || {
+    continue
+  }
+
+  # Validate it's a JSON array (could be a JSON object on error)
+  if ! printf '%s\n' "$files_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    continue
+  fi
+
+  # Fetch workflow run-state from Actions API (one call per repo, covers all workflows)
+  states_json=$(gh api "repos/$repo/actions/workflows" \
+    2>/dev/null) || {
+    states_json='{"workflows":[]}'
+  }
+
+  file_count=$(printf '%s\n' "$files_json" | jq 'length' 2>/dev/null) || continue
+  if [ -z "$file_count" ] || [ "$file_count" -eq 0 ]; then
+    continue
+  fi
+
+  i=0
+  while [ "$i" -lt "$file_count" ]; do
+    file_name=$(printf '%s\n' "$files_json" | jq -r ".[$i].name" 2>/dev/null)
+    file_path=$(printf '%s\n' "$files_json" | jq -r ".[$i].path" 2>/dev/null)
+
+    # Only process YAML workflow files
+    case "$file_name" in
+      *.yml|*.yaml) ;;
+      *) i=$((i + 1)); continue ;;
+    esac
+
+    # Fetch workflow file content (base64-encoded by GitHub API)
+    content_b64=$(gh api "repos/$repo/contents/$file_path" \
+      --header "Accept: application/vnd.github.v3+json" \
+      --jq '.content' \
+      2>/dev/null) || {
+      UNCLASSIFIABLE="${UNCLASSIFIABLE}  - ${repo_short}/${file_name}: could not fetch content\n"
+      i=$((i + 1))
+      continue
+    }
+
+    # Decode — strip embedded newlines before decode (portable for both GNU/BSD base64)
+    wf_content=$(printf '%s' "$content_b64" | tr -d '\n' | base64 --decode 2>/dev/null) || {
+      UNCLASSIFIABLE="${UNCLASSIFIABLE}  - ${repo_short}/${file_name}: base64 decode failed\n"
+      i=$((i + 1))
+      continue
+    }
+
+    # Detect on:schedule / cron: — look for a 'cron:' key in the YAML
+    # Use [[:space:]] not \s — \s is not portable in BSD grep -E (macOS)
+    if ! printf '%s\n' "$wf_content" | grep -qE '^[[:space:]]*-?[[:space:]]*cron:'; then
+      i=$((i + 1))
+      continue
+    fi
+
+    TOTAL_SCHEDULED=$((TOTAL_SCHEDULED + 1))
+
+    # Extract first cron expression
+    cron_expr=$(printf '%s\n' "$wf_content" \
+      | grep -E '^[[:space:]]*-?[[:space:]]*cron:' \
+      | head -1 \
+      | sed "s/.*cron:[[:space:]]*//" \
+      | tr -d "'" \
+      | tr -d '"' \
+      | sed 's/^[[:space:]]*//' \
+      | sed 's/[[:space:]]*$//') || cron_expr="(unknown)"
+
+    # Look up workflow state via Actions API (match on path)
+    wf_state=$(printf '%s\n' "$states_json" \
+      | jq -r --arg fpath "$file_path" \
+        '.workflows[] | select(.path == $fpath) | .state' \
+        2>/dev/null) || wf_state=""
+    [ -z "$wf_state" ] && wf_state="unknown"
+
+    if [ "$wf_state" = "disabled_inactivity" ] || [ "$wf_state" = "disabled_manually" ]; then
+      DISABLED_COUNT=$((DISABLED_COUNT + 1))
+      DISABLED_LIST="${DISABLED_LIST}  - ${repo_short}/${file_name} [state=${wf_state}]\n"
+    fi
+
+    # Classify: SAFE = body contains a git-commit/git-push pattern
+    # Patterns covered:
+    #   - bare 'git commit' / 'git push' steps
+    #   - stefanzweifel/git-auto-commit-action (most popular auto-commit action)
+    #   - EndBug/add-and-commit
+    #   - actions-gh-pages / peaceiris/actions-gh-pages (gh-pages deploy via force-push)
+    #   - ad-m/github-push-action
+    wf_class="AT-RISK"
+    # [[:space:]]+ is portable across BSD and GNU grep; \s+ is not.
+    if printf '%s\n' "$wf_content" | grep -qiE \
+      '(git[[:space:]]+commit|git[[:space:]]+push|git-auto-commit|add-and-commit|stefanzweifel/git-auto-commit-action|EndBug/add-and-commit|peaceiris/actions-gh-pages|ad-m/github-push-action)'; then
+      wf_class="SAFE"
+      SAFE_COUNT=$((SAFE_COUNT + 1))
+    else
+      ATRISK_COUNT=$((ATRISK_COUNT + 1))
+      ATRISK_LIST="${ATRISK_LIST}  - ${repo_short}/${file_name} [state=${wf_state}, cron=${cron_expr}]\n"
+    fi
+
+    # Truncate long values for table display
+    wf_display="${file_name%.yml}"
+    wf_display="${wf_display%.yaml}"
+    if [ "${#wf_display}" -gt 38 ]; then
+      wf_display="${wf_display:0:35}..."
+    fi
+    cron_display="$cron_expr"
+    if [ "${#cron_display}" -gt 28 ]; then
+      cron_display="${cron_display:0:25}..."
+    fi
+
+    printf '%-30s | %-40s | %-30s | %-22s | %s\n' \
+      "$repo_short" "$wf_display" "$cron_display" "$wf_state" "$wf_class"
+
+    i=$((i + 1))
+  done
+done
+
+# ──────────────────────────────────────────────
+# 3. Summary
+# ──────────────────────────────────────────────
+printf '\n'
+printf '%.0s═' $(seq 1 70)
+printf '\nSUMMARY\n'
+printf '%.0s─' $(seq 1 70)
+printf '\n'
+printf '  Total scheduled workflows found : %d\n' "$TOTAL_SCHEDULED"
+printf '  SAFE  (self-committing)         : %d\n' "$SAFE_COUNT"
+printf '  AT-RISK (non-committing)        : %d\n' "$ATRISK_COUNT"
+printf '  Already disabled                : %d\n' "$DISABLED_COUNT"
+printf '%.0s─' $(seq 1 70)
+printf '\n'
+
+if [ -n "$ATRISK_LIST" ]; then
+  printf '\nAT-RISK workflows (non-committing — at risk of auto-disable after 60d inactivity):\n'
+  printf '%b' "$ATRISK_LIST"
+else
+  printf '\nNo AT-RISK workflows found.\n'
+fi
+
+if [ -n "$DISABLED_LIST" ]; then
+  printf '\nAlready-disabled workflows (require re-enable + commit-keepalive fix):\n'
+  printf '%b' "$DISABLED_LIST"
+fi
+
+if [ -n "$UNCLASSIFIABLE" ]; then
+  printf '\nUnclassifiable (could not fetch/decode content):\n'
+  printf '%b' "$UNCLASSIFIABLE"
+fi
+
+printf '%.0s═' $(seq 1 70)
+printf '\n'
+
+# Cleanup temp files
+rm -f /tmp/_aw_repolist.json /tmp/_aw_active_repos.txt
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `.claude/scripts/audit_scheduled_workflows.sh` — a pure read-only scanner for `on:schedule` GitHub Actions workflows across JohnGavin repos.
- Implements Phase 0 of issue #656 (audit + work-list).
- Classifies each scheduled workflow as SAFE (self-committing) or AT-RISK (non-committing), reports `state` from the Actions API.

## Audit Results (2026-06-24)

| REPO | WORKFLOW | SCHEDULE(cron) | STATE | CLASS |
|------|----------|----------------|-------|-------|
| micromort | leaderboard-refresh | `0 6 * * 1` | active | SAFE |
| historical | data-poll | `0 6 * * 6` | active | SAFE |
| historical | link-audit | `17 6 * * *` | active | AT-RISK |
| crypto | weekly-pipeline | `0 7 * * 0` | active | AT-RISK |
| solwatch | weekly-pipeline | `0 7 * * 0` | active | AT-RISK |
| crypto_swarms | scheduled-run | `0 0,12 * * *` | active | SAFE |
| stratford-events | weekly_report | `0 8 * * 1` | disabled_inactivity | AT-RISK |
| tlang | build-to-cache | `0 3 * * *` | unknown | AT-RISK |
| irishbuoys | data-freshness-check | `30 5,17 * * *` | active | AT-RISK |
| irishbuoys | data-update | `0 6 * * *` | active | SAFE |
| irishbuoys | seed-cachix | `0 3 * * 1` | active | AT-RISK |
| irishbuoys | storm-alert | `0 8 * * *` | active | AT-RISK |
| irishbuoys | website-freshness-check | `0 6,18 * * *` | active | AT-RISK |
| llmtelemetry | daily-report | `0 8 * * *` | active | AT-RISK |
| llmtelemetry | hf-archive | `30 7 * * *` | active | AT-RISK |

**Totals: 15 scheduled | 4 SAFE | 11 AT-RISK | 1 already disabled**

## AT-RISK + Already-Disabled (Phase 1 work-list)

```
AT-RISK (active, need commit-keepalive):
  - historical/link-audit.yml          [daily, active]
  - crypto/weekly-pipeline.yml         [weekly, active]
  - solwatch/weekly-pipeline.yml       [weekly, active]
  - irishbuoys/data-freshness-check.yml [2x daily, active]
  - irishbuoys/seed-cachix.yml         [weekly, active]
  - irishbuoys/storm-alert.yml         [daily, active]
  - irishbuoys/website-freshness-check.yml [2x daily, active]
  - llmtelemetry/daily-report.yaml     [daily, active]
  - llmtelemetry/hf-archive.yaml       [daily, active]

AT-RISK + already disabled (need re-enable + keepalive):
  - stratford-events/weekly_report.yml [disabled_inactivity]

Unclassifiable (state=unknown, repo may be archived/private):
  - tlang/build-to-cache.yml
```

## Script Features

- **Pure read-only**: no `gh workflow enable/disable`, no repo writes
- Seeds repo list from `canonical_projects.csv` + `gh repo list` (last 90 days, non-archived)
- Fetches workflow YAML content via GitHub API (base64 decode)
- Classifies SAFE using: `git commit`, `git push`, `stefanzweifel/git-auto-commit-action`, `EndBug/add-and-commit`, `peaceiris/actions-gh-pages`, `ad-m/github-push-action`
- Uses `[[:space:]]` not `\s` (BSD grep portability)
- `--quiet` flag for table-only output

## Test plan

- [x] `bash -n` syntax check passes
- [x] Executed end-to-end, produced full table (15 scheduled workflows found)
- [x] No writes made to any repo
- [x] Cron detection handles `    - cron: '...'` YAML format correctly

Closes Phase 0 of #656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)