### PR TITLE
docs(roborev-bridge): clarify intentional no-status-filter + 0-closures behaviour (#580 follow-up)

### DIFF
--- a/.claude/scripts/roborev_bridge_to_unified.sh
+++ b/.claude/scripts/roborev_bridge_to_unified.sh
@@ -202,8 +202,14 @@ _ROWS_ATTEMPTED=0
 # Aggregation SQL.
 # Severity is embedded in reviews.output as markdown: "**Severity**: High|Medium|Low".
 # autoclose_today = closures with closure_type='stale' in last 24h.
+#   closures may legitimately have 0 rows (e.g. before any stale auto-closures
+#   accrue); COALESCE(,0) returns 0 in that case -- not a bug.
 # oldest_open_days = max age in days of any open finding via review_jobs.finished_at.
 # Only returns projects with open reviews OR recent activity.
+# LEFT JOIN review_jobs: intentionally no review_jobs.status filter -- jobs that
+#   crashed before producing a reviews row (status='failed' after #677 reclassify)
+#   still surface their reviews rows if present; jobs with no reviews row yield
+#   NULL columns, all handled by the COALESCE(,0) wrappers above.
 _SQLITE_QUERY="
 SELECT
   r.name AS project,


### PR DESCRIPTION
## Summary

Comment-only follow-up to #580 (roborev SQLite → unified.duckdb bridge). A schema audit found two behaviours that look like bugs to a future reader but are intentional. No logic, SQL, or behaviour changes.

**Comment 1 — LEFT JOIN no-status-filter (lines 209–212):**
The `LEFT JOIN review_jobs` deliberately has no `review_jobs.status` filter, so jobs that crashed before producing a `reviews` row still surface their findings if they exist. Missing `reviews` rows yield NULLs, handled by all the `COALESCE(,0)` wrappers. Relevant after #677 reclassified crashed jobs from `running` → `failed`.

**Comment 2 — 0 closures is not a bug (lines 205–206):**
The `closures` table may legitimately have 0 rows before any stale auto-closures accrue. `COALESCE(,0)` correctly returns 0 for `autoclose_today` in that case.

## Test plan
- [x] `bash -n .claude/scripts/roborev_bridge_to_unified.sh` passes (no parse errors)
- [x] Diff is pure comment additions — no SQL, logic, or shell behaviour changed