### PR TITLE
fix(cc): portable timeout for npx/burn-rate — eliminate cc startup hang

### DIFF
--- a/.claude/scripts/burn_rate_check.sh
+++ b/.claude/scripts/burn_rate_check.sh
@@ -76,6 +76,24 @@ week_start_ymd=$(date -v-"${days_since}"d +%Y%m%d 2>/dev/null \
 # GNU timeout absent on macOS and under launchd PATH (llm#420)
 TIMEOUT_CMD=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)
 
+# _bounded <secs> <cmd> [args...]
+# Portable bounded execution. Uses $TIMEOUT_CMD (GNU timeout / gtimeout) when
+# available; falls back to perl's alarm(2) built-in, which is always present
+# on macOS. If neither is available the command runs unbounded (last resort).
+# Root-cause fix: on macOS TIMEOUT_CMD is empty, so the old
+# ${TIMEOUT_CMD:+$TIMEOUT_CMD 30} expansion was a no-op — npx ran unbounded.
+_bounded() {
+  local secs="$1"; shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$secs" "$@"
+  elif command -v perl >/dev/null 2>&1; then
+    perl -e 'my $t = shift; alarm $t; exec @ARGV or die "exec: $!"' "$secs" "$@"
+  else
+    # Last resort: no timeout mechanism available; run unbounded
+    "$@"
+  fi
+}
+
 # Cache: reuse if < 5 minutes old AND for the same week window
 CACHE_FILE="/tmp/ccusage_burnweek_${week_start_ymd}_cache.json"
 CACHE_MAX_AGE=300
@@ -92,10 +110,13 @@ if [ "$use_cache" = true ]; then
   daily_json=$(cat "$CACHE_FILE")
 else
   err_tmp=$(mktemp /tmp/burn_rate_err_XXXXXX)
-  daily_json=$(${TIMEOUT_CMD:+$TIMEOUT_CMD 30} npx ccusage daily \
+  # _bounded: always bounded (perl alarm fallback when GNU timeout absent);
+  # --yes: never prompt to install a missing npx package;
+  # </dev/null: stdin is /dev/null so any install prompt gets immediate EOF.
+  daily_json=$(_bounded 30 npx --yes ccusage daily \
     --since "$week_start_ymd" \
     --timezone "$TZ_NAME" \
-    --json --offline 2>"$err_tmp") || {
+    --json --offline </dev/null 2>"$err_tmp") || {
     {
       echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ccusage daily --since $week_start_ymd failed — stderr:"
       cat "$err_tmp"

--- a/.claude/scripts/cc.sh
+++ b/.claude/scripts/cc.sh
@@ -317,10 +317,29 @@ select_mode() {
   fi
 }
 
+# _cc_bounded <secs> <cmd> [args...]
+# Defense-in-depth timeout for the cc startup path: detects GNU timeout /
+# gtimeout at call time, falls back to perl's alarm(2). If burn_rate_check.sh
+# itself hangs (e.g. internal _bounded fails to kill a child), this outer
+# wrapper still unblocks cc.sh startup within the given timeout.
+_cc_bounded() {
+  local secs="$1"; shift
+  local _tc
+  _tc=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)
+  if [ -n "$_tc" ]; then
+    "$_tc" "$secs" "$@"
+  elif command -v perl >/dev/null 2>&1; then
+    perl -e 'my $t = shift; alarm $t; exec @ARGV or die "exec: $!"' "$secs" "$@"
+  else
+    # Last resort: no timeout mechanism; run unbounded (should never reach here)
+    "$@"
+  fi
+}
+
 get_burn_rate() {
   local script="$HOME/.claude/scripts/burn_rate_check.sh"
   if [[ -x "$script" ]]; then
-    "$script" --percent-only 2>/dev/null || echo "0"
+    _cc_bounded 15 "$script" --percent-only 2>/dev/null || echo "0"
   else
     echo "0"
   fi


### PR DESCRIPTION
## Root cause

`cc.sh` hangs right after \"Switched to worktree\" because `get_burn_rate()` calls `burn_rate_check.sh --percent-only`, which runs:

```bash
daily_json=$(${TIMEOUT_CMD:+$TIMEOUT_CMD 30} npx ccusage daily ... --offline 2>"$err_tmp")
```

On macOS (no GNU coreutils), `TIMEOUT_CMD` is empty — the `${TIMEOUT_CMD:+...}` expansion is a **no-op**, so `npx ccusage` runs **unbounded**. On an npx cache miss it either blocks on a network download or sits waiting at an interactive \"Ok to proceed?\" prompt. Neither exits, so `cc` never reaches `exec claude`.

## Fix

### `burn_rate_check.sh` (primary)

- **`_bounded()` function** (portable timeout): uses `$TIMEOUT_CMD` (GNU timeout/gtimeout) when available, else falls back to `perl -e 'alarm ...; exec @ARGV'` — perl's alarm(2) is always present on macOS. Degrads to unbounded only when neither exists (last resort, effectively impossible on macOS).
- **Applied to npx call**: replaces `${TIMEOUT_CMD:+$TIMEOUT_CMD 30} npx ccusage` with `_bounded 30 npx --yes ccusage ... </dev/null` — 30s hard bound regardless of GNU timeout presence.
- **`--yes`**: prevents npx from ever prompting to install a missing package.
- **`</dev/null`**: stdin is `/dev/null` so any remaining interactive prompt receives immediate EOF.

### `cc.sh` (defense-in-depth)

- **`_cc_bounded()` function**: same portable-timeout pattern, detects timeout/gtimeout at call time.
- **`get_burn_rate()` wrapped**: `_cc_bounded 15 "$script" --percent-only` — even if `burn_rate_check.sh` itself hangs, `cc` startup is unblocked within 15 seconds.

## Timing proof (perl alarm fallback)

Test with `TIMEOUT_CMD=""` to force the perl path:

```
_bounded 2 sleep 30 → elapsed: 2s  (SIGALRM confirmed: "Alarm clock: 14")
```

Not 30s. The perl `alarm()` timer is preserved across `exec`, so it fires against the target process.

## Verification

- `bash -n burn_rate_check.sh` → PASS
- `bash -n cc.sh` → PASS
- `burn_rate_check.sh --percent-only` end-to-end: returned in **1s** with output `0`, exit 0 (no cache, no hang)

## Test plan

- [ ] Run `cc` on a machine without GNU coreutils (stock macOS) — confirm it starts without hanging
- [ ] Confirm `burn_rate_check.sh --percent-only` returns within 30s when npx ccusage is not cached
- [ ] Confirm `cc` startup proceeds to `exec claude` even when the burn-rate script times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Dispatch-Id: d7de75aa
Agent-Type: fixer