### PR TITLE
fix(hooks): guard session_init phase4 n_skills assignment against pipefail abort

### DIFF
--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -844,7 +844,7 @@ _p4_cache="${HOME}/.claude/logs/session_init_phase4_cache.txt"
 n_skills=""
 if [ -f "$_p4_cache" ]; then
   _p4_cached=$(cat "$_p4_cache" 2>/dev/null) || true
-  n_skills=$(echo "$_p4_cached" | grep -oE '[0-9]+ skills' | head -1)
+  n_skills=$(echo "$_p4_cached" | grep -oE '[0-9]+ skills' | head -1) || true
   if echo "$_p4_cached" | grep -qiE "WARNING|OVER"; then
     WARNINGS="${WARNINGS}$(echo "$_p4_cached" | grep -iE 'WARNING|OVER') "
   fi


### PR DESCRIPTION
## Summary

- `session_init.sh` sets `set -euo pipefail` at line 6
- At line 847 (Phase 4 block), the bare assignment `n_skills=$(echo "$_p4_cached" | grep -oE '[0-9]+ skills' | head -1)` was unguarded
- When the phase4 cache file is empty or lacks the text "N skills", `grep` exits 1; under `pipefail` the pipeline exits 1; under `set -e` the bare assignment aborts the entire hook
- This surfaced in the UI as: `SessionStart:startup hook error — Failed with non-blocking status code: No stderr output`
- Fix: append `|| true` to that single line, matching the guard already present on the phase3 block (lines 825-827) and the phase4 WARNINGS assignment (lines 848-849)

## Test plan

- [x] Ran hook with empty phase4 cache — exits 0 (verified in this PR)
- [x] Confirmed the single-line change matches the pattern already used by sibling assignments
- [x] No other changes made

## Files changed

- `.claude/hooks/session_init.sh` line 847: appended `|| true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)