### PR TITLE
feat(#322 Phase 2 Part A): stamp CLAUDE_TRIGGER in all scheduled roborev launchers

### DIFF
--- a/.claude/hooks/llmtelemetry_emit.sh
+++ b/.claude/hooks/llmtelemetry_emit.sh
@@ -19,6 +19,14 @@
 # response, we gate stop emission behind a per-session sentinel written by /bye.
 # Mid-session Stop invocations (non-/bye) skip emit entirely.
 #
+# Scheduled-session bypass (llmtelemetry#322 Phase 2):
+# Headless sessions (launchd/cron, claude -p, /schedule, /loop) never call
+# /bye, so they would emit nothing without the bypass. When CLAUDE_TRIGGER is
+# "scheduled" at Stop time, the sentinel gate is bypassed and emit runs
+# unconditionally. The payload includes "trigger":"scheduled" (vs "interactive"
+# for normal sessions). Set by exporting CLAUDE_TRIGGER=scheduled in launcher
+# scripts before invoking claude.
+#
 # Concurrent-session safety (llm#273):
 #   - SESSION_ID is stable: prefer $CLAUDE_SESSION_ID → PPID-anchored fallback
 #     written at start time. A PPID-keyed anchor file ensures start/stop resolve
@@ -80,6 +88,17 @@ if [ "$MODE" = "start" ]; then
   exit 0
 fi
 
+# ── STOP mode: determine trigger (scheduled vs interactive) ──────────────────
+# CLAUDE_TRIGGER=scheduled is exported by in-repo launcher scripts and launchd
+# entrypoints that invoke claude headlessly (cron jobs, /schedule, /loop).
+# Interactive sessions leave CLAUDE_TRIGGER unset → defaults to "interactive".
+# Validation: any value other than "scheduled" or "interactive" → "interactive".
+_RAW_TRIGGER="${CLAUDE_TRIGGER:-interactive}"
+case "$_RAW_TRIGGER" in
+  scheduled|interactive) TRIGGER="$_RAW_TRIGGER" ;;
+  *) TRIGGER="interactive" ;;
+esac
+
 # ── STOP mode: gate on per-session /bye sentinel (llm#273) ───────────────────
 # /bye writes ~/.claude/.bye-requested.<SESSION_ID> (per-session) AND the
 # legacy ~/.claude/.bye-requested for session_stop.sh pattern detection.
@@ -88,8 +107,18 @@ fi
 _BYE_SENTINEL_PER_SESSION="${HOME}/.claude/.bye-requested.${SESSION_ID}"
 _BYE_SENTINEL_GLOBAL="${HOME}/.claude/.bye-requested"
 
+# Scheduled-session bypass (llmtelemetry#322 Phase 2):
+# Headless sessions spawned by launchd/cron/claude-p never call /bye, so the
+# sentinel gate would permanently suppress their telemetry. When CLAUDE_TRIGGER
+# is "scheduled" at Stop time, bypass the /bye sentinel and emit unconditionally.
+# A headless claude session fires Stop exactly once at its natural exit, so
+# there is no risk of spurious duplicate emission — the bypass is safe.
+# Interactive sessions are unaffected: sentinel gate logic unchanged below.
 _sentinel_found=0
-if [ -f "$_BYE_SENTINEL_PER_SESSION" ]; then
+if [ "$TRIGGER" = "scheduled" ]; then
+  # Scheduled bypass: emit without /bye sentinel
+  _sentinel_found=1
+elif [ -f "$_BYE_SENTINEL_PER_SESSION" ]; then
   _sentinel_found=1
   rm -f "$_BYE_SENTINEL_PER_SESSION" 2>/dev/null || true
 elif [ -f "$_BYE_SENTINEL_GLOBAL" ]; then
@@ -147,8 +176,10 @@ fi
 jsons() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
 
 # Build and append the JSONL envelope
+# "trigger" is always written explicitly: "scheduled" for automated/headless
+# sessions (CLAUDE_TRIGGER=scheduled), "interactive" for human-driven sessions.
 JSONL=$(printf \
-  '{"ts":"%s","host":"%s","pid":"%s","payload":{"event_type":"session_stop","session_id":"%s","project":"%s","started_at":"%s","ended_at":"%s","duration_min":%s,"agent":"claude-code","source":"claude-code-hook","working_dir":"%s"}}' \
+  '{"ts":"%s","host":"%s","pid":"%s","payload":{"event_type":"session_stop","session_id":"%s","project":"%s","started_at":"%s","ended_at":"%s","duration_min":%s,"agent":"claude-code","source":"claude-code-hook","trigger":"%s","working_dir":"%s"}}' \
   "$TS_END" \
   "$(jsons "$HOST")" \
   "$$" \
@@ -157,6 +188,7 @@ JSONL=$(printf \
   "$(jsons "${TS_START:-}")" \
   "$TS_END" \
   "$DURATION_MIN" \
+  "$TRIGGER" \
   "$(jsons "$PROJECT_DIR")")
 
 printf '%s\n' "$JSONL" >> "$STAGING_DIR/events-${HOST}-${DATE}.jsonl" 2>/dev/null || true

--- a/.claude/scripts/roborev_auto_refine.sh
+++ b/.claude/scripts/roborev_auto_refine.sh
@@ -11,6 +11,11 @@
 
 set -euo pipefail
 
+# Mark session as scheduled/automated for llmtelemetry_emit.sh (#322 Phase 2).
+# Propagates to any claude process spawned by roborev refine so the Stop hook
+# emits "trigger":"scheduled" without requiring a /bye sentinel.
+export CLAUDE_TRIGGER="${CLAUDE_TRIGGER:-scheduled}"
+
 PIDFILE="$HOME/.claude/roborev-auto-refine.pid"
 LOGFILE="$HOME/.claude/logs/roborev-auto-refine.log"
 ROBOREV="/usr/local/bin/roborev"

--- a/.claude/scripts/roborev_autoclose.sh
+++ b/.claude/scripts/roborev_autoclose.sh
@@ -8,6 +8,10 @@
 #   - mapfile replaced with portable while-read loop (Bash 3.2 compat;
 #     macOS ships Bash 3.2 which lacks the mapfile builtin).
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+# Mark session as scheduled/automated for llmtelemetry_emit.sh (#322 Phase 2).
+# Propagates to any claude process spawned in this process tree so the Stop
+# hook emits "trigger":"scheduled" without requiring a /bye sentinel.
+export CLAUDE_TRIGGER="${CLAUDE_TRIGGER:-scheduled}"
 #
 # Two phases:
 #   Phase 1 — `roborev close <id>` for jobs that have a review attached

--- a/.claude/scripts/roborev_poll_merges.sh
+++ b/.claude/scripts/roborev_poll_merges.sh
@@ -18,6 +18,10 @@ if [ -x "${_SCRIPT_DIR}/codex_shim/codex" ]; then
   export PATH="${_SCRIPT_DIR}/codex_shim:$PATH"
 fi
 unset _SCRIPT_DIR
+# Mark session as scheduled/automated for llmtelemetry_emit.sh (#322 Phase 2).
+# Propagates to any claude process spawned in this process tree so the Stop
+# hook emits "trigger":"scheduled" without requiring a /bye sentinel.
+export CLAUDE_TRIGGER="${CLAUDE_TRIGGER:-scheduled}"
 # hook missed (remote-merged PRs don't fire local post-commit).
 #
 # For each repo in ~/.roborev/reviews.db's repos table:

--- a/.claude/scripts/roborev_weekly_chain.sh
+++ b/.claude/scripts/roborev_weekly_chain.sh
@@ -43,6 +43,11 @@ if [ "$_DEPTH" -gt 2 ]; then
 fi
 export _RWC_DEPTH=$((_DEPTH + 1))
 
+# Mark session as scheduled/automated for llmtelemetry_emit.sh (#322 Phase 2).
+# Propagates to any claude process spawned in this process tree so the Stop
+# hook emits "trigger":"scheduled" without requiring a /bye sentinel.
+export CLAUDE_TRIGGER="${CLAUDE_TRIGGER:-scheduled}"
+
 # ── Config ────────────────────────────────────────────────────────────────────
 SCRIPTS_DIR="${SCRIPTS_DIR:-$(dirname "$(realpath "$0")")}"
 HANDOFF_SCRIPT="${HANDOFF_SCRIPT:-$SCRIPTS_DIR/roborev_handoff.sh}"


### PR DESCRIPTION
## Summary

Closes llmtelemetry#322 Phase 2 Part A (llm side).

Headless/scheduled claude sessions (launchd, cron, `claude -p`) never call `/bye`, so the Stop hook's sentinel gate permanently suppressed their telemetry. This PR adds `export CLAUDE_TRIGGER=scheduled` to every in-repo scheduled entrypoint that spawns a claude subprocess (directly or via `roborev review`/`roborev refine`), and wires the emit hook to bypass the sentinel gate when that variable is set.

## Launchers instrumented

| Script | Via | Calls that spawn claude |
|--------|-----|------------------------|
| `.claude/hooks/llmtelemetry_emit.sh` | All Stop hooks | Reads `CLAUDE_TRIGGER`; bypasses `/bye` sentinel when `scheduled` |
| `.claude/scripts/roborev_autoclose.sh` | `com.claude.roborev-autoclose.plist` | `roborev close` (propagates to subprocess tree) |
| `.claude/scripts/roborev_poll_merges.sh` | `com.claude.roborev-poll-merges.plist` | `roborev review --since <sha>` |
| `.claude/scripts/roborev_weekly_chain.sh` | `com.claude.roborev-autoclose.plist` (Monday 09:15) | chains handoff + autoclose |
| `.claude/scripts/roborev_auto_refine.sh` | `com.roborev.auto-refine.plist` | `roborev refine` (event-driven daemon) |

## Plist-only automations needing manual env addition

None found. Every launchd automation that can spawn a claude subprocess does so via an in-repo script that is now stamped.

Other scheduled scripts audited and confirmed NOT to need CLAUDE_TRIGGER (they do not invoke `claude` or `roborev review/refine`):

- `session_end_refine.sh` — only fires via `/bye` sentinel in interactive sessions
- `config_pulse.sh` — DuckDB metric collection, no claude invocation
- `cron_catchup.sh` — runs shell/R/Python scripts, no claude invocation
- `self_review_stage1.sh` — SQL analysis via duckdb
- `roborev_severity_autoclose.sh` — `roborev close` only, no AI invocation
- `roborev_metrics_etl.sh`, `roborev_bridge_to_unified.sh`, `roborev_daily_backlog_aggregator.sh` — data ETL, no claude

## Verification

All five changed files pass `bash -n` syntax check (0 errors).

Emit hook dry-run (scratch dir, never touches real staging):

**Test A — CLAUDE_TRIGGER=scheduled, no /bye sentinel → "trigger":"scheduled":**
```json
{"ts":"2026-07-02T09:05:59Z","host":"JohnMacSil","pid":"31870","payload":{"event_type":"session_stop","session_id":"test-session-sched","project":"emit-test","started_at":"","ended_at":"2026-07-02T09:05:59Z","duration_min":null,"agent":"claude-code","source":"claude-code-hook","trigger":"scheduled","working_dir":"..."}}
```

**Test B — unset CLAUDE_TRIGGER, /bye sentinel present → "trigger":"interactive":**
```json
{"ts":"2026-07-02T09:06:22Z","host":"JohnMacSil","pid":"32607","payload":{"event_type":"session_stop","session_id":"test-session-interactive","project":"emit-test-b","started_at":"","ended_at":"2026-07-02T09:06:22Z","duration_min":null,"agent":"claude-code","source":"claude-code-hook","trigger":"interactive","working_dir":"..."}}
```

Both `"trigger"` values appear immediately after `"source":"claude-code-hook"` in the payload, always written explicitly.

## Test plan

- [x] `bash -n` all five modified files — PASS
- [x] Emit hook dry-run Test A (scheduled bypass) — PASS
- [x] Emit hook dry-run Test B (interactive gate) — PASS
- [ ] End-to-end: verify `com.roborev.auto-refine` daemon emits `"trigger":"scheduled"` in the next scheduled run (manual observation after launchd fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)