### PR TITLE
fix(#676): roborev silent-failure — detect job crashes, stop routing to dead agent

### DIFF
--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -71,16 +71,38 @@ cat("\n### Remote Sync\n")
 
 ## Roborev Findings Check
 
-Before committing, verify no unresolved roborev findings remain:
+Before committing, verify no unresolved roborev findings remain.
+
+**IMPORTANT:** `roborev summary --json` has two independent sections that must both be checked. Crashed reviews never produce a verdict, so `verdicts.failed` alone is insufficient:
+- `.verdicts` — only counts reviews that produced a pass/fail result. If a review job **crashes** (e.g. agent `IneligibleTierError`), it never reaches a verdict, so `verdicts.failed` stays 0 even when all jobs crashed (#676).
+- `.overview` — job-level outcomes (`total`, `done`, `failed`). Real job failures live here.
+- `.failures` — crash and quota counts: `{total, errors: {crash, quota}}`.
+- `.agents[]` — per-agent stats: `{agent, total, errors, pass_rate}`.
+
+Check ALL of the following and report NOT-CLEAN if ANY condition is true:
 
 ```bash
-/usr/local/bin/roborev summary --json | jq '.verdicts | {total: .total, failed: .failed, addressed: .addressed}'
+/usr/local/bin/roborev summary --json | jq '{
+  verdicts_failed: .verdicts.failed,
+  verdicts_addressed: .verdicts.addressed,
+  overview_failed: .overview.failed,
+  failures_total: (.failures.total // 0),
+  failures_crash: (.failures.errors.crash // 0),
+  failures_quota: (.failures.errors.quota // 0),
+  agent_errors: [.agents[] | select(.errors > 0) | {agent, errors}]
+}'
 ```
 
-If `verdicts.failed > 0` AND `verdicts.addressed < verdicts.failed`:
-- Report unaddressed failures with severity
+Report NOT-CLEAN and ask the user if ANY of:
+- `verdicts.failed > 0` AND `verdicts.addressed < verdicts.failed` — unaddressed verdict failures
+- `overview.failed > 0` — job-level failures (includes crashes that never produce a verdict)
+- `failures.total > 0` — any crash or quota errors recorded
+- any `.agents[] | .errors > 0` — an agent is failing systematically
+
+If NOT-CLEAN:
+- Report the failing category (verdict / job / crash / agent)
 - Ask user: "Proceed with commit despite unresolved roborev findings? (Y/N)"
-- If no, do NOT commit; suggest fixing failures first
+- If no, do NOT commit; suggest fixing failures first or investigating agent health (`roborev_agent_health.sh --status`)
 
 ## ctx.yaml Cache Verification
 

--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -959,6 +959,9 @@ if command -v /usr/local/bin/roborev >/dev/null 2>&1; then
     [ ! -f "$PWD/.roborev.toml" ] && WARNINGS="${WARNINGS}WARN: .roborev.toml missing "
   fi
   # Launch background refresh of roborev status
+  # Phase 8 (#676): also inspect job-level health via `roborev summary --json`.
+  # Crashed reviews never produce a verdict so verdicts.failed stays 0 — we must
+  # check overview.failed and failures.errors to detect silent failure cascades.
   mkdir -p "$(dirname "$_rv_cache")"
   nohup bash -c '
     rv_out=$(/usr/local/bin/roborev status 2>/dev/null) || true
@@ -966,7 +969,18 @@ if command -v /usr/local/bin/roborev >/dev/null 2>&1; then
       n_high=$(/usr/local/bin/roborev list --status failed --min-severity high --limit 100 2>/dev/null | grep -cE "^Job" || true)
       n_total=$(/usr/local/bin/roborev list --status failed --limit 100 2>/dev/null | grep -cE "^Job" || true)
       n_high="${n_high:-0}"; n_total="${n_total:-0}"
-      if [ "${n_high:-0}" -gt 0 ]; then
+      # Job-level failure check: overview.failed + failures.total (#676)
+      # Use timeout 5 so a slow roborev never blocks the background worker.
+      _summary=$(timeout 5 /usr/local/bin/roborev summary --json 2>/dev/null) || _summary=""
+      _overview_failed=0; _failures_total=0
+      if [ -n "$_summary" ] && command -v python3 >/dev/null 2>&1; then
+        _overview_failed=$(echo "$_summary" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('"'"'overview'"'"',{}).get('"'"'failed'"'"',0))" 2>/dev/null || echo 0)
+        _failures_total=$(echo "$_summary" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('"'"'failures'"'"',{}).get('"'"'total'"'"',0))" 2>/dev/null || echo 0)
+      fi
+      _overview_failed="${_overview_failed:-0}"; _failures_total="${_failures_total:-0}"
+      if [ "${_overview_failed:-0}" -gt 0 ] || [ "${_failures_total:-0}" -gt 0 ]; then
+        echo "roborev:FAIL(${_overview_failed})"
+      elif [ "${n_high:-0}" -gt 0 ]; then
         echo "roborev:${n_high}high/${n_total}total"
       elif [ "${n_total:-0}" -gt 0 ]; then
         echo "roborev:${n_total}failed"

--- a/.claude/scripts/roborev_agent_health.sh
+++ b/.claude/scripts/roborev_agent_health.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # roborev_agent_health.sh — detect sustained codex failures and temporarily
-# swap to gemini in ~/.roborev/config.toml; probe for recovery and swap back.
+# swap to claude-code in ~/.roborev/config.toml; probe for recovery and swap back.
+# (#676: free-tier agent was permanently dead — IneligibleTierError/UNSUPPORTED_CLIENT, exit 55.
+# All swap targets changed to claude-code.)
 #
 # Closes roborev #900 (#181 Theme 5) — timestamp format mismatch fixed.
 # The WHERE clause normalises ISO-8601 (YYYY-MM-DDTHH:MM:SS...Z) to SQLite's
@@ -175,20 +177,42 @@ if [ "$STATUS_ONLY" -eq 1 ]; then
   exit 0
 fi
 
-# ── Throttle: swap codex → gemini ────────────────────────────────────────────
+# ── Active-agent failure guard (#676) ────────────────────────────────────────
+# Check job-level health via roborev summary --json. Crashed reviews never
+# produce a verdict, so verdicts.failed == 0 is NOT a "clean" signal. We must
+# inspect overview.failed and agents[].errors to surface silent failures.
+# This guard logs a WARNING so roborev_agent_health.log captures the signal
+# even when the codex-specific failure count is below the swap threshold.
+_active_summary=$(timeout 5 "$ROBOREV" summary --json 2>/dev/null) || _active_summary=""
+if [ -n "$_active_summary" ] && command -v python3 >/dev/null 2>&1; then
+  _active_overview_failed=$(echo "$_active_summary" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); print(d.get('overview',{}).get('failed',0))" \
+    2>/dev/null || echo 0)
+  _active_agent_errors=$(echo "$_active_summary" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin)
+[print(a['agent']+'='+str(a.get('errors',0))) for a in d.get('agents',[]) if a.get('errors',0)>0]" \
+    2>/dev/null || echo "")
+  _active_overview_failed="${_active_overview_failed:-0}"
+  if [ "${_active_overview_failed:-0}" -gt 0 ] || [ -n "$_active_agent_errors" ]; then
+    log "WARN: active agent failing: overview.failed=${_active_overview_failed} agent_errors=${_active_agent_errors:-none}"
+    echo "roborev_agent_health: WARN: active agent failing (overview.failed=${_active_overview_failed}, agent_errors=${_active_agent_errors:-none})"
+  fi
+fi
+
+# ── Throttle: swap codex → claude-code ───────────────────────────────────────
 if [ "$recent_failures" -ge "$FAILURE_THRESHOLD" ] && ! marker_exists; then
   ts=$(date -u +%Y%m%d_%H%M%S)
   backup_path="${CONFIG_TOML}.bak-agent-health-${ts}"
   ts_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
   if [ "$APPLY" -eq 0 ]; then
-    echo "[dry] would throttle codex: backup config, swap to gemini, create marker, kickstart daemon"
+    echo "[dry] would throttle codex: backup config, swap to claude-code, create marker, kickstart daemon"
     echo "  reason: $recent_failures codex failures in last ${FAILURE_WINDOW_MIN} minutes"
     log "dry-run: would throttle codex (failures=$recent_failures threshold=$FAILURE_THRESHOLD)"
     exit 0
   fi
 
-  log "throttle: $recent_failures codex failures in last ${FAILURE_WINDOW_MIN}m — swapping to gemini"
+  log "throttle: $recent_failures codex failures in last ${FAILURE_WINDOW_MIN}m — swapping to claude-code"
 
   # Backup config
   if ! cp "$CONFIG_TOML" "$backup_path"; then
@@ -199,13 +223,14 @@ if [ "$recent_failures" -ge "$FAILURE_THRESHOLD" ] && ! marker_exists; then
   log "backup: $backup_path"
 
   # Swap agents in config (in-place sed; BSD/GNU compatible via temp file)
+  # (#676: swap target changed to claude-code; free-tier agent was permanently dead)
   tmp_config=$(mktemp)
   sed \
-    -e "s|^default_agent = 'codex'|default_agent = 'gemini'|" \
-    -e "s|^default_backup_agent = 'gemini'|default_backup_agent = 'codex'|" \
+    -e "s|^default_agent = 'codex'|default_agent = 'claude-code'|" \
+    -e "s|^default_backup_agent = 'claude-code'|default_backup_agent = 'codex'|" \
     "$CONFIG_TOML" > "$tmp_config"
   mv "$tmp_config" "$CONFIG_TOML"
-  log "config: swapped default_agent=gemini backup_agent=codex"
+  log "config: swapped default_agent=claude-code backup_agent=codex"
 
   # Write marker
   cat > "$MARKER" <<EOF
@@ -226,7 +251,7 @@ EOF
     log "warn: $LAUNCHD_PLIST not found — daemon not kickstarted"
   fi
 
-  echo "roborev_agent_health [applied]: codex throttled — swapped to gemini (backup: $backup_path)"
+  echo "roborev_agent_health [applied]: codex throttled — swapped to claude-code (backup: $backup_path)"
   exit 0
 fi
 
@@ -248,10 +273,11 @@ if marker_exists && [ "$recent_failures" -eq 0 ]; then
       log "recovery: restored config from $backup_path"
     else
       # Backup gone — re-swap manually
+      # (#676: swap target was claude-code, so invert back to codex primary / claude-code backup)
       tmp_config=$(mktemp)
       sed \
-        -e "s|^default_agent = 'gemini'|default_agent = 'codex'|" \
-        -e "s|^default_backup_agent = 'codex'|default_backup_agent = 'gemini'|" \
+        -e "s|^default_agent = 'claude-code'|default_agent = 'codex'|" \
+        -e "s|^default_backup_agent = 'codex'|default_backup_agent = 'claude-code'|" \
         "$CONFIG_TOML" > "$tmp_config"
       mv "$tmp_config" "$CONFIG_TOML"
       log "recovery: backup not found — re-swapped config in place"
@@ -271,8 +297,8 @@ if marker_exists && [ "$recent_failures" -eq 0 ]; then
 
     echo "roborev_agent_health [applied]: codex recovered — restored as primary agent"
   else
-    log "recovery-check: codex still unhealthy (version probe failed) — remaining on gemini"
-    echo "roborev_agent_health: codex still unhealthy — remaining on gemini"
+    log "recovery-check: codex still unhealthy (version probe failed) — remaining on claude-code"
+    echo "roborev_agent_health: codex still unhealthy — remaining on claude-code"
   fi
   exit 0
 fi

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -3,7 +3,8 @@ agent = ''
 # Default model for this repo when no workflow-specific model is set.
 model = ''
 # Backup agent for this repo if the primary agent fails.
-backup_agent = 'gemini'
+# Changed from 'gemini' to 'codex' — gemini free tier permanently dead (#676, IneligibleTierError/UNSUPPORTED_CLIENT, exit 55).
+backup_agent = 'codex'
 # Backup model for this repo if the primary model fails.
 backup_model = ''
 # Number of related reviews to include as context for this repo.


### PR DESCRIPTION
## Summary

- **`.roborev.toml`**: Changed `backup_agent` from the dead free-tier agent to `'codex'` (IneligibleTierError/UNSUPPORTED_CLIENT/exit 55 makes it permanently unavailable — #676).
- **`.claude/commands/session-end.md`** (+ `bye.md` symlink): Roborev Findings Check now inspects `overview.failed`, `failures.total`, and `agents[].errors` in addition to `verdicts.failed`. Crashed reviews never produce a verdict; checking only `verdicts.failed` silently hides 28/28 job crashes as "0 failed".
- **`.claude/hooks/session_init.sh` Phase 8**: Background roborev cache refresh now also calls `roborev summary --json` (wrapped in `timeout 5`); emits `roborev:FAIL(n)` instead of `roborev:ok` when `overview.failed > 0` or `failures.total > 0`.
- **`.claude/scripts/roborev_agent_health.sh`**: (a) All swap targets changed from the dead free-tier agent to `claude-code` (verified working — `grep -c gemini` → 0); (b) Added active-agent failure guard that logs a `WARN` line when `overview.failed > 0` or any `agents[].errors > 0`, making silent failure visible in the health log even below the swap threshold.

**Note:** The operational config fix (`default_agent='claude-code'`) was already applied out-of-repo by the orchestrator and is not part of this PR.

## Test plan

- [ ] `bash -n .claude/hooks/session_init.sh` — clean
- [ ] `bash -n .claude/scripts/roborev_agent_health.sh` — clean
- [ ] `python3 -c "import tomllib; tomllib.load(open('.roborev.toml','rb')); print('toml ok')"` — `toml ok`
- [ ] `grep -c gemini .claude/scripts/roborev_agent_health.sh` → `0`
- [ ] `grep -c "overview.failed\|\.failures\|agents\[\]" .claude/commands/session-end.md` → non-zero
- [ ] `diff .claude/commands/session-end.md .claude/commands/bye.md` → no output (symlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)