### PR TITLE
docs(rules): read-only cross-repo verify runs parallel, no worktree

### DIFF
--- a/.claude/rules/auto-delegation.md
+++ b/.claude/rules/auto-delegation.md
@@ -179,6 +179,44 @@ dispatch prompt, and run dual-repo post-verify after completion.
 See the "Cross-Repo Writes" section in the companion doc for the full pattern,
 dual-repo post-verify example, and the #182 decision rationale.
 
+### Read-Only Cross-Repo Verify → Parallel, NO Worktree
+
+The `isolation: "worktree"` requirement is a WRITE-safety guard (stop a
+`bypassPermissions` agent clobbering the main checkout). It does NOT apply to
+read-only agents, and when the target files live in a **different repo** from the
+session cwd, worktree isolation is actively HARMFUL — the harness worktrees the
+*session's* repo, so the agent cannot reach the other repo at all (the #182
+cross-repo failure). This is common when a project session verifies content in the
+local-only knowledge hub (`~/docs_gh/llm/knowledge/**`).
+
+**Rule:** dispatch read-only verifiers (`critic`, `reviewer`, `Explore`, or
+`general-purpose` restricted to Read/Grep/Glob) that target a separate repo:
+
+- **in parallel** — multiple `Agent` calls in ONE message, each a distinct
+  adversarial lens (e.g. citation-faithfulness · domain-correctness ·
+  schema/structural-integrity). Parallelism belongs in *verification*.
+- **WITHOUT `isolation: "worktree"`** — read-only needs no write sandbox, and a
+  worktree would sever cross-repo access.
+
+**Corollary for the write side.** The fixer/curator half of a cross-repo
+*local-hub* task (a repo that is never pushed, e.g. the knowledge hub) also runs
+**without worktree**, restricted to file-tools (no Bash, no git), with the
+orchestrator doing the commit afterward. Do NOT parallelise a single-file fix —
+concurrent edits to one file conflict; the parallelism was spent in verification.
+(For cross-repo writes to a *pushed* repo, use the `$WORKTREE_PATH` pre-create
+pattern above instead.)
+
+| Cross-repo task | Isolation | Concurrency |
+|---|---|---|
+| Read-only verify (separate repo) | none (read-only) | parallel, diverse lenses |
+| Write to local-only hub (never pushed) | none; file-tools + no Bash; orchestrator commits | serial per file |
+| Write to a pushed repo | pre-created `$WORKTREE_PATH` worktree (#182) | per dual-repo post-verify |
+
+Origin: 2026-07-03/04 oncology-hub immunoparesis note — curator/fixer written and
+critic-verified across the mycare→knowledge-hub boundary; a 3-lens parallel
+read-only re-audit ran with no worktrees. See `agent-identity-and-task-scopes`
+(scope propagation) and `worktree-location` (harness worktree conventions).
+
 ## Parallel Worktree Sessions
 
 For independent tasks, spawn a worker-tier worktree session:


### PR DESCRIPTION
## What

Adds a subsection to the always-loaded `auto-delegation` rule:
**"Read-Only Cross-Repo Verify → Parallel, NO Worktree"** + a 3-row decision table.

## Why

`isolation: "worktree"` is a **write**-safety guard. Using it for read-only
verifiers is unnecessary, and when the target files live in a **different repo**
from the session cwd, a worktree severs cross-repo access (the #182 failure) —
the harness worktrees the *session's* repo, so the agent can't reach the other
repo at all. This bites whenever a project session verifies content in the
local-only knowledge hub (`~/docs_gh/llm/knowledge/**`).

## Rule encoded

| Cross-repo task | Isolation | Concurrency |
|---|---|---|
| Read-only verify (separate repo) | none (read-only) | parallel, diverse lenses |
| Write to local-only hub (never pushed) | none; file-tools + no Bash; orchestrator commits | serial per file |
| Write to a pushed repo | pre-created `\$WORKTREE_PATH` worktree (#182) | per dual-repo post-verify |

Parallelism belongs in *verification* (independent adversarial lenses); a
single-file fix stays serial (concurrent edits conflict).

## Origin

2026-07-04 oncology-hub immunoparesis/IVIG note: curator + fixer written and
critic-verified across the mycare → knowledge-hub boundary, with a 3-lens
parallel read-only re-audit run without worktrees. Cross-links
`agent-identity-and-task-scopes` and `worktree-location`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)