### PR TITLE
fix(ci): install visNetwork/ggraph/igraph — unblock Quarto Publish (#714 regression)

### DIFF
--- a/.github/workflows/quarto-publish.yaml
+++ b/.github/workflows/quarto-publish.yaml
@@ -77,6 +77,9 @@ jobs:
             any::withr
             any::gridExtra
             any::qrcode
+            any::visNetwork
+            any::ggraph
+            any::igraph
 
       - uses: quarto-dev/quarto-actions/setup@v2
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,10 +31,12 @@ Suggests:
     fs,
     gert,
     ggplot2,
+    ggraph,
     gh,
     gridExtra,
     gt,
     gtExtras,
+    igraph,
     knitr,
     lubridate,
     quarto,
@@ -42,6 +44,7 @@ Suggests:
     targets,
     testthat (>= 3.0.0),
     tidyr,
+    visNetwork,
     withr
 Config/testthat/edition: 3
 RoxygenNote: 7.3.3


### PR DESCRIPTION
## Problem
Quarto Publish has failed on every push since **#714** (Topic Graph tab) merged:
```
Error in library(): there is no package called 'visNetwork'
Quitting from knowledge-evolution.qmd:99-269 [setup]
Execution halted → ##[error]Process completed with exit code 1
```
`knowledge-evolution.qmd` calls `library(visNetwork/ggraph/igraph)`. These are in the **nix env** (`default.R`) — so it renders locally — but were never declared for CI. The `quarto-publish.yaml` workflow installs an **explicit `packages:` list** (no `deps::.`), and `R CMD INSTALL .` skips `Suggests`, so the three packages were absent in CI.

## Fix
- **`.github/workflows/quarto-publish.yaml`** — add `any::visNetwork`, `any::ggraph`, `any::igraph` to the `setup-r-dependencies` list. *(This is the change that actually unblocks CI.)*
- **`DESCRIPTION`** — declare the three under `Suggests` (correct hygiene; the vignette genuinely uses them; helps `R CMD check`/pkgdown).

## Notes
- The render dies *before* post-render, so the #715 link guard / #718 contrast hook were never the cause.
- Separate pre-existing gap (not fixed here): a bare-worktree `quarto render` also fails on `library(llm)` (package not installed in the worktree nix shell) — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)