### PR TITLE
fix(quarto): wire mandated dark-contrast post-render hook

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -8,6 +8,8 @@ project:
   post-render:
     # Fail the render if any internal link 404s (JohnGavin/llm#715).
     - .claude/scripts/quarto_post_render_links.sh
+    # Fail the render on dark-mode contrast violations (dark-mode-completeness rule).
+    - /Users/johngavin/docs_gh/llm/.claude/scripts/quarto_post_render_contrast.sh
 
 website:
   title: "LLM Project"


### PR DESCRIPTION
Adds the dark-contrast post-render hook that the `dark-mode-completeness` rule mandates for every `_quarto.yml`. This project had **no** `post-render:` section until #715 added one (for the internal-link guard); this puts the contrast hook alongside it.

## Change
`_quarto.yml` `project: post-render:` gains:
```yaml
- /Users/johngavin/docs_gh/llm/.claude/scripts/quarto_post_render_contrast.sh
```
(the canonical absolute path per the rule; the wrapper skips gracefully — exit 0 — if the script is absent, e.g. in CI).

## Verified safe
Adding a *failing gate* risks breaking the build if violations exist, so I checked first: ran `quarto_post_render_contrast.sh` against the current `docs/` render → **47 files checked, 0 contrast violations** (exit 0). So the gate passes on today's site.

## Note
Observed while verifying: a fresh-worktree `quarto render` fails at `index.qmd` (`library(llm)` — the package isn't installed in the worktree nix shell; Quarto exits 0 with a warning). That's a separate render-env issue, not addressed here — worth a follow-up so local/CI renders load the package (pkgload/install step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)