### PR TITLE
feat(#679): roborev cross-counter consistency check

### DIFF
--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -104,6 +104,16 @@ If NOT-CLEAN:
 - Ask user: "Proceed with commit despite unresolved roborev findings? (Y/N)"
 - If no, do NOT commit; suggest fixing failures first or investigating agent health (`roborev_agent_health.sh --status`)
 
+### Cross-counter consistency check (#679)
+
+Also run the automated consistency check — it detects self-contradictory state that the raw counters above might not surface:
+
+```bash
+~/.claude/scripts/roborev_consistency_check.sh --verbose
+```
+
+If it prints any `roborev:INCONSISTENT(<which>)` line, add that to the NOT-CLEAN report above. The check is tolerant — it exits 0 silently if roborev or jq is missing, so it never blocks /bye.
+
 ## ctx.yaml Cache Verification
 
 After commit/push, verify all ctx files are current:

--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -996,6 +996,26 @@ fi
 # Phase 8b: roborev-autoclose visibility
 phase_roborev_autoclose 2>/dev/null || echo "roborev-autoclose: threshold=unknown (error reading counter file)"
 
+# Phase 8c: roborev cross-counter consistency check (#679)
+# Detects self-contradictory state in roborev summary (e.g. large backlog + no verdicts,
+# or 100% pass_rate while many jobs crashed). Separate cache so Phase 8's roborev_status
+# token is unchanged. Failure of this check NEVER breaks session init.
+_rvc_cache="${HOME}/.claude/logs/session_init_roborev_consistency_cache.txt"
+_rvc_script="${CLAUDE_DIR}/scripts/roborev_consistency_check.sh"
+rvc_status=""
+if [ -f "$_rvc_cache" ]; then
+  rvc_status=$(cat "$_rvc_cache" 2>/dev/null) || rvc_status=""
+fi
+if [ -x "$_rvc_script" ] && command -v /usr/local/bin/roborev >/dev/null 2>&1; then
+  mkdir -p "$(dirname "$_rvc_cache")"
+  _rvc_script_snap="$_rvc_script"
+  _rvc_cache_snap="$_rvc_cache"
+  nohup bash -c "
+    _out=\$(timeout 10 bash '${_rvc_script_snap}' 2>/dev/null | head -1 || true)
+    echo \"\${_out:-roborev:consistent}\" > '${_rvc_cache_snap}'
+  " > /dev/null 2>&1 &
+fi
+
 # Phase 9: Burn rate — CodexBar is now primary (#281 Phase 4c; closes llm#420).
 # Soak log (2026-06-05 to 2026-06-16) confirmed CodexBar reliable (burn:78-86%)
 # while ccusage/cmonitor-rs has been dead (BURN GUARD DEAD, 5+ consecutive runs).
@@ -1233,6 +1253,7 @@ summary="$summary | env-class:${env_class_val} | config:ok | ${n_skills:-skills:
 [ "$is_worktree" = "Y" ] && summary="$summary | worktree:active"
 [ "$wt_count" -gt 0 ] && summary="$summary | worktrees:${wt_count}"
 [ -n "$roborev_status" ] && summary="$summary | $roborev_status"
+[ -n "$rvc_status" ] && summary="$summary | $rvc_status"
 [ -n "$burn_output" ] && summary="$summary | $burn_output"
 echo "$summary"
 

--- a/.claude/scripts/roborev_consistency_check.sh
+++ b/.claude/scripts/roborev_consistency_check.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# roborev_consistency_check.sh
+# Cross-counter consistency check for roborev — asserts that the numbers in
+# `roborev summary --json` do not contradict each other, which is the earliest
+# cheap signal that the review pipeline is broken (llm#679, meta-fix for #676).
+#
+# Usage:
+#   roborev_consistency_check.sh [--verbose] [--json]
+#   roborev_consistency_check.sh --fixture <summary.json> [--backlog-count <n>] [--verbose] [--json]
+#
+# Exit codes:
+#   0 — all invariants pass (or check skipped due to missing tooling)
+#   1 — at least one invariant INCONSISTENT
+#
+# Emits on failure:
+#   roborev:INCONSISTENT(<which>) <short reason with numbers>
+# Silent on success unless --verbose is given.
+#
+# Wired into session_init.sh banner (Phase 8) and /bye (session-end.md).
+# See: llm#679
+
+set -euo pipefail
+
+# ── Thresholds (tune here) ───────────────────────────────────────────────────
+BACKLOG_THRESHOLD=10          # open backlog items above which we expect verdicts
+VERDICTS_LOW_THRESHOLD=1      # verdict count at-or-below which we flag if backlog large
+CRASH_RATE_THRESHOLD="0.5"    # fraction of overview.total that is crash+quota → flag
+AGENT_ERROR_RATE_THRESHOLD="0.5"  # per-agent errors/total fraction → flag
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+VERBOSE=0
+JSON_OUT=0
+FIXTURE_FILE=""
+FIXTURE_BACKLOG=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --verbose)    VERBOSE=1; shift ;;
+    --json)       JSON_OUT=1; shift ;;
+    --fixture)    FIXTURE_FILE="$2"; shift 2 ;;
+    --backlog-count) FIXTURE_BACKLOG="$2"; shift 2 ;;
+    *)            shift ;;  # ignore unknown flags
+  esac
+done
+
+# ── Tooling checks ────────────────────────────────────────────────────────────
+ROBOREV_BIN="${ROBOREV_BIN:-/usr/local/bin/roborev}"
+
+if [ -z "$FIXTURE_FILE" ]; then
+  if ! command -v "$ROBOREV_BIN" >/dev/null 2>&1 && [ ! -x "$ROBOREV_BIN" ]; then
+    echo "roborev:consistency-skipped (roborev not installed)"
+    exit 0
+  fi
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "roborev:consistency-skipped (jq not installed)"
+  exit 0
+fi
+
+# ── Gather summary JSON ───────────────────────────────────────────────────────
+if [ -n "$FIXTURE_FILE" ]; then
+  if [ ! -f "$FIXTURE_FILE" ]; then
+    echo "roborev:consistency-skipped (fixture file not found: $FIXTURE_FILE)"
+    exit 0
+  fi
+  SUMMARY_JSON=$(cat "$FIXTURE_FILE")
+else
+  SUMMARY_JSON=$(timeout 5 "$ROBOREV_BIN" summary --json 2>/dev/null) || SUMMARY_JSON=""
+fi
+
+if [ -z "$SUMMARY_JSON" ]; then
+  echo "roborev:consistency-skipped (summary --json returned empty)"
+  exit 0
+fi
+
+# Validate it's valid JSON
+if ! echo "$SUMMARY_JSON" | jq . >/dev/null 2>&1; then
+  echo "roborev:consistency-skipped (summary --json returned invalid JSON)"
+  exit 0
+fi
+
+# ── Extract counters via jq ───────────────────────────────────────────────────
+OV_TOTAL=$(echo "$SUMMARY_JSON"    | jq -r '.overview.total         // 0')
+OV_FAILED=$(echo "$SUMMARY_JSON"   | jq -r '.overview.failed        // 0')
+VD_TOTAL=$(echo "$SUMMARY_JSON"    | jq -r '.verdicts.total         // 0')
+VD_PASS_RATE=$(echo "$SUMMARY_JSON"| jq -r '.verdicts.pass_rate     // 0')
+CR_CRASH=$(echo "$SUMMARY_JSON"    | jq -r '.failures.errors.crash  // 0')
+CR_QUOTA=$(echo "$SUMMARY_JSON"    | jq -r '.failures.errors.quota  // 0')
+
+# Integer-safe coercions (jq -r can return null if field absent)
+OV_TOTAL="${OV_TOTAL:-0}";   OV_TOTAL="${OV_TOTAL/null/0}"
+OV_FAILED="${OV_FAILED:-0}"; OV_FAILED="${OV_FAILED/null/0}"
+VD_TOTAL="${VD_TOTAL:-0}";   VD_TOTAL="${VD_TOTAL/null/0}"
+VD_PASS_RATE="${VD_PASS_RATE:-0}"; VD_PASS_RATE="${VD_PASS_RATE/null/0}"
+CR_CRASH="${CR_CRASH:-0}";   CR_CRASH="${CR_CRASH/null/0}"
+CR_QUOTA="${CR_QUOTA:-0}";   CR_QUOTA="${CR_QUOTA/null/0}"
+
+# ── Backlog count ─────────────────────────────────────────────────────────────
+# In fixture mode: use --backlog-count N (or 0 if not provided)
+# In live mode: query sqlite DB
+if [ -n "$FIXTURE_BACKLOG" ]; then
+  BACKLOG_OPEN="$FIXTURE_BACKLOG"
+else
+  BACKLOG_OPEN=0
+  _RB_DB="${HOME}/.roborev/reviews.db"
+  if [ -f "$_RB_DB" ] && command -v sqlite3 >/dev/null 2>&1; then
+    BACKLOG_OPEN=$(sqlite3 "$_RB_DB" \
+      "SELECT COUNT(*) FROM reviews WHERE closed=0" 2>/dev/null) || BACKLOG_OPEN=0
+    BACKLOG_OPEN="${BACKLOG_OPEN:-0}"
+  fi
+fi
+
+# ── Invariant checks ──────────────────────────────────────────────────────────
+INCONSISTENCIES=""
+FIRED_WHICH=""
+
+# Helper: append a finding
+_flag() {
+  local which="$1"; local reason="$2"
+  INCONSISTENCIES="${INCONSISTENCIES}roborev:INCONSISTENT(${which}) ${reason}"$'\n'
+  FIRED_WHICH="${FIRED_WHICH}${which} "
+}
+
+# Invariant 1: Large backlog with near-zero verdicts
+# If we have many open reviews but almost no verdicts, reviews aren't producing outputs
+if [ "$BACKLOG_OPEN" -gt "$BACKLOG_THRESHOLD" ] 2>/dev/null; then
+  if [ "$VD_TOTAL" -le "$VERDICTS_LOW_THRESHOLD" ] 2>/dev/null; then
+    _flag "backlog-vs-verdicts" \
+      "backlog.open=${BACKLOG_OPEN} but verdicts.total=${VD_TOTAL} (>$BACKLOG_THRESHOLD open reviews, <=$VERDICTS_LOW_THRESHOLD verdicts suggests reviews not completing)"
+  fi
+fi
+
+# Invariant 2: Jobs exist but zero verdicts — every job failed before verdict
+if [ "$OV_TOTAL" -gt 0 ] 2>/dev/null; then
+  if [ "$VD_TOTAL" -eq 0 ] 2>/dev/null; then
+    _flag "jobs-no-verdicts" \
+      "overview.total=${OV_TOTAL} but verdicts.total=0 (all jobs failed before producing a verdict)"
+  fi
+fi
+
+# Invariant 3: High crash+quota rate
+# Use jq for float arithmetic: (crash+quota)/total > threshold
+if [ "$OV_TOTAL" -gt 0 ] 2>/dev/null; then
+  CR_HIGH=$(echo "$SUMMARY_JSON" | jq --argjson threshold "$CRASH_RATE_THRESHOLD" \
+    --argjson total "$OV_TOTAL" \
+    '((.failures.errors.crash // 0) + (.failures.errors.quota // 0)) as $errors |
+     if $total > 0 and ($errors / $total) > $threshold then 1 else 0 end' 2>/dev/null) || CR_HIGH=0
+  if [ "${CR_HIGH:-0}" = "1" ]; then
+    CR_TOTAL=$((CR_CRASH + CR_QUOTA))
+    _flag "high-crash-rate" \
+      "crash+quota=${CR_TOTAL}/${OV_TOTAL} jobs ($(echo "$SUMMARY_JSON" | \
+        jq -r "(((.failures.errors.crash // 0) + (.failures.errors.quota // 0)) / $OV_TOTAL * 100 | round | tostring) + \"%\"" 2>/dev/null || echo "?%") > threshold ${CRASH_RATE_THRESHOLD})"
+  fi
+fi
+
+# Invariant 4: Per-agent error rate above threshold
+# Iterate over agents[] where errors/total > threshold
+if echo "$SUMMARY_JSON" | jq -e '.agents | type == "array"' >/dev/null 2>&1; then
+  BAD_AGENTS=$(echo "$SUMMARY_JSON" | jq -r \
+    --argjson threshold "$AGENT_ERROR_RATE_THRESHOLD" \
+    '.agents[] |
+     select(.total > 0 and ((.errors // 0) / .total) > $threshold) |
+     .agent + "=" + ((.errors // 0) | tostring) + "/" + (.total | tostring)' \
+    2>/dev/null) || BAD_AGENTS=""
+  if [ -n "$BAD_AGENTS" ]; then
+    while IFS= read -r agent_stat; do
+      [ -z "$agent_stat" ] && continue
+      agent_name=$(echo "$agent_stat" | cut -d= -f1)
+      agent_nums=$(echo "$agent_stat" | cut -d= -f2)
+      _flag "agent:${agent_name}" \
+        "agent ${agent_name} errors=${agent_nums} (>${AGENT_ERROR_RATE_THRESHOLD} rate)"
+    done <<< "$BAD_AGENTS"
+  fi
+fi
+
+# Invariant 5: 100% pass_rate but overview.failed > 0 — pass_rate masks crashes
+# Pass rate is computed only over verdicts; if jobs crash they don't reach verdict,
+# so pass_rate can appear 1.0 while overview.failed is high.
+if [ "$OV_FAILED" -gt 0 ] 2>/dev/null; then
+  # Compare float: pass_rate == 1.0
+  RATE_IS_ONE=$(echo "$VD_PASS_RATE" | awk '{print ($1 == 1.0) ? "1" : "0"}')
+  if [ "${RATE_IS_ONE:-0}" = "1" ]; then
+    _flag "passrate-masks-crashes" \
+      "verdicts.pass_rate=1.0 but overview.failed=${OV_FAILED} (\"100% pass\" is hiding job-level failures)"
+  fi
+fi
+
+# ── JSON output mode ──────────────────────────────────────────────────────────
+if [ "$JSON_OUT" = "1" ]; then
+  jq -n \
+    --argjson ov_total    "$OV_TOTAL" \
+    --argjson ov_failed   "$OV_FAILED" \
+    --argjson vd_total    "$VD_TOTAL" \
+    --arg     vd_rate     "$VD_PASS_RATE" \
+    --argjson cr_crash    "$CR_CRASH" \
+    --argjson cr_quota    "$CR_QUOTA" \
+    --argjson backlog     "$BACKLOG_OPEN" \
+    --arg     fired       "${FIRED_WHICH% }" \
+    --argjson bt          "$BACKLOG_THRESHOLD" \
+    --argjson vt          "$VERDICTS_LOW_THRESHOLD" \
+    --arg     ct          "$CRASH_RATE_THRESHOLD" \
+    --arg     at          "$AGENT_ERROR_RATE_THRESHOLD" \
+    '{
+      counters: {
+        overview_total: $ov_total,
+        overview_failed: $ov_failed,
+        verdicts_total: $vd_total,
+        verdicts_pass_rate: ($vd_rate | tonumber),
+        crash: $cr_crash,
+        quota: $cr_quota,
+        backlog_open: $backlog
+      },
+      thresholds: {
+        backlog_open_gt: $bt,
+        verdicts_total_lte: $vt,
+        crash_rate_gt: ($ct | tonumber),
+        agent_error_rate_gt: ($at | tonumber)
+      },
+      inconsistencies_fired: (if $fired == "" then [] else ($fired | split(" ") | map(select(. != ""))) end)
+    }' 2>/dev/null || true
+fi
+
+# ── Emit results ──────────────────────────────────────────────────────────────
+if [ -n "$INCONSISTENCIES" ]; then
+  printf '%s' "$INCONSISTENCIES"
+  exit 1
+fi
+
+if [ "$VERBOSE" = "1" ]; then
+  echo "roborev:consistent (backlog=${BACKLOG_OPEN}, overview_total=${OV_TOTAL}, verdicts=${VD_TOTAL}, crash+quota=$((CR_CRASH+CR_QUOTA)))"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds `.claude/scripts/roborev_consistency_check.sh` — asserts 5 cross-counter invariants over `roborev summary --json` to automatically detect self-contradictory state (the `#676` silent-failure pattern where `verdicts.total=1` while `backlog.open=59` was visually obvious but un-flagged by code)
- Wires the check into session_init.sh (Phase 8c, background + cache pattern) and `/bye` (session-end.md / bye.md, additive step in Roborev Findings Check section)

## The 5 Invariants

| # | Invariant | Token |
|---|-----------|-------|
| 1 | `backlog.open > 10` AND `verdicts.total <= 1` | `INCONSISTENT(backlog-vs-verdicts)` |
| 2 | `overview.total > 0` AND `verdicts.total == 0` | `INCONSISTENT(jobs-no-verdicts)` |
| 3 | `(crash + quota) / overview.total > 0.5` | `INCONSISTENT(high-crash-rate)` |
| 4 | any `agents[].errors / agents[].total > 0.5` | `INCONSISTENT(agent:<name>)` |
| 5 | `verdicts.pass_rate == 1.0` AND `overview.failed > 0` | `INCONSISTENT(passrate-masks-crashes)` |

## Self-test fixture results

**Bad fixture** (#676 case: `overview.total=28, overview.failed=28, verdicts.total=1, pass_rate=1, crash=27, quota=1, gemini errors=28/28`, backlog=59):
```
roborev:INCONSISTENT(backlog-vs-verdicts) backlog.open=59 but verdicts.total=1 (>10 open reviews, <=1 verdicts suggests reviews not completing)
roborev:INCONSISTENT(high-crash-rate) crash+quota=28/28 jobs (100% > threshold 0.5)
roborev:INCONSISTENT(agent:gemini) agent gemini errors=28/28 (>0.5 rate)
roborev:INCONSISTENT(passrate-masks-crashes) verdicts.pass_rate=1.0 but overview.failed=28 ("100% pass" is hiding job-level failures)
exit 1
```

**Healthy fixture** (25 total, 2 failed, 23 verdicts, pass_rate=0.78, 1 crash, claude-code at 8% error rate, backlog=5):
```
(no output — exits 0 silently)
```

## Wiring diffs (additive only)

**session_init.sh**: Added Phase 8c block (~16 lines) between Phase 8b (autoclose) and Phase 9 (burn rate). Uses a separate cache file (`session_init_roborev_consistency_cache.txt`) so Phase 8's `roborev_status` token is unchanged. Consistency token appended to summary line as `| rvc_status`.

**session-end.md** (bye.md mirrors via symlink): Added "Cross-counter consistency check (#679)" subsection inside "Roborev Findings Check" — 10 lines, calls `~/.claude/scripts/roborev_consistency_check.sh --verbose` and merges any `INCONSISTENT` findings into the NOT-CLEAN report.

## Tolerant behaviour

Exits 0 with `roborev:consistency-skipped` if roborev binary missing, jq missing, summary --json returns empty or invalid JSON, or fixture file not found — never blocks a session.

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)