### PR TITLE
fix(ci): repo-relative contrast post-render path (#718 regression)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -9,7 +9,10 @@ project:
     # Fail the render if any internal link 404s (JohnGavin/llm#715).
     - .claude/scripts/quarto_post_render_links.sh
     # Fail the render on dark-mode contrast violations (dark-mode-completeness rule).
-    - /Users/johngavin/docs_gh/llm/.claude/scripts/quarto_post_render_contrast.sh
+    # Repo-relative so CI can spawn it (the absolute path doesn't exist on the
+    # runner); the wrapper's internal check script is $HOME-absolute and skips
+    # gracefully in CI, while still enforcing locally.
+    - .claude/scripts/quarto_post_render_contrast.sh
 
 website:
   title: "LLM Project"


### PR DESCRIPTION
Quarto Publish failed after #718 with `Failed to spawn '/Users/johngavin/docs_gh/llm/.claude/scripts/quarto_post_render_contrast.sh': No such file or directory` — the **absolute path doesn't exist on the CI runner**. #720's package fix let the render succeed and the #717 link guard pass in CI; this was the next failure in the chain. Making the contrast hook repo-relative (matching the link hook) lets CI spawn it; its internal $HOME-absolute check script skips gracefully in CI (guard exits 0) while still enforcing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)