### PR TITLE
feat(etl): add ETL freshness registry — Phase 1a (#309)

### DIFF
--- a/.claude/hooks/llmtelemetry_emit.sh
+++ b/.claude/hooks/llmtelemetry_emit.sh
@@ -37,6 +37,7 @@
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" 2>/dev/null && pwd)"
 MODE="${1:-stop}"
 LOG_DIR="$HOME/.claude/logs"
 STAGING_DIR="$LOG_DIR/llmtelemetry-staging"
@@ -192,6 +193,14 @@ JSONL=$(printf \
   "$(jsons "$PROJECT_DIR")")
 
 printf '%s\n' "$JSONL" >> "$STAGING_DIR/events-${HOST}-${DATE}.jsonl" 2>/dev/null || true
+
+# ETL freshness registry (llm#309 Phase 1a): event-driven, no SLA -> unknown.
+# Freshness proxy is the staging file's mtime (this is a JSONL sink, not a
+# queryable DB table — the file we just appended to is the source of truth).
+if [ -x "${SCRIPT_DIR}/etl_freshness_upsert.sh" ]; then
+  "${SCRIPT_DIR}/etl_freshness_upsert.sh" llmtelemetry "$LOG_DIR/unified.duckdb" "" \
+    --file "$STAGING_DIR/events-${HOST}-${DATE}.jsonl" >/dev/null 2>&1 || true
+fi
 
 # Clean up per-session state files and PPID anchor (only on real session end)
 rm -f "$STATE_START" "$STATE_SID" "$_PPID_ANCHOR" 2>/dev/null || true

--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -1548,6 +1548,29 @@ if [ "${CLAUDE_CANONICAL_PROJECTS_AUDIT:-1}" != "0" ]; then
   fi
 fi
 
+# ── Phase 15c: ETL Registry Freshness — BACKGROUND (DuckDB query ≤5s) ──────────
+# Reads the push-based `etl_freshness` registry table (llm#309 Phase 1a):
+# every ETL writer upserts its own status into this table after each run
+# (see .claude/scripts/etl_freshness_upsert.sh). Complementary to Phase 15a
+# (which pulls freshness live from a hardcoded source-table list) — this
+# phase surfaces writer-self-reported staleness instead.
+# Skippable: CLAUDE_ETL_FRESHNESS_CHECK=0 (shared opt-out with Phase 15a).
+# Fail-open by construction: the background script itself never exits
+# non-zero on a query miss (etl_freshness_stale_banner.sh), and any failure
+# here only ever produces an empty cache file — the hook never aborts.
+_etlreg_cache="${HOME}/.claude/logs/session_init_etl_registry_cache.txt"
+if [ "${CLAUDE_ETL_FRESHNESS_CHECK:-1}" != "0" ]; then
+  if [ -f "$_etlreg_cache" ]; then
+    _etlreg_cached=$(cat "$_etlreg_cache" 2>/dev/null) || true
+    [ -n "$_etlreg_cached" ] && echo "$_etlreg_cached"
+  fi
+  _etlreg_script="${CLAUDE_DIR}/scripts/etl_freshness_stale_banner.sh"
+  if [ -x "$_etlreg_script" ]; then
+    mkdir -p "$(dirname "$_etlreg_cache")"
+    nohup bash -c "timeout 5 '$_etlreg_script' 2>/dev/null > '$_etlreg_cache' || printf '' > '$_etlreg_cache'" > /dev/null 2>&1 &
+  fi
+fi
+
 # ── Phase 14: Record session-start SHA (for session-end refine) ───────────────
 # Writes HEAD SHA to ~/.claude/.session_start_sha_<project> so that
 # session_end_refine.sh can bound a roborev refine to commits from this session.

--- a/.claude/rules/session-init-phases.md
+++ b/.claude/rules/session-init-phases.md
@@ -45,6 +45,7 @@ Update this table in the same commit.
 | 14b | CI-Failure Issues | Counts open GitHub issues labeled `ci-failure` | One line if N>=1; silent if N=0 |
 | 15a | ETL Freshness Alarm | Checks age of most-recent row in 5 unified.duckdb tables; GREEN/AMBER/RED/CRITICAL. Skipped if `CLAUDE_ETL_FRESHNESS_CHECK=0`. 5s timeout, fail-open. See JohnGavin/llm#491. | Silent when all GREEN; one `etl-freshness: N RED, N AMBER, …` line when any table is non-GREEN |
 | 15b | Canonical-Projects Audit | Classifies distinct project/repo values across `roborev_review_lifecycle`, `roborev_finding_lineage_summary`, and `sessions` tables as FIXTURE / CANONICAL / UNKNOWN. Skipped if `CLAUDE_CANONICAL_PROJECTS_AUDIT=0`. 5s timeout, fail-open. See JohnGavin/llm#535. | Silent when fully clean; one `canonical-projects-audit: UNKNOWN=N …` line when unknowns found |
+| 15c | ETL Registry Freshness | Reads the push-based `etl_freshness` registry table (rows upserted by each ETL writer via `.claude/scripts/etl_freshness_upsert.sh` after every run). Complementary to Phase 15a's pull-based hardcoded table list. Skipped if `CLAUDE_ETL_FRESHNESS_CHECK=0` (shared opt-out). 5s timeout, fail-open — `etl_freshness_stale_banner.sh` never exits non-zero on a query miss. See JohnGavin/llm#309. | Silent when no sources are stale; one `STALE: <source> (<N>d)` line per stale source |
 | 14 | Session-Start SHA | Records HEAD SHA for session-end roborev refine | Silent (infrastructure) |
 
 ## Adding a New Phase

--- a/.claude/scripts/burn_rate_check.sh
+++ b/.claude/scripts/burn_rate_check.sh
@@ -22,8 +22,27 @@
 #   stderr of every failed fetch  → ~/.claude/logs/burn_rate_check.err
 #   >= 2 consecutive failures     → loud "BURN GUARD DEAD" line instead of
 #                                   the quiet burn:err that hid this for days
+#
+# npx cache-corruption fix (llm#309 Phase 1a):
+#   burn_rate_check.err showed weeks of repeated
+#   `npm error ENOTEMPTY ... rename ... ccusage-darwin-arm64` failures. Root
+#   cause: the 30s `_bounded` timeout SIGTERMs `npx --yes ccusage` mid
+#   platform-binary extraction on a cold cache, corrupting the shared
+#   ~/.npm/_npx/<hash>/ extraction directory; every subsequent run then
+#   raced on the half-extracted dir and failed the same way, forever (npx
+#   never re-extracts once a package dir exists, corrupt or not).
+#   Fix: install ccusage ONCE to a stable prefix (matching the
+#   npm-global-in-nix-shell convention) and exec the installed binary
+#   directly on every run — this sidesteps npx's resolution/extraction path
+#   entirely, so there is nothing left for the timeout to interrupt. Falls
+#   back to the original bounded `npx --yes` call if the local install is
+#   ever unavailable.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ETL_FRESHNESS_UPSERT="${SCRIPT_DIR}/etl_freshness_upsert.sh"
+UNIFIED_DB="${HOME}/.claude/logs/unified.duckdb"
 
 MODE="${1:-full}"
 CAP="${CLAUDE_WEEKLY_CAP_USD:-150}"
@@ -33,6 +52,17 @@ TZ_NAME="${CLAUDE_TIMEZONE:-Europe/Dublin}"
 ERR_LOG="$HOME/.claude/logs/burn_rate_check.err"
 FAIL_COUNT_FILE="$HOME/.claude/.burn_rate_fail_count"
 
+# ETL freshness registry (llm#309 Phase 1a): 24h cadence. Freshness proxy is
+# CACHE_FILE's mtime — it only updates on a *successful* fetch, so a guard
+# that silently stops fetching (the exact "BURN GUARD DEAD" failure mode
+# above) ages past 24h and flips to status='stale', surfaced at session
+# start even before 2 consecutive failures trip the louder canary.
+_register_burn_freshness() {
+  [ -x "$ETL_FRESHNESS_UPSERT" ] || return 0
+  [ -n "${CACHE_FILE:-}" ] || return 0
+  "$ETL_FRESHNESS_UPSERT" burn_rate "$UNIFIED_DB" 24 --file "$CACHE_FILE" >/dev/null 2>&1 || true
+}
+
 # Consecutive-failure canary (llm#597). A dead guard must get LOUDER, not
 # quieter: after 2 consecutive fetch failures the output stops being a quiet
 # burn:err and names the log to read.
@@ -41,6 +71,7 @@ fail_and_exit() {
   [ -f "$FAIL_COUNT_FILE" ] && n=$(cat "$FAIL_COUNT_FILE" 2>/dev/null || echo 0)
   n=$((n + 1))
   echo "$n" > "$FAIL_COUNT_FILE" 2>/dev/null || true
+  _register_burn_freshness
   if [ "$MODE" = "--percent-only" ]; then
     echo "0"  # Always numeric for scripts
   elif [ "$n" -ge 2 ]; then
@@ -94,6 +125,27 @@ _bounded() {
   fi
 }
 
+# ── Local ccusage install (llm#309) ─────────────────────────────────────────
+# Installs ccusage ONCE to a stable prefix instead of resolving/extracting it
+# through npx on every invocation. Matches the npm-global-in-nix-shell
+# convention: --prefix + --cache to an isolated dir (avoids the read-only
+# store-prefix issue inside a nix shell, and avoids sharing a cache dir with
+# any concurrent install). Returns 0 and leaves $CCUSAGE_BIN executable when
+# a usable install is available; returns 1 (never aborts) otherwise so the
+# caller can fall back to `npx --yes`.
+CCUSAGE_PREFIX="${CCUSAGE_PREFIX:-$HOME/.npm-global}"
+CCUSAGE_BIN="${CCUSAGE_PREFIX}/bin/ccusage"
+
+_ensure_ccusage_installed() {
+  [ -x "$CCUSAGE_BIN" ] && return 0
+  command -v npm >/dev/null 2>&1 || return 1
+  mkdir -p "$CCUSAGE_PREFIX" 2>/dev/null || return 1
+  _bounded 60 npm install --prefix "$CCUSAGE_PREFIX" \
+    --cache "/tmp/ccusage-npm-cache-$$" ccusage@latest \
+    >/dev/null 2>>"$ERR_LOG" || true
+  [ -x "$CCUSAGE_BIN" ]
+}
+
 # Cache: reuse if < 5 minutes old AND for the same week window
 CACHE_FILE="/tmp/ccusage_burnweek_${week_start_ymd}_cache.json"
 CACHE_MAX_AGE=300
@@ -110,26 +162,40 @@ if [ "$use_cache" = true ]; then
   daily_json=$(cat "$CACHE_FILE")
 else
   err_tmp=$(mktemp /tmp/burn_rate_err_XXXXXX)
-  # _bounded: always bounded (perl alarm fallback when GNU timeout absent);
-  # --yes: never prompt to install a missing npx package;
-  # </dev/null: stdin is /dev/null so any install prompt gets immediate EOF.
-  daily_json=$(_bounded 30 npx --yes ccusage daily \
-    --since "$week_start_ymd" \
-    --timezone "$TZ_NAME" \
-    --json --offline </dev/null 2>"$err_tmp") || {
-    {
-      echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ccusage daily --since $week_start_ymd failed — stderr:"
-      cat "$err_tmp"
-    } >> "$ERR_LOG" 2>/dev/null || true
-    rm -f "$err_tmp"
-    fail_and_exit
-  }
+  daily_json=""
+  if _ensure_ccusage_installed; then
+    # Local install (llm#309): bypasses npx's resolution/extraction path —
+    # no repeated cache extraction means no ENOTEMPTY race on a timeout kill.
+    daily_json=$(_bounded 30 "$CCUSAGE_BIN" daily \
+      --since "$week_start_ymd" \
+      --timezone "$TZ_NAME" \
+      --json --offline </dev/null 2>"$err_tmp") || daily_json=""
+  fi
+  if [ -z "$daily_json" ]; then
+    # Fallback: local install unavailable or its run failed — original path.
+    # _bounded: always bounded (perl alarm fallback when GNU timeout absent);
+    # --yes: never prompt to install a missing npx package;
+    # </dev/null: stdin is /dev/null so any install prompt gets immediate EOF.
+    daily_json=$(_bounded 30 npx --yes ccusage daily \
+      --since "$week_start_ymd" \
+      --timezone "$TZ_NAME" \
+      --json --offline </dev/null 2>>"$err_tmp") || {
+      {
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ccusage daily --since $week_start_ymd failed — stderr:"
+        cat "$err_tmp"
+      } >> "$ERR_LOG" 2>/dev/null || true
+      rm -f "$err_tmp"
+      _register_burn_freshness
+      fail_and_exit
+    }
+  fi
   rm -f "$err_tmp"
   echo "$daily_json" > "$CACHE_FILE"
 fi
 
 # Fetch succeeded — reset the consecutive-failure canary
 rm -f "$FAIL_COUNT_FILE" 2>/dev/null || true
+_register_burn_freshness
 
 # Parse: spend = totals.totalCost over the since-window (our cap week)
 result=$(echo "$daily_json" | python3 -c "

--- a/.claude/scripts/etl_freshness_stale_banner.sh
+++ b/.claude/scripts/etl_freshness_stale_banner.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# etl_freshness_stale_banner.sh — session-start banner for stale ETL sources.
+#
+# Reads the push-based `etl_freshness` registry table (llm#309 Phase 1a; rows
+# are written by .claude/scripts/etl_freshness_upsert.sh, called by each ETL
+# writer after it finishes running) and prints one `STALE: <source> (<N>d)`
+# line per source currently marked stale. Silent when there are none.
+#
+# Complementary to etl_freshness_check.sh (session_init.sh Phase 15a), which
+# pulls freshness live from a hardcoded table list. This script surfaces
+# writer-self-reported staleness instead.
+#
+# Usage:
+#   etl_freshness_stale_banner.sh
+#   ETL_FRESHNESS_DB=/path/to/scratch.duckdb etl_freshness_stale_banner.sh   # testing
+#
+# Fail-open: a missing duckdb binary, a missing DB, a missing etl_freshness
+# table, or any query error all print nothing and exit 0. Never aborts the
+# caller under `set -euo pipefail` (hook-pipefail-no-stderr lesson).
+#
+# Tracked in llm#309 Phase 1a.
+
+set -uo pipefail
+
+DB="${ETL_FRESHNESS_DB:-${HOME}/.claude/logs/unified.duckdb}"
+
+command -v duckdb >/dev/null 2>&1 || exit 0
+[ -f "$DB" ] || exit 0
+
+_rows=$(duckdb -init /dev/null "$DB" -noheader -list -c "
+  SELECT source_name || '|' ||
+         CAST(FLOOR(EXTRACT(EPOCH FROM (current_timestamp - COALESCE(last_row_ts, last_etl_run_ts))) / 86400.0) AS BIGINT)
+  FROM etl_freshness
+  WHERE status = 'stale';
+" 2>/dev/null) || exit 0
+
+[ -n "$_rows" ] || exit 0
+
+while IFS='|' read -r _src _days; do
+  [ -z "$_src" ] && continue
+  echo "STALE: ${_src} (${_days}d)"
+done <<< "$_rows"
+
+exit 0

--- a/.claude/scripts/etl_freshness_upsert.sh
+++ b/.claude/scripts/etl_freshness_upsert.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# etl_freshness_upsert.sh — record ETL freshness for a data source in unified.duckdb
+#
+# Makes silent ETL staleness impossible (llm#309 Phase 1a): every ETL writer
+# calls this helper after it finishes writing, so a single registry table
+# (`etl_freshness`) always answers "when did each source last update, and is
+# that within its expected cadence?" without any writer having to build its
+# own freshness logic.
+#
+# Usage:
+#   etl_freshness_upsert.sh <source_name> <db_path> [cadence_hours] \
+#       [--table TABLE --ts-col COLUMN | --file PATH]
+#
+#   source_name     Stable identifier for the data source, e.g. 'sessions',
+#                    'roborev', 'burn_rate'. Primary key in etl_freshness.
+#   db_path          Path to the unified DuckDB (or a scratch DB for tests).
+#   cadence_hours    Expected refresh interval in hours. Omit (or pass "")
+#                    for event-driven sources with no SLA -> status='unknown'.
+#   --table/--ts-col Derive last_row_ts from MAX(ts_col) FROM table. Silently
+#                    skipped (last_row_ts stays NULL) if the table does not
+#                    exist yet — never errors.
+#   --file PATH      Derive last_row_ts from this file's mtime instead of a
+#                    DB table (for writers whose source-of-truth is a JSONL
+#                    staging file, not a queryable table).
+#
+# Idempotent: CREATE TABLE IF NOT EXISTS + INSERT OR REPLACE keyed on
+# source_name. Safe to call on every ETL run.
+#
+# Fail-open: a missing duckdb binary, a missing source table, or a DB write
+# failure never aborts the caller — this script exits 0 in all of those
+# cases. It exits 1 only on a genuine usage error (missing required args),
+# so callers should still guard invocations with `|| true`.
+#
+# Tracked in llm#309 Phase 1a.
+
+set -uo pipefail
+
+SOURCE_NAME="${1:-}"
+DB_PATH="${2:-}"
+CADENCE_HOURS="${3:-}"
+shift 3 2>/dev/null || true
+
+if [ -z "$SOURCE_NAME" ] || [ -z "$DB_PATH" ]; then
+  echo "usage: etl_freshness_upsert.sh <source_name> <db_path> [cadence_hours] [--table T --ts-col C | --file PATH]" >&2
+  exit 1
+fi
+
+TABLE=""
+TS_COL=""
+FILE_PATH=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --table)  TABLE="${2:-}";     shift 2 2>/dev/null || shift ;;
+    --ts-col) TS_COL="${2:-}";    shift 2 2>/dev/null || shift ;;
+    --file)   FILE_PATH="${2:-}"; shift 2 2>/dev/null || shift ;;
+    *) shift ;;
+  esac
+done
+
+if ! command -v duckdb >/dev/null 2>&1; then
+  echo "etl_freshness_upsert: SKIP (duckdb not in PATH)" >&2
+  exit 0
+fi
+
+# ── Escape single quotes for safe SQL string literals ──────────────────────
+_esc() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+_source_esc="$(_esc "$SOURCE_NAME")"
+
+# ── Determine the last_row_ts SQL expression ───────────────────────────────
+LAST_ROW_TS_EXPR="NULL::TIMESTAMP"
+
+if [ -n "$FILE_PATH" ] && [ -f "$FILE_PATH" ]; then
+  # Portable mtime -> epoch (GNU stat -c, BSD stat -f fallback), then epoch ->
+  # ISO-ish string (BSD `date -r <epoch>`, GNU `date -d @<epoch>` fallback —
+  # the two-step chain works on both: GNU `-r` wants a *file*, so it errs
+  # cleanly on a bare epoch number and falls through to the `-d @epoch` form).
+  _mtime_epoch=$(stat -c %Y "$FILE_PATH" 2>/dev/null || stat -f %m "$FILE_PATH" 2>/dev/null || echo "")
+  if [ -n "$_mtime_epoch" ]; then
+    _mtime_iso=$(date -u -r "$_mtime_epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null \
+      || date -u -d "@${_mtime_epoch}" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "")
+    if [ -n "$_mtime_iso" ]; then
+      LAST_ROW_TS_EXPR="TIMESTAMP '$(_esc "$_mtime_iso")'"
+    fi
+  fi
+elif [ -n "$TABLE" ] && [ -n "$TS_COL" ]; then
+  _table_esc="$(_esc "$TABLE")"
+  _exists=$(duckdb -init /dev/null "$DB_PATH" -noheader -list -c \
+    "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = '${_table_esc}';" 2>/dev/null || echo 0)
+  _exists="${_exists:-0}"
+  if [ "${_exists}" -ge 1 ] 2>/dev/null; then
+    LAST_ROW_TS_EXPR="(SELECT MAX(\"${TS_COL}\") FROM \"${TABLE}\")"
+  fi
+fi
+
+# ── Determine the cadence SQL literal ───────────────────────────────────────
+# Empty or non-numeric -> NULL (event-driven source, no SLA -> status='unknown')
+CADENCE_SQL="NULL"
+case "$CADENCE_HOURS" in
+  ''|*[!0-9.]*) CADENCE_SQL="NULL" ;;
+  *) CADENCE_SQL="$CADENCE_HOURS" ;;
+esac
+
+duckdb -init /dev/null "$DB_PATH" -c "
+CREATE TABLE IF NOT EXISTS etl_freshness (
+  source_name            VARCHAR PRIMARY KEY,
+  last_row_ts            TIMESTAMP,
+  last_etl_run_ts         TIMESTAMP,
+  expected_cadence_hours DOUBLE,
+  status                  VARCHAR
+);
+
+INSERT OR REPLACE INTO etl_freshness
+  (source_name, last_row_ts, last_etl_run_ts, expected_cadence_hours, status)
+SELECT
+  '${_source_esc}',
+  lrt.last_row_ts,
+  current_timestamp,
+  ${CADENCE_SQL},
+  CASE
+    WHEN ${CADENCE_SQL} IS NULL THEN 'unknown'
+    WHEN lrt.last_row_ts IS NULL THEN 'unknown'
+    WHEN EXTRACT(EPOCH FROM (current_timestamp - lrt.last_row_ts)) / 3600.0 > ${CADENCE_SQL}
+      THEN 'stale'
+    ELSE 'fresh'
+  END
+FROM (SELECT ${LAST_ROW_TS_EXPR} AS last_row_ts) lrt;
+" 2>/dev/null || { echo "etl_freshness_upsert: WARN duckdb upsert failed for source=${SOURCE_NAME}" >&2; exit 0; }
+
+exit 0

--- a/.claude/scripts/housekeeping_schema_init.sql
+++ b/.claude/scripts/housekeeping_schema_init.sql
@@ -157,6 +157,23 @@ CREATE TABLE IF NOT EXISTS roborev_daily_summary (
 CREATE INDEX IF NOT EXISTS idx_roborev_daily_summary_fired_at ON roborev_daily_summary(fired_at);
 CREATE INDEX IF NOT EXISTS idx_roborev_daily_summary_project_window ON roborev_daily_summary(project, window_end);
 
+-- etl_freshness: one row per ETL data source, upserted by the source's own
+-- writer after every run via .claude/scripts/etl_freshness_upsert.sh. Makes
+-- silent ETL staleness impossible — session_init.sh Phase 15c surfaces any
+-- row with status='stale' at session start.
+-- status vocabulary: fresh | stale | unknown (unknown = no expected_cadence_hours,
+-- i.e. an event-driven source with no SLA, e.g. sessions/agent_runs).
+-- PK: source_name.
+-- See llm#309 Phase 1a.
+CREATE TABLE IF NOT EXISTS etl_freshness (
+  source_name             VARCHAR PRIMARY KEY,
+  last_row_ts             TIMESTAMP,
+  last_etl_run_ts         TIMESTAMP,
+  expected_cadence_hours  DOUBLE,
+  status                  VARCHAR
+);
+CREATE INDEX IF NOT EXISTS idx_etl_freshness_status ON etl_freshness(status);
+
 CREATE INDEX IF NOT EXISTS idx_worktree_gc_events_fired_at ON worktree_gc_events(fired_at);
 CREATE INDEX IF NOT EXISTS idx_branch_gc_events_fired_at ON branch_gc_events(fired_at);
 CREATE INDEX IF NOT EXISTS idx_branch_gc_events_project_branch ON branch_gc_events(project, branch_name);

--- a/.claude/scripts/log_session.sh
+++ b/.claude/scripts/log_session.sh
@@ -19,6 +19,7 @@
 #   most once per session boundary and retain the duckdb CLI path.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DB="$HOME/.claude/logs/unified.duckdb"
 ACTION="${1:-}"
 SESSION_ID="${2:-$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo unknown)}"
@@ -53,6 +54,11 @@ case "$ACTION" in
       WHERE session_id = '$SESSION_ID';
     " 2>/dev/null || true
     rm -f "$HOME/.claude/logs/.current_session"
+    # ETL freshness registry (llm#309 Phase 1a): event-driven, no SLA -> unknown.
+    if [ -x "${SCRIPT_DIR}/etl_freshness_upsert.sh" ]; then
+      "${SCRIPT_DIR}/etl_freshness_upsert.sh" sessions "$DB" "" \
+        --table sessions --ts-col started_at >/dev/null 2>&1 || true
+    fi
     ;;
   error)
     SOURCE="${5:-unknown}"
@@ -115,6 +121,11 @@ case "$ACTION" in
           duration_sec, prompt_preview, status, tool_use_id)
         VALUES ('$SESSION_ID','$AGENT_TYPE','inherited',current_timestamp,
           current_timestamp,0,'$PROMPT_PV','$STATUS',NULLIF('$TOOL_USE_ID',''));" 2>/dev/null || true
+    fi
+    # ETL freshness registry (llm#309 Phase 1a): event-driven, no SLA -> unknown.
+    if [ -x "${SCRIPT_DIR}/etl_freshness_upsert.sh" ]; then
+      "${SCRIPT_DIR}/etl_freshness_upsert.sh" agent_runs "$DB" "" \
+        --table agent_runs --ts-col started_at >/dev/null 2>&1 || true
     fi
     ;;
   *)

--- a/.claude/scripts/roborev_metrics_etl.sh
+++ b/.claude/scripts/roborev_metrics_etl.sh
@@ -402,5 +402,12 @@ if [ "${EXIT_CODE}" -eq 0 ]; then
   date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/roborev-metrics-etl.stamp"
 fi
 
+# ETL freshness registry (llm#309 Phase 1a): daily cadence — 24h.
+ETL_FRESHNESS_UPSERT="${SCRIPT_DIR}/etl_freshness_upsert.sh"
+if [ -x "$ETL_FRESHNESS_UPSERT" ]; then
+  "$ETL_FRESHNESS_UPSERT" roborev "$UNIFIED_DB" 24 \
+    --table roborev_daily_metrics --ts-col etl_run_at >/dev/null 2>&1 || true
+fi
+
 echo "roborev_metrics_etl: exit=${EXIT_CODE}"
 exit $EXIT_CODE

--- a/tests/test_etl_freshness_upsert.sh
+++ b/tests/test_etl_freshness_upsert.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# tests/test_etl_freshness_upsert.sh
+#
+# Unit tests for the ETL freshness registry (JohnGavin/llm#309 Phase 1a):
+#   .claude/scripts/etl_freshness_upsert.sh
+#   .claude/scripts/etl_freshness_stale_banner.sh
+#   .claude/hooks/session_init.sh Phase 15c wiring
+#
+# Every test runs against a freshly-created scratch DuckDB — never the live
+# ~/.claude/logs/unified.duckdb.
+#
+# Exits 0 if all tests pass, 1 on any failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPSERT="${SCRIPT_DIR}/../.claude/scripts/etl_freshness_upsert.sh"
+BANNER="${SCRIPT_DIR}/../.claude/scripts/etl_freshness_stale_banner.sh"
+SESSION_INIT="${SCRIPT_DIR}/../.claude/hooks/session_init.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT="$(mktemp -d)"
+
+cleanup() { rm -rf "${TMPDIR_ROOT}"; }
+trap cleanup EXIT
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "${expected}" = "${actual}" ]; then
+    pass "${desc}"
+  else
+    fail "${desc} — expected='${expected}' actual='${actual}'"
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "${haystack}" | grep -qF "${needle}"; then
+    pass "${desc}"
+  else
+    fail "${desc} — '${needle}' not found in output: ${haystack}"
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "${haystack}" | grep -qF "${needle}"; then
+    fail "${desc} — '${needle}' should NOT appear but does"
+  else
+    pass "${desc}"
+  fi
+}
+
+if ! command -v duckdb >/dev/null 2>&1; then
+  echo "SKIP: duckdb not in PATH — cannot run fixture-based tests"
+  exit 0
+fi
+
+# ── Test 0: bash -n syntax check on all touched scripts ──────────────────────
+for f in "${UPSERT}" "${BANNER}" "${SESSION_INIT}"; do
+  rc=0
+  bash -n "${f}" 2>/dev/null || rc=$?
+  assert_eq "test0: bash -n exits 0 ($(basename "${f}"))" "0" "${rc}"
+done
+
+# ── Test 1: usage error — missing required args exits 1 ──────────────────────
+rc1=0
+bash "${UPSERT}" >/dev/null 2>&1 || rc1=$?
+assert_eq "test1: missing args exits 1 (usage error)" "1" "${rc1}"
+
+# ── Test 2: upsert with no --table/--file creates a row, status=unknown ──────
+DB2="${TMPDIR_ROOT}/db2.duckdb"
+rc2=0
+bash "${UPSERT}" burn_rate "${DB2}" 24 >/dev/null 2>&1 || rc2=$?
+assert_eq "test2: exit 0 with no table/file" "0" "${rc2}"
+
+row2=$(duckdb -init /dev/null "${DB2}" -noheader -list -c \
+  "SELECT source_name, status FROM etl_freshness WHERE source_name='burn_rate';" 2>/dev/null)
+assert_contains "test2: row created for burn_rate" "burn_rate" "${row2}"
+assert_contains "test2: status=unknown (no last_row_ts source)" "unknown" "${row2}"
+
+# ── Test 3: cadence omitted (event-driven) -> status=unknown even with data ──
+DB3="${TMPDIR_ROOT}/db3.duckdb"
+duckdb -init /dev/null "${DB3}" -c "
+  CREATE TABLE sessions (started_at TIMESTAMP);
+  INSERT INTO sessions VALUES (current_timestamp);
+" >/dev/null 2>&1
+
+rc3=0
+bash "${UPSERT}" sessions "${DB3}" "" --table sessions --ts-col started_at >/dev/null 2>&1 || rc3=$?
+assert_eq "test3: exit 0 with empty cadence" "0" "${rc3}"
+
+status3=$(duckdb -init /dev/null "${DB3}" -noheader -list -c \
+  "SELECT status FROM etl_freshness WHERE source_name='sessions';" 2>/dev/null)
+assert_eq "test3: status=unknown when cadence omitted" "unknown" "${status3}"
+
+# ── Test 4: last_row_ts 30 days back + cadence 24h -> status=stale ───────────
+DB4="${TMPDIR_ROOT}/db4.duckdb"
+duckdb -init /dev/null "${DB4}" -c "
+  CREATE TABLE roborev_daily_metrics (etl_run_at TIMESTAMP);
+  INSERT INTO roborev_daily_metrics VALUES (current_timestamp - INTERVAL 30 DAY);
+" >/dev/null 2>&1
+
+rc4=0
+bash "${UPSERT}" roborev "${DB4}" 24 --table roborev_daily_metrics --ts-col etl_run_at \
+  >/dev/null 2>&1 || rc4=$?
+assert_eq "test4: exit 0" "0" "${rc4}"
+
+status4=$(duckdb -init /dev/null "${DB4}" -noheader -list -c \
+  "SELECT status FROM etl_freshness WHERE source_name='roborev';" 2>/dev/null)
+assert_eq "test4: 30d-old row + 24h cadence -> stale" "stale" "${status4}"
+
+# ── Test 5: same source, refreshed to 1 hour old -> status=fresh (idempotent) ─
+duckdb -init /dev/null "${DB4}" -c "
+  UPDATE roborev_daily_metrics SET etl_run_at = current_timestamp - INTERVAL 1 HOUR;
+" >/dev/null 2>&1
+
+rc5=0
+bash "${UPSERT}" roborev "${DB4}" 24 --table roborev_daily_metrics --ts-col etl_run_at \
+  >/dev/null 2>&1 || rc5=$?
+assert_eq "test5: exit 0" "0" "${rc5}"
+
+status5=$(duckdb -init /dev/null "${DB4}" -noheader -list -c \
+  "SELECT status FROM etl_freshness WHERE source_name='roborev';" 2>/dev/null)
+assert_eq "test5: 1h-old row + 24h cadence -> fresh" "fresh" "${status5}"
+
+rowcount5=$(duckdb -init /dev/null "${DB4}" -noheader -list -c \
+  "SELECT COUNT(*) FROM etl_freshness WHERE source_name='roborev';" 2>/dev/null)
+assert_eq "test5: idempotent — still exactly 1 row for roborev" "1" "${rowcount5}"
+
+# ── Test 6: --table pointing at a non-existent table -> status=unknown, no error ─
+DB6="${TMPDIR_ROOT}/db6.duckdb"
+rc6=0
+bash "${UPSERT}" ghost "${DB6}" 24 --table does_not_exist --ts-col ts >/dev/null 2>&1 || rc6=$?
+assert_eq "test6: exit 0 even when table missing" "0" "${rc6}"
+
+status6=$(duckdb -init /dev/null "${DB6}" -noheader -list -c \
+  "SELECT status FROM etl_freshness WHERE source_name='ghost';" 2>/dev/null)
+assert_eq "test6: missing table -> unknown (last_row_ts NULL)" "unknown" "${status6}"
+
+# ── Test 7: --file mode uses file mtime; stale file -> status=stale ──────────
+DB7="${TMPDIR_ROOT}/db7.duckdb"
+STALE_FILE="${TMPDIR_ROOT}/stale_events.jsonl"
+echo '{"ts":"old"}' > "${STALE_FILE}"
+# Backdate the file's mtime by 30 days (portable: touch -t or -d)
+OLD_TS="$(date -v-30d '+%Y%m%d%H%M' 2>/dev/null || date -d '-30 days' '+%Y%m%d%H%M')"
+touch -t "${OLD_TS}" "${STALE_FILE}" 2>/dev/null || true
+
+rc7=0
+bash "${UPSERT}" llmtelemetry "${DB7}" 24 --file "${STALE_FILE}" >/dev/null 2>&1 || rc7=$?
+assert_eq "test7: exit 0 with --file mode" "0" "${rc7}"
+
+status7=$(duckdb -init /dev/null "${DB7}" -noheader -list -c \
+  "SELECT status FROM etl_freshness WHERE source_name='llmtelemetry';" 2>/dev/null)
+assert_eq "test7: 30d-old file + 24h cadence -> stale" "stale" "${status7}"
+
+# ── Test 8: duckdb missing from PATH -> upsert exits 0 (fail-open) ───────────
+DB8="${TMPDIR_ROOT}/db8.duckdb"
+rc8=0
+PATH="/usr/bin:/bin" bash "${UPSERT}" x "${DB8}" 24 >/dev/null 2>&1 || rc8=$?
+assert_eq "test8: exit 0 when duckdb absent from PATH" "0" "${rc8}"
+
+# ── Test 9: banner is silent when nothing is stale ───────────────────────────
+DB9="${TMPDIR_ROOT}/db9.duckdb"
+bash "${UPSERT}" fresh_source "${DB9}" 24 --file "${STALE_FILE}" >/dev/null 2>&1
+# Overwrite it fresh directly for a clean fresh row
+duckdb -init /dev/null "${DB9}" -c "
+  UPDATE etl_freshness SET last_row_ts = current_timestamp, status = 'fresh'
+  WHERE source_name = 'fresh_source';
+" >/dev/null 2>&1
+
+out9=$(ETL_FRESHNESS_DB="${DB9}" bash "${BANNER}" 2>&1)
+rc9=$?
+assert_eq "test9: banner exits 0" "0" "${rc9}"
+assert_eq "test9: banner prints nothing when all fresh" "" "${out9}"
+
+# ── Test 10: banner prints one STALE line per stale source ───────────────────
+duckdb -init /dev/null "${DB9}" -c "
+  INSERT OR REPLACE INTO etl_freshness
+    (source_name, last_row_ts, last_etl_run_ts, expected_cadence_hours, status)
+  VALUES ('burn_rate', current_timestamp - INTERVAL 3 DAY, current_timestamp, 24, 'stale');
+" >/dev/null 2>&1
+
+out10=$(ETL_FRESHNESS_DB="${DB9}" bash "${BANNER}" 2>&1)
+rc10=$?
+assert_eq "test10: banner exits 0 with a stale row present" "0" "${rc10}"
+assert_contains "test10: banner reports STALE: burn_rate" "STALE: burn_rate" "${out10}"
+assert_not_contains "test10: banner does not report fresh_source" "STALE: fresh_source" "${out10}"
+
+# ── Test 11: banner never exits non-zero on a query miss ─────────────────────
+# 11a: DB file missing entirely
+rc11a=0
+ETL_FRESHNESS_DB="/tmp/no_such_etl_freshness_db_$$" bash "${BANNER}" >/dev/null 2>&1 || rc11a=$?
+assert_eq "test11a: banner exit 0 on missing DB" "0" "${rc11a}"
+
+# 11b: DB exists but etl_freshness table does not (query miss)
+DB11B="${TMPDIR_ROOT}/db11b.duckdb"
+duckdb -init /dev/null "${DB11B}" -c "CREATE TABLE unrelated (x INTEGER);" >/dev/null 2>&1
+rc11b=0
+ETL_FRESHNESS_DB="${DB11B}" bash "${BANNER}" >/dev/null 2>&1 || rc11b=$?
+assert_eq "test11b: banner exit 0 when etl_freshness table missing" "0" "${rc11b}"
+
+# 11c: duckdb missing from PATH entirely
+rc11c=0
+PATH="/usr/bin:/bin" ETL_FRESHNESS_DB="${DB9}" bash "${BANNER}" >/dev/null 2>&1 || rc11c=$?
+assert_eq "test11c: banner exit 0 when duckdb absent from PATH" "0" "${rc11c}"
+
+# ── Test 12: session_init.sh wires Phase 15c to the banner script ────────────
+assert_eq "test12: etl_freshness_stale_banner.sh is executable" "1" \
+  "$([ -x "${BANNER}" ] && echo 1 || echo 0)"
+
+phase15c_present=$(grep -c "etl_freshness_stale_banner.sh" "${SESSION_INIT}" || true)
+if [ "${phase15c_present:-0}" -ge 1 ]; then
+  pass "test12: session_init.sh references etl_freshness_stale_banner.sh"
+else
+  fail "test12: session_init.sh does not reference etl_freshness_stale_banner.sh"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${PASS} PASS, ${FAIL} FAIL"
+
+if [ "${FAIL}" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Adds a push-based `etl_freshness` registry table (`source_name`, `last_row_ts`, `last_etl_run_ts`, `expected_cadence_hours`, `status`) so ETL staleness can never go silent.
- New helper `.claude/scripts/etl_freshness_upsert.sh <source_name> <db_path> [cadence_hours] [--table T --ts-col C | --file PATH]` — idempotent, fail-open, called by each writer after it finishes.
- Wired into `roborev_metrics_etl.sh` (24h cadence), `log_session.sh` (`sessions`/`agent_runs`, event-driven → unknown), `llmtelemetry_emit.sh` (`llmtelemetry`, file-mtime proxy → unknown).
- New `.claude/scripts/etl_freshness_stale_banner.sh` + `session_init.sh` Phase 15c: prints `STALE: <source> (<N>d)` at session start for any stale source; complementary to the existing pull-based Phase 15a. Guarded/fail-open throughout — never aborts the hook on a query miss.
- Diagnosed and fixed the degraded `burn_rate_check.sh` guard: weeks of `npm error ENOTEMPTY ... ccusage-darwin-arm64` were caused by the 30s bounded `npx` call being killed mid platform-binary extraction, corrupting the shared npx cache for every subsequent run. Fix: install ccusage once to a stable prefix (`~/.npm-global`, matching the npm-global-in-nix-shell convention) and exec it directly, bypassing npx's extraction path; falls back to the original `npx --yes` path if the local install is ever unavailable. Also registers a `burn_rate` row in `etl_freshness` (24h cadence, CACHE_FILE mtime as freshness proxy).
- `housekeeping_schema_init.sql` updated with the `etl_freshness` DDL for consistency with `housekeeping_schema_apply.sh`.
- `.claude/rules/session-init-phases.md` updated with the new Phase 15c row.

## Test plan
- [x] `tests/test_etl_freshness_upsert.sh` — 29/29 PASS (upsert creates rows; 30d-stale → `stale`; 1h-fresh → `fresh`; no-cadence → `unknown`; missing table/file/DB/duckdb all fail-open exit 0; banner prints `STALE:` lines only for stale sources; `session_init.sh` wiring verified)
- [x] `bash -n` clean on all 8 touched/added shell scripts
- [x] `housekeeping_schema_init.sql` applies cleanly against a scratch DuckDB; `DESCRIBE etl_freshness` matches spec exactly
- [x] `roborev_metrics_etl.sh` self-test: 13/13 PASS (run inside the project nix shell) — no regression from the new freshness-registry call
- [x] `.claude/tests/test_agent_run_hook.sh` (existing `log_session.sh` regression suite): 15/15 PASS
- [x] Manually replayed the `llmtelemetry_emit.sh` start/stop flow in a scratch `$HOME` — JSONL staging output unchanged; `etl_freshness` row correctly written to the scratch DB only
- [x] No writes to the live `~/.claude/logs/unified.duckdb` at any point — all testing used scratch DuckDB files

Closes #309 (Phase 1a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)