### PR TITLE
fix(launchd): overnight cron errors — nix-shell env + NULL repo guard

### DIFF
--- a/.claude/scripts/roborev_metrics_etl.R
+++ b/.claude/scripts/roborev_metrics_etl.R
@@ -582,6 +582,17 @@ build_review_lifecycle <- function(jobs, reviews, markers) {
                   drop = FALSE]
   merged <- merge(reviews, jb, by = "job_id", all.x = TRUE)
 
+  # Drop rows where repo is NA (reviews from non-canonical repos excluded by the
+  # canonical-project guard in jobs_raw leave NA after the LEFT JOIN; inserting
+  # them would violate the NOT NULL constraint on roborev_review_lifecycle.repo).
+  n_null_repo <- sum(is.na(merged$repo))
+  if (n_null_repo > 0L) {
+    log_msg(sprintf(
+      "WARN: dropping %d lifecycle row(s) with NULL repo — non-canonical or fixture reviews excluded by canonical guard",
+      n_null_repo))
+    merged <- merged[!is.na(merged$repo), , drop = FALSE]
+  }
+
   # Join the latest closure marker per job (left join — NAs for open/unmarked reviews)
   if (!is.null(markers) && nrow(markers) > 0L) {
     merged <- merge(merged, markers, by = "job_id", all.x = TRUE)

--- a/bin/launchd_health_weekly_cron.sh
+++ b/bin/launchd_health_weekly_cron.sh
@@ -95,18 +95,22 @@ if [ -z "${SKIP_CRON_PULL:-}" ]; then
 fi
 log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
 
-# ── Bring Nix-shell R into PATH if needed ─────────────────────────────────────
+# ── Verify nix-shell is accessible (mirrors roborev_daily_cron.sh) ────────────
+# All R calls use nix-shell so R_LIBS_SITE and the full package environment
+# are inherited — calling the Rscript binary directly loses those.
 
 LLM_NIX="${REPO_ROOT}/default.nix"
-RSCRIPT="${RSCRIPT:-Rscript}"
-if [[ -f "${LLM_NIX}" ]] && command -v nix-shell >/dev/null 2>&1; then
-  NIX_R="$(nix-shell "${LLM_NIX}" --run "which Rscript" 2>/dev/null || true)"
-  if [[ -n "$NIX_R" ]]; then
-    export PATH="$(dirname "$NIX_R"):$PATH"
-    RSCRIPT="$NIX_R"
-    log "using nix Rscript: $RSCRIPT"
-  fi
+NIX_SHELL_BIN="/nix/var/nix/profiles/default/bin/nix-shell"
+
+if [ ! -f "${LLM_NIX}" ]; then
+  log "ERROR: nix file not found at ${LLM_NIX}"
+  exit 1
 fi
+if [ ! -x "${NIX_SHELL_BIN}" ]; then
+  log "ERROR: nix-shell not found at ${NIX_SHELL_BIN} (PATH=${PATH})"
+  exit 1
+fi
+log "using nix-shell: ${NIX_SHELL_BIN}"
 
 # ── DuckDB availability check (llm#554) ───────────────────────────────────────
 # Gracefully skip all DB writes when duckdb binary or unified.duckdb is absent.
@@ -143,7 +147,7 @@ fi
 # ── Step 1: Generate markdown report ─────────────────────────────────────────
 
 log "Step 1: generating launchd health report → ${REPORT_OUT}"
-"${RSCRIPT}" "${SCRIPTS_DIR}/launchd_health_report.R" --out "${REPORT_OUT}" 2>>"${LOG_FILE}"
+"${NIX_SHELL_BIN}" "${LLM_NIX}" --run "Rscript '${SCRIPTS_DIR}/launchd_health_report.R' --out '${REPORT_OUT}'" 2>>"${LOG_FILE}"
 STEP1_EXIT=$?
 if [ "${STEP1_EXIT}" -ne 0 ]; then
   log "WARNING: launchd_health_report.R exited ${STEP1_EXIT} — continuing"
@@ -271,7 +275,7 @@ fi
 
 export LAUNCHD_SCRIPTS_DIR="${SCRIPTS_DIR}"
 log "Step 2: sending launchd health email..."
-"${RSCRIPT}" "${SCRIPTS_DIR}/send_launchd_health_email.R" 2>>"${LOG_FILE}"
+"${NIX_SHELL_BIN}" "${LLM_NIX}" --run "Rscript '${SCRIPTS_DIR}/send_launchd_health_email.R'" 2>>"${LOG_FILE}"
 STEP2_EXIT=$?
 
 if [ "${STEP2_EXIT}" -ne 0 ]; then

--- a/bin/roborev_weekly_rollup_cron.sh
+++ b/bin/roborev_weekly_rollup_cron.sh
@@ -21,6 +21,8 @@ export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 SCRIPTS_DIR="$REPO_DIR/.claude/scripts"
+LLM_NIX="$REPO_DIR/default.nix"
+NIX_SHELL_BIN="/nix/var/nix/profiles/default/bin/nix-shell"
 
 LOG="$HOME/.claude/logs/roborev_weekly_rollup.log"
 mkdir -p "$(dirname "$LOG")"
@@ -63,25 +65,16 @@ if [ -z "${SKIP_CRON_PULL:-}" ]; then
 fi
 log "HEAD: $(git -C "${REPO_DIR}" rev-parse --short HEAD) $(git -C "${REPO_DIR}" log -1 --format='%s')"
 
-# ── Locate Rscript ────────────────────────────────────────────────────────────
-RSCRIPT=""
-for candidate in \
-    "$(command -v Rscript 2>/dev/null)" \
-    /nix/var/nix/profiles/default/bin/Rscript \
-    /opt/homebrew/bin/Rscript \
-    /usr/local/bin/Rscript \
-    /usr/bin/Rscript; do
-  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
-    RSCRIPT="$candidate"
-    break
-  fi
-done
-
-if [ -z "$RSCRIPT" ]; then
-  log "ERROR: Rscript not found in PATH — cannot generate rollup"
+# ── Verify nix-shell is accessible (mirrors roborev_daily_cron.sh) ────────────
+if [ ! -f "$LLM_NIX" ]; then
+  log "ERROR: nix file not found at $LLM_NIX"
   exit 1
 fi
-log "using Rscript: $RSCRIPT"
+if [ ! -x "$NIX_SHELL_BIN" ]; then
+  log "ERROR: nix-shell not found at $NIX_SHELL_BIN (PATH=$PATH)"
+  exit 1
+fi
+log "using nix-shell: $NIX_SHELL_BIN"
 
 # ── Step 1: generate rollup markdown ─────────────────────────────────────────
 ROLLUP_SCRIPT="$SCRIPTS_DIR/roborev_weekly_rollup.R"
@@ -90,8 +83,8 @@ if [ ! -f "$ROLLUP_SCRIPT" ]; then
   exit 1
 fi
 
-log "running $ROLLUP_SCRIPT"
-"$RSCRIPT" "$ROLLUP_SCRIPT" 2>&1 | tee -a "$LOG"
+log "running $ROLLUP_SCRIPT via nix-shell"
+"$NIX_SHELL_BIN" "$LLM_NIX" --run "Rscript '${ROLLUP_SCRIPT}'" 2>&1 | tee -a "$LOG"
 rollup_rc=${PIPESTATUS[0]}
 if [ "$rollup_rc" -ne 0 ]; then
   log "WARNING: rollup script exited $rollup_rc — continuing to email step (partial output possible)"
@@ -104,8 +97,8 @@ if [ ! -f "$EMAIL_SCRIPT" ]; then
   exit 1
 fi
 
-log "running $EMAIL_SCRIPT (EMAIL_DRY_RUN=$EMAIL_DRY_RUN)"
-"$RSCRIPT" "$EMAIL_SCRIPT" 2>&1 | tee -a "$LOG"
+log "running $EMAIL_SCRIPT via nix-shell (EMAIL_DRY_RUN=$EMAIL_DRY_RUN)"
+"$NIX_SHELL_BIN" "$LLM_NIX" --run "Rscript '${EMAIL_SCRIPT}'" 2>&1 | tee -a "$LOG"
 email_rc=${PIPESTATUS[0]}
 
 if [ "$email_rc" -ne 0 ]; then


### PR DESCRIPTION
## Summary

- **Error 1** (`bin/roborev_weekly_rollup_cron.sh`): removed bare-Rscript search loop; replaced with `NIX_SHELL_BIN` + `nix-shell "${LLM_NIX}" --run "Rscript '...'"` pattern matching `roborev_daily_cron.sh`
- **Error 2** (`bin/launchd_health_weekly_cron.sh`): removed `nix-shell --run "which Rscript"` / direct-binary approach; both R invocations now go through `nix-shell` so `R_LIBS_SITE` is inherited
- **Error 3** (`.claude/scripts/roborev_metrics_etl.R`): after LEFT JOIN in `build_review_lifecycle()`, orphaned reviews from non-canonical repos (excluded by canonical-project guard) produce `NA` repo violating NOT NULL on `roborev_review_lifecycle.repo`; added filter + WARN log
- **Error 4** (`config_pulse.sh`): fixed in companion commit `llmtelemetry@c35ec82` — added `REPO_ROOT` resolution from `CONFIG_DIR` symlink and `git -C "${REPO_ROOT}"` guards for new commit-count metrics; bare `git` would fail with `fatal: not in a git directory` when launchd starts with cwd=`/`

## Test plan

- [ ] `bash -n bin/roborev_weekly_rollup_cron.sh` — passes
- [ ] `bash -n bin/launchd_health_weekly_cron.sh` — passes
- [ ] `bash -n llmtelemetry/inst/scripts/config_pulse.sh` — passes
- [ ] `Rscript -e 'parse(".claude/scripts/roborev_metrics_etl.R")'` — 112 expressions, no errors
- [ ] Dry-run Error 1 fix: `DRYRUN=1 EMAIL_DRY_RUN=1 SKIP_CRON_PULL=1 bash bin/roborev_weekly_rollup_cron.sh`
- [ ] Dry-run Error 2 fix: `EMAIL_DRY_RUN=1 SKIP_CRON_PULL=1 bash bin/launchd_health_weekly_cron.sh`
- [ ] Verify Error 3 fix: next ETL run should log `WARN: dropping N lifecycle row(s) with NULL repo` instead of crashing

## Notes

- Error 4 is in `llmtelemetry` (config_pulse.sh symlinks there): committed as `llmtelemetry@c35ec82`
- The `fatal: not in a git directory` noise from nix-shell's internal tarball-cache git operations (visible in `config_pulse.err`) is a separate concern that requires updating the launchd plist to use the GC-rooted drv instead of `default.nix` — filed as follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Dispatch-Id: 8675c524
Agent-Type: fixer