### PR TITLE
fix(#715): broken-internal-link post-render guard

### DIFF
--- a/.claude/scripts/check_internal_links.sh
+++ b/.claude/scripts/check_internal_links.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# check_internal_links.sh — fail on broken internal links in a rendered site.
+#
+# Scans every *.html under a docs dir for internal hyperlinks whose target file
+# does not exist, resolving each href relative to the linking file's directory.
+# Purpose: stop a Quarto/pkgdown render from shipping 404s (JohnGavin/llm#715).
+#
+# Usage:
+#   check_internal_links.sh [DOCS_DIR]      # default: ./docs
+#   SELFTEST=1 check_internal_links.sh      # run built-in self-test, exit 0/1
+#
+# Exit: 0 = no broken internal links; 1 = broken links found (listed on stderr);
+#       2 = usage/environment error.
+#
+# What counts as an INTERNAL link to verify:
+#   - href="something.html", href="../a/b.html", href="dir/", href="page.html#frag"
+# Ignored (never flagged):
+#   - external:  http://  https://  //host  mailto:  tel:  javascript:  data:
+#   - in-page:   href="#anchor"  and empty href=""
+#   - non-.html assets (css/js/png/…) — link-checking targets pages, not assets
+#
+# Portable: bash 3.2 (macOS) + GNU/BSD coreutils. No perl/python required.
+
+set -uo pipefail
+
+DOCS_DIR="${1:-docs}"
+
+# ── strip a leading marker used by the self-test to avoid recursion ──────────
+if [ "${SELFTEST:-0}" = "1" ]; then
+  _tmp="$(mktemp -d "${TMPDIR:-/tmp}/linkcheck_selftest_XXXXXX")" || exit 2
+  trap 'rm -rf "$_tmp"' EXIT
+  mkdir -p "$_tmp/sub"
+  # good.html: links to a sibling that exists, an external URL, and an anchor
+  printf '%s\n' '<a href="target.html">ok</a> <a href="https://x.test/y.html">ext</a> <a href="#top">anch</a>' > "$_tmp/good.html"
+  printf '%s\n' 'target' > "$_tmp/target.html"
+  # bad.html: links to a sibling that does NOT exist
+  printf '%s\n' '<a href="missing.html">dead</a> <a href="sub/also-missing.html#f">dead2</a>' > "$_tmp/bad.html"
+
+  # Expect: with only good.html present it passes; with bad.html it fails.
+  if ! SELFTEST=0 "$0" "$_tmp/goodonly" >/dev/null 2>&1; then :; fi
+  mkdir -p "$_tmp/goodonly"
+  cp "$_tmp/good.html" "$_tmp/target.html" "$_tmp/goodonly/" 2>/dev/null
+  if ! SELFTEST=0 "$0" "$_tmp/goodonly" >/dev/null 2>&1; then
+    echo "SELFTEST FAIL: clean dir reported broken links" >&2; exit 1
+  fi
+  if SELFTEST=0 "$0" "$_tmp" >/dev/null 2>&1; then
+    echo "SELFTEST FAIL: dir with a dead link was reported clean" >&2; exit 1
+  fi
+  echo "SELFTEST PASS"
+  exit 0
+fi
+
+if [ ! -d "$DOCS_DIR" ]; then
+  echo "check_internal_links: docs dir not found: $DOCS_DIR" >&2
+  exit 2
+fi
+
+# Normalise a path with .. and . segments (pure shell; no realpath dependency,
+# and the target need not exist). Prints the cleaned path.
+_normalise() {
+  local path="$1" out=() seg IFS='/'
+  # shellcheck disable=SC2086
+  set -- $path
+  for seg in "$@"; do
+    case "$seg" in
+      ''|'.') : ;;
+      '..')   [ ${#out[@]} -gt 0 ] && unset 'out[${#out[@]}-1]' ;;
+      *)      out+=("$seg") ;;
+    esac
+  done
+  local joined=""
+  for seg in "${out[@]:-}"; do joined="$joined/$seg"; done
+  printf '%s' "${joined:-/}"
+}
+
+broken=0
+report=""
+
+while IFS= read -r html; do
+  base_dir="$(dirname "$html")"
+  # Extract href="..." values (double- or single-quoted).
+  while IFS= read -r href; do
+    [ -n "$href" ] || continue
+    # Drop fragment and query.
+    target="${href%%#*}"
+    target="${target%%\?*}"
+    [ -n "$target" ] || continue          # was a pure #anchor / empty
+    case "$target" in
+      http://*|https://*|//*|mailto:*|tel:*|javascript:*|data:*) continue ;;
+    esac
+    # Only verify links to pages (html) or directory indexes; skip assets.
+    case "$target" in
+      */) resolved_rel="${target}index.html" ;;
+      *.html) resolved_rel="$target" ;;
+      *) continue ;;
+    esac
+    case "$resolved_rel" in
+      /*) resolved="$DOCS_DIR$resolved_rel" ;;        # site-absolute
+      *)  resolved="$(_normalise "$base_dir/$resolved_rel")" ;;
+    esac
+    if [ ! -f "$resolved" ]; then
+      broken=$((broken + 1))
+      report="${report}${html#"$DOCS_DIR"/}  ->  ${href}   (missing: ${resolved})"$'\n'
+    fi
+  done < <(grep -oE 'href="[^"]*"|href='"'"'[^'"'"']*'"'"'' "$html" 2>/dev/null | sed -E 's/^href=["'"'"']//; s/["'"'"']$//')
+done < <(find "$DOCS_DIR" -type f -name '*.html' 2>/dev/null)
+
+if [ "$broken" -gt 0 ]; then
+  echo "check_internal_links: $broken broken internal link(s) in $DOCS_DIR:" >&2
+  printf '%s' "$report" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/scripts/quarto_post_render_links.sh
+++ b/.claude/scripts/quarto_post_render_links.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# quarto_post_render_links.sh — Quarto post-render hook: fail on broken internal links.
+#
+# Wired into a project's _quarto.yml:
+#   project:
+#     post-render:
+#       - .claude/scripts/quarto_post_render_links.sh
+#
+# Quarto sets QUARTO_PROJECT_OUTPUT_DIR (e.g. "docs"). This wrapper scans the
+# WHOLE output dir (not just the freshly-rendered files) because a link's target
+# may be a page rendered in a previous/partial pass. It delegates to the
+# canonical check_internal_links.sh and aborts the render (exit 1) if any
+# internal link 404s. See JohnGavin/llm#715.
+#
+# Self-locating: finds check_internal_links.sh beside itself via BASH_SOURCE so
+# it works both on a local machine and in CI (where $HOME/docs_gh/llm is absent).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check_internal_links.sh"
+
+if [ ! -x "$CHECK_SCRIPT" ]; then
+  echo "post-render-links: $CHECK_SCRIPT not found or not executable" >&2
+  exit 0  # Don't fail the render if the check infrastructure is missing.
+fi
+
+OUT_DIR="${QUARTO_PROJECT_OUTPUT_DIR:-docs}"
+if [ ! -d "$OUT_DIR" ]; then
+  echo "post-render-links: output dir not found: $OUT_DIR" >&2
+  exit 0
+fi
+
+echo
+echo "=== Internal-link check (post-render) ==="
+if "$CHECK_SCRIPT" "$OUT_DIR"; then
+  echo "OK: no broken internal links in $OUT_DIR"
+  exit 0
+fi
+echo "FAIL: broken internal links (listed above). Render is BLOCKED (llm#715)." >&2
+exit 1

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,6 +5,9 @@ project:
     - "index.qmd"
     - "vignettes/*.qmd"
     - "vignettes/articles/*.qmd"
+  post-render:
+    # Fail the render if any internal link 404s (JohnGavin/llm#715).
+    - .claude/scripts/quarto_post_render_links.sh
 
 website:
   title: "LLM Project"


### PR DESCRIPTION
Fixes #715.

## Root cause
The 5 dead links on `docs/vignettes/knowledge-evolution.html` were **stale local `docs/` output**, not a config bug. `_quarto.yml`'s navbar correctly points to `vignettes/*.qmd` (→ `docs/vignettes/*.html`), but those pages only existed as old `docs/articles/*.html`; they'd never been re-rendered into `docs/vignettes/`. `docs/` is **gitignored (CI-built)**, so a clean render regenerates them correctly — **verified**: a full `quarto render` in a clean worktree → the guard reports **0 broken links**.

So the durable fix is exactly the issue's **Suggested guard**: a post-render internal-link check that fails the render instead of shipping 404s.

## What this adds
- **`.claude/scripts/check_internal_links.sh`** — scans a rendered docs dir for internal `href="*.html"` links whose target file is absent (resolves each href relative to the linking file; ignores `http(s)`/`mailto`/`tel`/`#anchors`/non-`.html` assets; handles `dir/` → `index.html`). `SELFTEST=1` mode. Exit 1 on any broken link.
- **`.claude/scripts/quarto_post_render_links.sh`** — Quarto post-render wrapper, **self-locating via `BASH_SOURCE`** so it works locally *and* in CI (where `$HOME/docs_gh/llm` doesn't exist). Scans `QUARTO_PROJECT_OUTPUT_DIR`.
- **`_quarto.yml`** — wires the wrapper into `project: post-render:`.

## Verification
| Check | Result |
|-------|--------|
| `SELFTEST=1` | PASS |
| Guard on a **fresh** full render | exit 0 — 0 broken (proves the links resolve under a clean render) |
| Guard on the **stale** local `docs/` | exit 1 — caught the exact 5 links from `knowledge-evolution.html` (and `scrolly-config-evolution.html`) |
| Wrapper on fresh / stale | exit 0 / exit 1 (blocks render) |

## Notes
- No `docs/` changes committed (gitignored / CI-built). The clean render + this guard is the fix.
- Observed but out of scope: `_quarto.yml` had **no** `post-render:` section at all, so the mandated dark-contrast hook isn't wired here either — worth a follow-up to add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)