### PR TITLE
feat(#674): warm r-btw GC-rooted drv on default.nix change (Option B)

### DIFF
--- a/.claude/hooks/nix_gcroot_warm.sh
+++ b/.claude/hooks/nix_gcroot_warm.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# nix_gcroot_warm.sh — PostToolUse hook (Bash|Edit|Write). When llm's default.nix
+# becomes newer than the GC-rooted drv stamp, fire nix_gcroot_refresh.sh in the
+# background so the NEXT session's r-btw MCP boot enters a pre-warmed drv (zero
+# eval) instead of paying ~10s re-instantiation inline. Idempotent, non-blocking.
+# Follow-up to #673 / #674 (Option B). See nix-operations.md and the
+# startup-cost-is-mcp-not-hook memory.
+#
+# Env overrides (for tests): NIX_GCROOT_WARM_NIX_FILE, NIX_GCROOT_WARM_STAMP,
+# NIX_GCROOT_WARM_REFRESH, NIX_GCROOT_WARM_DRYRUN=1 (print intent, do not spawn).
+set -euo pipefail
+
+NIX_FILE="${NIX_GCROOT_WARM_NIX_FILE:-/Users/johngavin/docs_gh/llm/default.nix}"
+STAMP="${NIX_GCROOT_WARM_STAMP:-${HOME}/.claude/nix-gcroots/llm-shell.drv.stamp}"
+REFRESH="${NIX_GCROOT_WARM_REFRESH:-${HOME}/.claude/scripts/nix_gcroot_refresh.sh}"
+
+# Hooks receive JSON on stdin; we never read it, so we never block on it.
+
+[ -f "$NIX_FILE" ] || exit 0
+[ -x "$REFRESH" ] || exit 0
+
+# Fresh? stamp exists AND default.nix is NOT newer than it -> nothing to do.
+if [ -e "$STAMP" ] && [ ! "$NIX_FILE" -nt "$STAMP" ]; then
+    exit 0
+fi
+
+# Stale (or no stamp yet): warm in the background. Never block the tool call.
+if [ "${NIX_GCROOT_WARM_DRYRUN:-0}" = "1" ]; then
+    echo "nix_gcroot_warm: would refresh $NIX_FILE"
+    exit 0
+fi
+nohup "$REFRESH" "$NIX_FILE" >/dev/null 2>&1 &
+exit 0

--- a/.claude/scripts/r_btw_mcp_launch.sh
+++ b/.claude/scripts/r_btw_mcp_launch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# r_btw_mcp_launch.sh — launch the r-btw MCP server via a GC-rooted nix drv to
+# avoid the ~8s nixpkgs re-evaluation that `nix-shell default.nix` pays on EVERY
+# Claude Code startup. The MCP boot is the dominant session-start cost; #657
+# only fixed the session_init.sh hook. See nix-operations.md memory + llm#596.
+#
+# Strategy: ask nix_gcroot_refresh.sh for a fresh-or-fallback drv path (instant
+# when default.nix is unchanged; re-instantiates only after an edit), then enter
+# via that drv (zero eval, zero network). Falls back to default.nix if no usable
+# drv exists, so the server always starts.
+set -euo pipefail
+
+NIX_FILE="/Users/johngavin/docs_gh/llm/default.nix"
+REFRESH="${HOME}/.claude/scripts/nix_gcroot_refresh.sh"
+NIX_SHELL="/nix/var/nix/profiles/default/bin/nix-shell"
+
+TARGET="$NIX_FILE"
+if [ -x "$REFRESH" ]; then
+    DRV="$("$REFRESH" "$NIX_FILE" 2>/dev/null | tail -1 || true)"
+    if [ -n "${DRV:-}" ] && [ -e "$DRV" ]; then
+        TARGET="$DRV"
+    fi
+fi
+
+RCODE='btw::btw_mcp_server(tools = btw::btw_tools(c("docs", "pkg", "files", "run", "env", "session")))'
+exec "$NIX_SHELL" "$TARGET" --run "Rscript -e '$RCODE'"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -531,6 +531,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/nix_gcroot_warm.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "Stop": [


### PR DESCRIPTION
## Summary

This is Option B of #674. After PR #673 wired r-btw MCP boot through a GC-rooted nix drv, the drv stamp can go stale when `default.nix` changes. This PR adds a PostToolUse hook that detects staleness and triggers the refresh in the background immediately — so the **next session's MCP boot** enters a pre-warmed drv (zero eval, ~0s) instead of paying ~10s re-instantiation inline.

- New hook: `.claude/hooks/nix_gcroot_warm.sh` — registered as `PostToolUse` with matcher `Bash|Edit|Write`, timeout 5s
- When `default.nix` is newer than `~/.claude/nix-gcroots/llm-shell.drv.stamp`, fires `nix_gcroot_refresh.sh` in the background via `nohup`
- Idempotent: refresh self-skips when the stamp is already fresh (~0.04s overhead)
- Non-blocking: hook exits immediately after backgrounding the refresh
- Env-overridable for testing: `NIX_GCROOT_WARM_NIX_FILE`, `NIX_GCROOT_WARM_STAMP`, `NIX_GCROOT_WARM_REFRESH`, `NIX_GCROOT_WARM_DRYRUN=1`

## Test plan

- [x] `bash -n .claude/hooks/nix_gcroot_warm.sh` — syntax OK (no output)
- [x] JSON valid: `python3 -c "import json; json.load(open('.claude/settings.json')); print('ok')"` → `ok`
- [x] Entry confirmed in PostToolUse: `[{'matcher': 'Bash|Edit|Write', 'hooks': [{'type': 'command', 'command': '~/.claude/hooks/nix_gcroot_warm.sh', 'timeout': 5}]}]`
- [x] FRESH case (stamp newer than nix file): exits 0, NO output — hook correctly skips
- [x] STALE case (nix file newer than stamp): prints `nix_gcroot_warm: would refresh /tmp/nf` — hook correctly fires

Closes #674. Follows #673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)