### PR TITLE
perf(mcp): boot r-btw via GC-rooted drv (cut ~4s off startup)

### DIFF
--- a/.claude/scripts/r_btw_mcp_launch.sh
+++ b/.claude/scripts/r_btw_mcp_launch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# r_btw_mcp_launch.sh — launch the r-btw MCP server via a GC-rooted nix drv to
+# avoid the ~8s nixpkgs re-evaluation that `nix-shell default.nix` pays on EVERY
+# Claude Code startup. The MCP boot is the dominant session-start cost; #657
+# only fixed the session_init.sh hook. See nix-operations.md memory + llm#596.
+#
+# Strategy: ask nix_gcroot_refresh.sh for a fresh-or-fallback drv path (instant
+# when default.nix is unchanged; re-instantiates only after an edit), then enter
+# via that drv (zero eval, zero network). Falls back to default.nix if no usable
+# drv exists, so the server always starts.
+set -euo pipefail
+
+NIX_FILE="/Users/johngavin/docs_gh/llm/default.nix"
+REFRESH="${HOME}/.claude/scripts/nix_gcroot_refresh.sh"
+NIX_SHELL="/nix/var/nix/profiles/default/bin/nix-shell"
+
+TARGET="$NIX_FILE"
+if [ -x "$REFRESH" ]; then
+    DRV="$("$REFRESH" "$NIX_FILE" 2>/dev/null | tail -1 || true)"
+    if [ -n "${DRV:-}" ] && [ -e "$DRV" ]; then
+        TARGET="$DRV"
+    fi
+fi
+
+RCODE='btw::btw_mcp_server(tools = btw::btw_tools(c("docs", "pkg", "files", "run", "env", "session")))'
+exec "$NIX_SHELL" "$TARGET" --run "Rscript -e '$RCODE'"


### PR DESCRIPTION
## Problem

User reported Claude Code still takes >10s to start despite #657. Investigation (measured, not assumed):

| Component | Time |
|---|---|
| `session_init.sh` SessionStart hook | 3.5s (✅ #657 fixed: was 17.6s) |
| other SessionStart hooks | 0.04s |
| **`r-btw` MCP server boot** (`nix-shell default.nix --run Rscript`) | **~10s every launch** ❌ |

`#657` optimized the SessionStart hook but the real bottleneck is the `r-btw` MCP server in `~/.claude.json`, which boots via `nix-shell default.nix` and re-evaluates the nixpkgs flake on every launch (8.75s, repeatable; first run also network-fetches `flakehub.com/.../nixpkgs-weekly`). The harness blocks on it to enumerate the btw tools.

This is the exact failure mode already documented in `nix-operations.md` / llm#596 for launchd/cron — the GC-rooted-drv rule was just never applied to the MCP config.

## Fix

`r_btw_mcp_launch.sh`: calls existing `nix_gcroot_refresh.sh` for a fresh-or-fallback drv (0.04s when `default.nix` unchanged; re-instantiates only after an edit), enters via that drv (zero eval / zero network), falls back to `default.nix` if no usable drv exists.

Measured: MCP boot ~10.5s → ~6.2s (the ~1.8s btw server init is irreducible). ~4s off perceived startup.

## Activation (manual, after merge)

Repoint the `r-btw` command in `~/.claude.json` (a global home file, not in this repo) to `~/.claude/scripts/r_btw_mcp_launch.sh` with empty `args`. Takes effect on session restart.

## Test

- `bash -n` clean
- refresh returns drv in 0.04s on fresh cache
- wrapper boots full btw MCP server via drv, exits cleanly on EOF in 6.15s

Follow-up to #657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)