### PR TITLE
fix(etl): NULL repo guard + DuckDB lock backoff (llm#706)

### DIFF
--- a/.claude/scripts/roborev_metrics_etl.R
+++ b/.claude/scripts/roborev_metrics_etl.R
@@ -210,6 +210,23 @@ repo_clause <- if (!is.null(repo)) {
   ""
 }
 
+# ── Guard: review_jobs.source column may be absent in older schema (llm#706) ──
+# review_jobs.source was added post-initial-schema.  If absent, the SELECT
+# below would throw "Referenced column not found", and the tryCatch would
+# return data.frame() for jobs_raw.  A subsequent LEFT JOIN of reviews_raw
+# onto the empty jobs_raw produces NULL in the repo column for every review —
+# violating the NOT NULL constraint on roborev_review_lifecycle.repo.
+# Detect the column before building sql_jobs and substitute NULL when absent.
+has_source_col <- tryCatch({
+  "source" %in% names(dbGetQuery(read_con, "SELECT * FROM src.review_jobs LIMIT 0"))
+}, error = function(e) {
+  log_msg("WARN: cannot introspect review_jobs columns: ", conditionMessage(e))
+  FALSE
+})
+if (!has_source_col) {
+  log_msg("WARN: review_jobs.source column absent — using NULL AS source in sql_jobs (llm#706 Cause-1 guard)")
+}
+
 sql_jobs <- sprintf("
   SELECT
     rj.id          AS job_id,
@@ -221,13 +238,13 @@ sql_jobs <- sprintf("
     rj.enqueued_at,
     rj.started_at,
     rj.finished_at,
-    rj.source
+    %s             AS source
   FROM src.review_jobs rj
   JOIN src.repos rp ON rp.id = rj.repo_id
   WHERE date(rj.enqueued_at) >= DATE '%s'
   %s
   ORDER BY rj.id
-", since_str, repo_clause)
+", if (has_source_col) "rj.source" else "NULL", since_str, repo_clause)
 
 jobs_raw <- tryCatch(
   dbGetQuery(read_con, sql_jobs),
@@ -265,7 +282,10 @@ if (!include_fixtures && nrow(jobs_raw) > 0L && "repo" %in% names(jobs_raw)) {
     },
     error = function(e) {
       log_msg("WARN: canonical_check failed (", conditionMessage(e),
-              ") — skipping guard, all repos pass")
+              ") — skipping guard, all repos pass.",
+              " If error is a DuckDB lock, the r-btw MCP server likely holds",
+              " a persistent write connection to unified.duckdb;",
+              " the main ETL write connection will retry with backoff (llm#706 Cause 2).")
       NULL  # NULL signals "guard unavailable, let everything through"
     }
   )
@@ -582,13 +602,21 @@ build_review_lifecycle <- function(jobs, reviews, markers) {
                   drop = FALSE]
   merged <- merge(reviews, jb, by = "job_id", all.x = TRUE)
 
-  # Drop rows where repo is NA (reviews from non-canonical repos excluded by the
-  # canonical-project guard in jobs_raw leave NA after the LEFT JOIN; inserting
-  # them would violate the NOT NULL constraint on roborev_review_lifecycle.repo).
+  # Drop rows where repo is NA after the LEFT JOIN.
+  # Root causes (llm#706 Cause 1):
+  #   (a) The job was filtered by the canonical-project guard (non-canonical repo).
+  #   (b) The job is outside the --since window so it is absent from jobs_raw.
+  #   (c) sql_jobs failed (e.g. missing source column) and returned an empty df —
+  #       now prevented by the has_source_col guard above, but kept as defence-in-depth.
+  # Inserting NULL would violate the NOT NULL constraint on
+  # roborev_review_lifecycle.repo and abort the entire transaction (pre-#689 bug).
   n_null_repo <- sum(is.na(merged$repo))
   if (n_null_repo > 0L) {
-    log_msg(sprintf(
-      "WARN: dropping %d lifecycle row(s) with NULL repo — non-canonical or fixture reviews excluded by canonical guard",
+    log_msg(sprintf(paste0(
+      "WARN: dropping %d lifecycle row(s) with NULL repo",
+      " (job outside window, non-canonical/fixture repo excluded by guard,",
+      " or sql_jobs schema mismatch).",
+      " These rows cannot be persisted due to NOT NULL constraint on repo (llm#706)."),
       n_null_repo))
     merged <- merged[!is.na(merged$repo), , drop = FALSE]
   }
@@ -2057,13 +2085,24 @@ hk_fail_cli <- function(err) {
   invisible(NULL)
 }
 
-# ── Connect read-write, verified (llm#595 fix 2) ──────────────────────────
+# ── Connect read-write, verified (llm#595 fix 2; backoff improved llm#706) ─
 # dbConnect() can silently join a cached READ-ONLY database instance for the
 # same path (the #595 failure mode), and a concurrent writer can hold the
 # lock (the 02:00 slot collides with other launchd writers). Verify with
 # duckdb_databases().readonly; on read-only or error, disconnect with
 # shutdown = TRUE (evicts the cached instance) and retry with backoff.
-connect_unified_rw <- function(path, attempts = 3L, wait_s = 10L) {
+#
+# Known contending writers for unified.duckdb (llm#706 Cause 2):
+#   - r-btw MCP DuckDB server: keeps a persistent read-write connection.
+#     Managed by ~/.claude/scripts/r_btw_mcp_launch.sh (GC-rooted drv, llm#673).
+#     Fix: r_btw_mcp_launch.sh should open unified.duckdb read-only or via WAL.
+#     Until then, the ETL must tolerate the lock with retry-and-backoff.
+#   - Other launchd ETL slots at 02:00–03:00 (stage1_findings, kb_digest,
+#     self_review_email) that also write to unified.duckdb.
+#
+# Retry strategy: 5 attempts × 15 s = up to ~75 s of waiting.
+# The r-btw MCP query pipeline typically completes within 30 s.
+connect_unified_rw <- function(path, attempts = 5L, wait_s = 15L) {
   last_err <- "unknown"
   for (i in seq_len(attempts)) {
     con <- tryCatch(dbConnect(duckdb::duckdb(), path), error = function(e) e)
@@ -2080,10 +2119,24 @@ connect_unified_rw <- function(path, attempts = 3L, wait_s = 10L) {
     } else {
       last_err <- conditionMessage(con)
     }
-    log_msg(sprintf("WARN: unified.duckdb not writable (attempt %d/%d): %s",
-                    i, attempts, last_err))
+    if (i == 1L) {
+      # First failure: emit diagnostic note naming known contenders (llm#706).
+      log_msg(sprintf(paste0(
+        "WARN: unified.duckdb not writable (attempt %d/%d): %s —",
+        " waiting %ds for lock release. Known contender: r-btw MCP DuckDB",
+        " server (persistent write connection). See llm#706 for serialisation fix."),
+        i, attempts, last_err, wait_s))
+    } else {
+      log_msg(sprintf("WARN: unified.duckdb not writable (attempt %d/%d): %s",
+                      i, attempts, last_err))
+    }
     if (i < attempts) Sys.sleep(wait_s)
   }
+  log_msg(sprintf(paste0(
+    "ERROR: unified.duckdb still not writable after %d attempts (~%ds total).",
+    " Giving up. Check whether r-btw MCP server or another launchd ETL is",
+    " holding the write lock. PID of holder may appear above."),
+    attempts, attempts * wait_s))
   attr(last_err, "failed") <- TRUE
   last_err
 }


### PR DESCRIPTION
## Summary

Fixes JohnGavin/llm#706: `roborev-metrics-etl` exits 1 due to two independent failures.

### Cause 1 — NULL repo (NOT NULL constraint on `roborev_review_lifecycle.repo`)

**Root cause**: `sql_jobs` selects `rj.source` which may be absent in older `review_jobs` schemas (column added post-initial-schema). When absent, the query throws *Referenced column not found* and the `tryCatch` returns an empty `data.frame()` for `jobs_raw`. A subsequent `LEFT JOIN` of `reviews_raw` onto empty `jobs_raw` produces `NULL` in the `repo` column for every review, violating the `NOT NULL` constraint and aborting the transaction with exit 1.

**Fix (`.claude/scripts/roborev_metrics_etl.R`, before `sql_jobs`)**: detect whether `source` exists via a `LIMIT 0` introspection query; substitute `NULL AS source` in `sql_jobs` when absent. This prevents `jobs_raw` from silently being empty. The existing NULL-repo guard in `build_review_lifecycle` (added by #689) is kept as defence-in-depth; its log message is extended to name all known root causes.

### Cause 2 — DuckDB single-writer lock (exit 1 after retries)

**Root cause**: The r-btw MCP DuckDB server holds a persistent read-write connection to `unified.duckdb`. When the ETL launchd slot fires at 02:00, both the `canonical_check` (read-only probe) and the main write connection fail with *Conflicting lock is held (PID …)*. `connect_unified_rw` previously retried 3 × 10 s = 30 s total — insufficient for the MCP pipeline which can run 30–60 s.

**Fix (`connect_unified_rw` function)**: increase to 5 attempts × 15 s = up to ~75 s of waiting. Add a first-failure diagnostic log naming the r-btw MCP server as the known contender (helps operators triage the PID from logs). Add a final-failure summary with total elapsed wait. Also extend the `canonical_check` error handler to note the MCP contender.

### Fixture test results

SQLite fixture built without `source` column, ETL run with `--apply --include-fixtures`:
```
WARN: review_jobs.source column absent — using NULL AS source in sql_jobs (llm#706 Cause-1 guard)
roborev_review_lifecycle — upserted 1 rows
done — daily=1 lifecycle=1 ...
EXIT: 0
```
No NOT NULL constraint violation. 1 review correctly written to `unified.duckdb`.

## Test plan

- [x] Fixture test: SQLite with no `source` column → ETL exits 0, guard WARN fires, lifecycle row committed
- [x] R `parse()` check: no syntax errors in the edited file  
- [x] `bash -n` check: shell wrapper syntax OK
- [x] The lock retry test (separate-process DuckDB contention) cannot be driven as a fully automated fixture without background process coordination; retry parameters and log messages verified by code review

## Files changed

- `.claude/scripts/roborev_metrics_etl.R` — `has_source_col` guard, updated `sql_jobs`, extended NULL-repo guard log message, `canonical_check` contender note, `connect_unified_rw` 5×15 s retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Dispatch-Id: 3099a263
Agent-Type: fixer