### PR TITLE
feat(skill-usage): instrument + backfill skill_usage table (Card 1b, #729)

### DIFF
--- a/.claude/hooks/log_skill_use.sh
+++ b/.claude/hooks/log_skill_use.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# log_skill_use.sh — Stage Skill-tool invocations for skill_usage instrumentation.
+# Hook: PostToolUse(Skill) in settings.json.
+#
+# Card 1b (own-your-context plan): skill_usage had only ~29 rows against 3,783
+# sessions because the only path into the table was a nightly ETL scanning
+# raw JSONL transcripts (skill_usage_etl.R/.sh) for a narrow literal-match
+# pattern. This hook adds a REAL-TIME forward path so every Skill invocation
+# is captured going forward, independent of that nightly batch scan.
+#
+# CONCURRENCY (mirrors log_session.sh's `hook` case, #710): do NOT open the
+# duckdb CLI here — a busy session firing many tool calls per minute would
+# contend for the exclusive write lock on unified.duckdb. Instead append one
+# JSON line per event to an append-only staging file (each printf/>> is an
+# atomic kernel write <= PIPE_BUF). skill_usage_staging_import.sh drains this
+# file into the skill_usage table on the existing roborev-metrics-etl launchd
+# schedule (see roborev_metrics_etl.sh).
+#
+# Reads the hook payload as JSON on stdin (modern interface). ALWAYS exits 0
+# — must never block the Skill tool call.
+set -uo pipefail
+
+_staging="$HOME/.claude/logs/skill_usage_staging.jsonl"
+mkdir -p "$(dirname "$_staging")" 2>/dev/null || true
+
+_sid=""
+if [ -f "$HOME/.claude/logs/.current_session" ]; then
+  _sid=$(cat "$HOME/.claude/logs/.current_session" 2>/dev/null || echo "")
+fi
+[ -n "$_sid" ] || _sid="unknown"
+
+_input=$(cat 2>/dev/null || echo "")   # consume stdin once
+
+_jq() { echo "$_input" | jq -r "$1" 2>/dev/null || echo ""; }
+
+if [ -n "$_input" ] && command -v jq >/dev/null 2>&1; then
+  _skill=$(_jq '.tool_input.skill // empty')
+  _args=$(_jq '.tool_input.args // empty')
+else
+  # Legacy fallback: crude grep extraction when jq is unavailable.
+  _skill=$(echo "$_input" | grep -o '"skill":"[^"]*"' | head -1 | cut -d'"' -f4)
+  _args=""
+fi
+
+[ -n "$_skill" ] || exit 0   # not a real Skill invocation (e.g. payload shape changed) — nothing to log
+
+_proj="$(pwd)"
+_ts=$(date -u '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')
+
+# args_hash: short non-reversible fingerprint of the args string. We never
+# store args content itself — only a fixed-length hash — so free-text skill
+# args (which may reference private notes/paths) never land in the DB.
+_args_hash=""
+if [ -n "$_args" ] && command -v shasum >/dev/null 2>&1; then
+  _args_hash=$(printf '%s' "$_args" | shasum -a 256 | cut -c1-16)
+fi
+
+# JSON-escape (backslash then double-quote; strip control chars that would
+# break JSONL), same convention as log_session.sh's `hook` case.
+_esc() {
+  printf '%s' "$1" | tr '\n\r\t' '   ' | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+_skill_esc=$(_esc "$_skill")
+_proj_esc=$(_esc "$_proj")
+_sid_esc=$(_esc "$_sid")
+
+printf '{"ts":"%s","session_id":"%s","skill_name":"%s","project_path":"%s","args_hash":"%s"}\n' \
+  "$_ts" "$_sid_esc" "$_skill_esc" "$_proj_esc" "$_args_hash" \
+  >> "$_staging" 2>/dev/null || true
+
+exit 0

--- a/.claude/scripts/backfill_skill_usage.R
+++ b/.claude/scripts/backfill_skill_usage.R
@@ -15,8 +15,10 @@
 # length hash (never stored as free text) — consistent with
 # log_skill_use.sh's privacy stance.
 #
-# Idempotent: dedupes on (session_id, skill_name, ts) via NOT EXISTS at
-# insert time, so re-running never increases the row count.
+# Idempotent: dedupes on (session_id, skill_name, ts, args_hash) via NOT
+# EXISTS at insert time, so re-running never increases the row count.
+# args_hash is matched with IS NOT DISTINCT FROM (NULL-safe) so two
+# invocations differing only in args are never conflated into one row.
 #
 # Usage:
 #   Rscript backfill_skill_usage.R [--apply] [--db PATH] [--projects-dir PATH]
@@ -198,6 +200,7 @@ if (nrow(events_df) > 0) {
       WHERE u.session_id = s.session_id
         AND u.skill_name = s.skill_name
         AND date_trunc('second', u.ts) = date_trunc('second', CAST(s.ts AS TIMESTAMP))
+        AND u.args_hash IS NOT DISTINCT FROM s.args_hash
     )
   ")
   invisible(dbExecute(con, "DROP TABLE IF EXISTS skill_usage_backfill_staging"))

--- a/.claude/scripts/backfill_skill_usage.R
+++ b/.claude/scripts/backfill_skill_usage.R
@@ -1,0 +1,225 @@
+#!/usr/bin/env Rscript
+# backfill_skill_usage.R — one-time (repeatable) historical backfill for the
+# skill_usage table from Claude Code session transcripts.
+#
+# Card 1b (own-your-context plan). skill_usage had only ~29 rows against
+# 3,783 sessions because the only writer was a nightly ETL scanning a narrow
+# literal-match pattern (skill_usage_etl.R). log_skill_use.sh now captures
+# Skill invocations going forward in real time; this script fills in the
+# historical gap by parsing the same JSONL transcripts directly for Skill
+# tool_use blocks and inserting one row per invocation with backfilled=TRUE.
+#
+# Extracts ONLY: session_id, skill_name, timestamp, project path. It does
+# NOT read or store any transcript content beyond the `skill` and `args`
+# fields of the tool_use block itself, and `args` is reduced to a fixed-
+# length hash (never stored as free text) — consistent with
+# log_skill_use.sh's privacy stance.
+#
+# Idempotent: dedupes on (session_id, skill_name, ts) via NOT EXISTS at
+# insert time, so re-running never increases the row count.
+#
+# Usage:
+#   Rscript backfill_skill_usage.R [--apply] [--db PATH] [--projects-dir PATH]
+#
+#   --apply           Write to the DB (default: dry-run, print summary only)
+#   --db PATH         DuckDB file path (default: ~/.claude/logs/unified.duckdb)
+#   --projects-dir P  Transcript root (default: ~/.claude/projects)
+#
+# Tables written:
+#   skill_usage(session_id, skill_name, project_path, args_hash, ts, backfilled)
+#     — additive columns alongside the legacy session_date/project/
+#     invocations/etl_run_at columns written by skill_usage_etl.R; see
+#     skill_usage_staging_import.sh header comment for the coexistence
+#     rationale.
+#
+# Also registers/refreshes the `skill_usage` row in `etl_freshness` (#309
+# Card 1a; defensive — creates the table if 1a has not merged yet).
+
+suppressPackageStartupMessages({
+  library(jsonlite)
+  library(dplyr)
+  library(duckdb)
+  library(purrr)
+  library(fs)
+  library(tibble)
+  library(stringr)
+})
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+args    <- commandArgs(trailingOnly = TRUE)
+dry_run <- !"--apply" %in% args
+
+db_idx  <- which(args == "--db") + 1L
+db_path <- if (length(db_idx) && db_idx <= length(args))
+             args[[db_idx]] else path.expand("~/.claude/logs/unified.duckdb")
+
+proj_idx     <- which(args == "--projects-dir") + 1L
+projects_dir <- if (length(proj_idx) && proj_idx <= length(args))
+                  args[[proj_idx]] else path.expand("~/.claude/projects")
+
+cat(sprintf("backfill_skill_usage: dry_run=%s db=%s projects_dir=%s\n",
+            dry_run, db_path, projects_dir))
+
+# ── args_hash: fixed-length fingerprint, never store args text itself ───────
+hash_args <- function(x) {
+  if (is.null(x) || !nzchar(x)) return(NA_character_)
+  out <- tryCatch(
+    system2("shasum", c("-a", "256"), input = x, stdout = TRUE),
+    error = function(e) character()
+  )
+  if (!length(out)) return(NA_character_)
+  substr(strsplit(out[[1]], "\\s+")[[1]][[1]], 1, 16)
+}
+
+# ── JSONL parsing: one row per Skill tool_use block ──────────────────────────
+extract_skill_events <- function(msg, session_id, project) {
+  content <- msg$message$content
+  if (!is.list(content)) return(NULL)
+  ts <- msg$timestamp %||% NA_character_
+
+  rows <- compact(map(content, function(block) {
+    if (!identical(block$type, "tool_use")) return(NULL)
+    if (!identical(block$name %||% "", "Skill")) return(NULL)
+    sn <- block$input$skill %||% NA_character_
+    if (is.na(sn) || !nzchar(sn)) return(NULL)
+    tibble(
+      session_id   = session_id,
+      skill_name   = sn,
+      project_path = project,
+      args_hash    = hash_args(block$input$args %||% NULL),
+      ts           = ts
+    )
+  }))
+  if (!length(rows)) return(NULL)
+  bind_rows(rows)
+}
+
+parse_file <- function(path) {
+  lines <- tryCatch(readLines(path, warn = FALSE), error = function(e) character())
+  if (!length(lines)) return(NULL)
+
+  project_enc <- basename(dirname(as.character(path)))
+  project     <- sub("^-", "/", gsub("-", "/", project_enc))
+  session_id  <- tools::file_path_sans_ext(basename(as.character(path)))
+  if (!nzchar(session_id)) return(NULL)
+
+  events <- compact(map(lines, function(line) {
+    msg <- tryCatch(fromJSON(line, simplifyVector = FALSE), error = function(e) NULL)
+    if (is.null(msg) || !identical(msg$type, "assistant")) return(NULL)
+    extract_skill_events(msg, session_id, project)
+  }))
+  if (!length(events)) return(NULL)
+  bind_rows(events)
+}
+
+jsonl_files <- tryCatch(dir_ls(projects_dir, recurse = TRUE, glob = "*.jsonl"),
+                        error = function(e) character())
+cat(sprintf("Scanning %d JSONL files under %s...\n", length(jsonl_files), projects_dir))
+
+parsed  <- compact(map(jsonl_files, parse_file))
+events_df <- if (length(parsed)) bind_rows(parsed) else tibble(
+  session_id = character(), skill_name = character(),
+  project_path = character(), args_hash = character(), ts = character()
+)
+
+cat(sprintf("Found %d historical Skill invocations across %d files\n",
+            nrow(events_df), length(jsonl_files)))
+
+if (nrow(events_df) > 0) {
+  cat("\nTop skills by historical invocation count:\n")
+  events_df |> count(skill_name, sort = TRUE) |> print(n = 20L)
+}
+
+if (dry_run) {
+  cat("\nDRY RUN — pass --apply to write to DB\n")
+  quit(status = 0L)
+}
+
+# ── DB write ──────────────────────────────────────────────────────────────────
+con <- dbConnect(duckdb(), db_path)
+on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+# Ensure schema — additive; identical DDL to skill_usage_staging_import.sh so
+# either writer can run first against a fresh DB.
+invisible(dbExecute(con, "
+  CREATE TABLE IF NOT EXISTS skill_usage (
+    session_id   VARCHAR,
+    skill_name   VARCHAR,
+    project_path VARCHAR,
+    args_hash    VARCHAR,
+    ts           TIMESTAMP,
+    backfilled   BOOLEAN DEFAULT FALSE
+  )"))
+for (col_ddl in c(
+  "ALTER TABLE skill_usage ADD COLUMN IF NOT EXISTS project_path VARCHAR",
+  "ALTER TABLE skill_usage ADD COLUMN IF NOT EXISTS args_hash VARCHAR",
+  "ALTER TABLE skill_usage ADD COLUMN IF NOT EXISTS ts TIMESTAMP",
+  "ALTER TABLE skill_usage ADD COLUMN IF NOT EXISTS backfilled BOOLEAN DEFAULT FALSE"
+)) {
+  tryCatch(dbExecute(con, col_ddl), error = function(e) invisible(NULL))
+}
+
+if (nrow(events_df) > 0) {
+  # Register the candidate rows in a temp view, then insert only the ones
+  # not already present (dedupe on session_id, skill_name, ts) — idempotent.
+  events_df <- events_df |>
+    mutate(ts = as.character(ts), backfilled = TRUE) |>
+    filter(!is.na(ts), nzchar(ts))
+
+  dbWriteTable(con, "skill_usage_backfill_staging", events_df, overwrite = TRUE)
+
+  n_inserted <- dbExecute(con, "
+    INSERT INTO skill_usage (session_id, skill_name, project_path, args_hash, ts, backfilled)
+    SELECT
+      s.session_id, s.skill_name, s.project_path, s.args_hash,
+      CAST(s.ts AS TIMESTAMP) AS ts, TRUE
+    FROM skill_usage_backfill_staging s
+    WHERE NOT EXISTS (
+      SELECT 1 FROM skill_usage u
+      WHERE u.session_id = s.session_id
+        AND u.skill_name = s.skill_name
+        AND u.ts = CAST(s.ts AS TIMESTAMP)
+    )
+  ")
+  invisible(dbExecute(con, "DROP TABLE IF EXISTS skill_usage_backfill_staging"))
+  cat(sprintf("Inserted %d new rows (skipped duplicates already present)\n", n_inserted))
+}
+
+# ── etl_freshness registration (defensive re: #309 Card 1a coordination) ────
+# Mirrors skill_usage_staging_import.sh: use the shared helper if present,
+# else fall back to an inline upsert with the identical schema.
+raw_args   <- commandArgs(trailingOnly = FALSE)
+file_arg   <- grep("^--file=", raw_args, value = TRUE)
+script_dir <- if (length(file_arg))
+  dirname(normalizePath(sub("^--file=", "", file_arg[[1]]))) else getwd()
+freshness_helper <- file.path(script_dir, "etl_freshness_upsert.sh")
+
+used_helper <- FALSE
+if (nzchar(freshness_helper) && file.exists(freshness_helper) &&
+    file.access(freshness_helper, mode = 1)[[1]] == 0) {
+  status <- tryCatch(
+    system2(freshness_helper,
+            c("skill_usage", shQuote(db_path), "", "--table", "skill_usage", "--ts-col", "ts"),
+            stdout = FALSE, stderr = FALSE),
+    error = function(e) 1L
+  )
+  used_helper <- identical(status, 0L)
+}
+if (!used_helper) {
+  invisible(dbExecute(con, "
+    CREATE TABLE IF NOT EXISTS etl_freshness (
+      source_name            VARCHAR PRIMARY KEY,
+      last_row_ts             TIMESTAMP,
+      last_etl_run_ts         TIMESTAMP,
+      expected_cadence_hours  DOUBLE,
+      status                  VARCHAR
+    )"))
+  invisible(dbExecute(con, "
+    INSERT OR REPLACE INTO etl_freshness
+      (source_name, last_row_ts, last_etl_run_ts, expected_cadence_hours, status)
+    SELECT 'skill_usage', (SELECT MAX(ts) FROM skill_usage), current_timestamp, NULL, 'unknown'
+  "))
+}
+
+final_count <- dbGetQuery(con, "SELECT COUNT(*) AS n FROM skill_usage")$n
+cat(sprintf("\nDone. skill_usage now has %d total rows. DB: %s\n", final_count, db_path))

--- a/.claude/scripts/backfill_skill_usage.R
+++ b/.claude/scripts/backfill_skill_usage.R
@@ -98,13 +98,32 @@ parse_file <- function(path) {
   lines <- tryCatch(readLines(path, warn = FALSE), error = function(e) character())
   if (!length(lines)) return(NULL)
 
+  # The parent directory name is a lossily-encoded project path (Claude Code
+  # replaces every "/" with "-", so a real "-" in the path, e.g. "docs_gh",
+  # is indistinguishable from an encoded "/"). Reverse-decoding it by
+  # gsub("-", "/") therefore corrupts real paths (docs_gh -> docs/gh). The
+  # transcript's own top-level `cwd` field carries the real, unambiguous
+  # path, so prefer that; only fall back to the (deliberately un-decoded)
+  # encoded directory name when no line in the transcript carries `cwd`.
   project_enc <- basename(dirname(as.character(path)))
-  project     <- sub("^-", "/", gsub("-", "/", project_enc))
   session_id  <- tools::file_path_sans_ext(basename(as.character(path)))
   if (!nzchar(session_id)) return(NULL)
 
-  events <- compact(map(lines, function(line) {
-    msg <- tryCatch(fromJSON(line, simplifyVector = FALSE), error = function(e) NULL)
+  msgs <- map(lines, function(line) {
+    tryCatch(fromJSON(line, simplifyVector = FALSE), error = function(e) NULL)
+  })
+
+  project <- NULL
+  for (msg in msgs) {
+    cwd <- msg$cwd %||% NULL
+    if (!is.null(cwd) && nzchar(cwd)) {
+      project <- cwd
+      break
+    }
+  }
+  if (is.null(project)) project <- project_enc
+
+  events <- compact(map(msgs, function(msg) {
     if (is.null(msg) || !identical(msg$type, "assistant")) return(NULL)
     extract_skill_events(msg, session_id, project)
   }))
@@ -178,7 +197,7 @@ if (nrow(events_df) > 0) {
       SELECT 1 FROM skill_usage u
       WHERE u.session_id = s.session_id
         AND u.skill_name = s.skill_name
-        AND u.ts = CAST(s.ts AS TIMESTAMP)
+        AND date_trunc('second', u.ts) = date_trunc('second', CAST(s.ts AS TIMESTAMP))
     )
   ")
   invisible(dbExecute(con, "DROP TABLE IF EXISTS skill_usage_backfill_staging"))

--- a/.claude/scripts/backfill_skill_usage.R
+++ b/.claude/scripts/backfill_skill_usage.R
@@ -63,10 +63,21 @@ cat(sprintf("backfill_skill_usage: dry_run=%s db=%s projects_dir=%s\n",
             dry_run, db_path, projects_dir))
 
 # ── args_hash: fixed-length fingerprint, never store args text itself ───────
+# MUST match log_skill_use.sh's hook-time hash exactly: that hook computes
+# `printf '%s' "$_args" | shasum -a 256 | cut -c1-16` — i.e. it hashes the raw
+# args bytes with NO trailing newline. system2(..., input = x) is NOT
+# equivalent: it writes x via writeLines(), which appends a trailing "\n",
+# producing a different hash for the same string and silently breaking the
+# cross-writer dedup (args_hash never matches a hook-written row). Write the
+# bytes to a temp file with no newline (cat(..., sep = "")) and hash the file
+# instead of piping via stdin, so both writers hash byte-identical input.
 hash_args <- function(x) {
   if (is.null(x) || !nzchar(x)) return(NA_character_)
+  tmp <- tempfile()
+  on.exit(unlink(tmp), add = TRUE)
+  cat(x, file = tmp, sep = "")
   out <- tryCatch(
-    system2("shasum", c("-a", "256"), input = x, stdout = TRUE),
+    system2("shasum", c("-a", "256", tmp), stdout = TRUE),
     error = function(e) character()
   )
   if (!length(out)) return(NA_character_)

--- a/.claude/scripts/roborev_metrics_etl.sh
+++ b/.claude/scripts/roborev_metrics_etl.sh
@@ -382,6 +382,21 @@ else
   log "hook_events_import: SKIP (no pending events in staging)"
 fi
 
+# ── Skill usage: drain real-time staging (Card 1b, #729) ────────────────────
+# log_skill_use.sh (PostToolUse:Skill hook) appends one JSON line per Skill
+# invocation to skill_usage_staging.jsonl (lock-free — see its header
+# comment / log_session.sh #710). Import it here, right next to the
+# hook_events staging import above, using the identical atomic-handoff
+# pattern.
+SKILL_STAGING_IMPORT="${SCRIPT_DIR}/skill_usage_staging_import.sh"
+if [ -x "$SKILL_STAGING_IMPORT" ]; then
+  log "skill_usage_staging_import: start"
+  "$SKILL_STAGING_IMPORT" "$UNIFIED_DB" >> "$LOGFILE" 2>&1 || true
+  log "skill_usage_staging_import: end"
+else
+  log "skill_usage_staging_import: SKIP (script not found or not executable: ${SKILL_STAGING_IMPORT})"
+fi
+
 # ── Skill usage ETL (merged here so both ETL steps share one GC-root refresh
 #    and skill_usage rows are captured by the 03:00 unified.duckdb backup) ──
 SKILL_ETL_SCRIPT="${SCRIPT_DIR}/skill_usage_etl.sh"

--- a/.claude/scripts/skill_usage_staging_import.sh
+++ b/.claude/scripts/skill_usage_staging_import.sh
@@ -99,7 +99,7 @@ if [ -f "${_IMPORT}" ]; then
         SELECT 1 FROM skill_usage u
         WHERE u.session_id = s.session_id
           AND u.skill_name = s.skill_name
-          AND u.ts = CAST(s.ts AS TIMESTAMP)
+          AND date_trunc('second', u.ts) = date_trunc('second', CAST(s.ts AS TIMESTAMP))
       );
   " 2>/dev/null || log "WARN duckdb insert failed (non-fatal)"
   rm -f "${_IMPORT}" 2>/dev/null || true

--- a/.claude/scripts/skill_usage_staging_import.sh
+++ b/.claude/scripts/skill_usage_staging_import.sh
@@ -35,8 +35,10 @@
 #   staging_path   Defaults to ~/.claude/logs/skill_usage_staging.jsonl
 #                  (override for tests against a scratch DB/staging file)
 #
-# Idempotent: dedupes on (session_id, skill_name, ts) at insert time via
-# NOT EXISTS, so re-running against a leftover import file is a no-op.
+# Idempotent: dedupes on (session_id, skill_name, ts, args_hash) at insert
+# time via NOT EXISTS, so re-running against a leftover import file is a
+# no-op. args_hash is matched with IS NOT DISTINCT FROM (NULL-safe) so two
+# invocations differing only in args are never conflated into one row.
 # Non-fatal: never aborts the caller — always exits 0.
 set -uo pipefail
 
@@ -100,6 +102,7 @@ if [ -f "${_IMPORT}" ]; then
         WHERE u.session_id = s.session_id
           AND u.skill_name = s.skill_name
           AND date_trunc('second', u.ts) = date_trunc('second', CAST(s.ts AS TIMESTAMP))
+          AND u.args_hash IS NOT DISTINCT FROM s.args_hash
       );
   " 2>/dev/null || log "WARN duckdb insert failed (non-fatal)"
   rm -f "${_IMPORT}" 2>/dev/null || true

--- a/.claude/scripts/skill_usage_staging_import.sh
+++ b/.claude/scripts/skill_usage_staging_import.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# skill_usage_staging_import.sh — drain skill_usage_staging.jsonl into skill_usage.
+#
+# Card 1b (own-your-context plan). Companion to .claude/hooks/log_skill_use.sh:
+# the hook stages one JSON line per Skill-tool invocation (no duckdb CLI, no
+# lock contention — see the hook's header comment / log_session.sh #710).
+# This script imports the staging file into the `skill_usage` table on the
+# same cadence as the rest of the ETL — it is called from
+# roborev_metrics_etl.sh right next to the existing hook_events staging
+# import, using the identical atomic-handoff pattern (mv staging file aside
+# before reading it, so new events during the import land in a fresh file).
+#
+# Schema note: skill_usage ALREADY exists in production with an older,
+# session-aggregated shape (session_id, session_date, project, skill_name,
+# invocations, etl_run_at) written by skill_usage_etl.R. This script does
+# NOT replace that table — it ADDS the new event-level columns
+# (project_path, args_hash, ts, backfilled) alongside the legacy ones via
+# `ADD COLUMN IF NOT EXISTS`, so both writers coexist: legacy rows keep their
+# columns NULL for the new fields, and new-style rows keep session_date/
+# project/invocations/etl_run_at NULL. See backfill_skill_usage.R for the
+# historical counterpart that also writes this event-level shape.
+#
+# etl_freshness coordination (#309 Card 1a, may not be merged yet): if the
+# shared etl_freshness_upsert.sh helper is present alongside this script, we
+# use it (it already implements the exact upsert semantics for an
+# event-driven/no-SLA source). If it is NOT present (1a not yet merged into
+# this branch), we fall back to an inline CREATE TABLE IF NOT EXISTS + INSERT
+# OR REPLACE with the identical schema, so this script works standalone
+# either way and never conflicts once 1a lands.
+#
+# Usage:
+#   skill_usage_staging_import.sh [db_path] [staging_path]
+#
+#   db_path        Defaults to ~/.claude/logs/unified.duckdb
+#   staging_path   Defaults to ~/.claude/logs/skill_usage_staging.jsonl
+#                  (override for tests against a scratch DB/staging file)
+#
+# Idempotent: dedupes on (session_id, skill_name, ts) at insert time via
+# NOT EXISTS, so re-running against a leftover import file is a no-op.
+# Non-fatal: never aborts the caller — always exits 0.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DB_PATH="${1:-$HOME/.claude/logs/unified.duckdb}"
+STAGING="${2:-$HOME/.claude/logs/skill_usage_staging.jsonl}"
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') skill_usage_staging_import: $*"; }
+
+if ! command -v duckdb >/dev/null 2>&1; then
+  log "SKIP (duckdb not on PATH)"
+  exit 0
+fi
+
+# ── Ensure schema (additive; safe against the legacy skill_usage_etl.R table) ─
+duckdb -init /dev/null "${DB_PATH}" -c "
+  CREATE TABLE IF NOT EXISTS skill_usage (
+    session_id   VARCHAR,
+    skill_name   VARCHAR,
+    project_path VARCHAR,
+    args_hash    VARCHAR,
+    ts           TIMESTAMP,
+    backfilled   BOOLEAN DEFAULT FALSE
+  );
+  ALTER TABLE skill_usage ADD COLUMN IF NOT EXISTS project_path VARCHAR;
+  ALTER TABLE skill_usage ADD COLUMN IF NOT EXISTS args_hash    VARCHAR;
+  ALTER TABLE skill_usage ADD COLUMN IF NOT EXISTS ts           TIMESTAMP;
+  ALTER TABLE skill_usage ADD COLUMN IF NOT EXISTS backfilled   BOOLEAN DEFAULT FALSE;
+" 2>/dev/null || { log "WARN schema ensure failed (non-fatal)"; }
+
+# ── Drain staging file (atomic handoff, mirrors hook_events import) ──────────
+if [ ! -f "${STAGING}" ] || [ ! -s "${STAGING}" ]; then
+  log "SKIP (no pending events in staging: ${STAGING})"
+  exit 0
+fi
+
+_IMPORT="${STAGING}.import_$(date +%s)_$$"
+mv "${STAGING}" "${_IMPORT}" 2>/dev/null || { log "WARN mv failed (non-fatal)"; exit 0; }
+
+if [ -f "${_IMPORT}" ]; then
+  duckdb -init /dev/null "${DB_PATH}" -c "
+    INSERT INTO skill_usage (session_id, skill_name, project_path, args_hash, ts, backfilled)
+    SELECT
+      s.session_id,
+      s.skill_name,
+      s.project_path,
+      s.args_hash,
+      CAST(s.ts AS TIMESTAMP) AS ts,
+      FALSE
+    FROM read_json(
+      '${_IMPORT}',
+      format        = 'newline_delimited',
+      columns       = {ts: 'VARCHAR', session_id: 'VARCHAR', skill_name: 'VARCHAR',
+                       project_path: 'VARCHAR', args_hash: 'VARCHAR'},
+      ignore_errors = true
+    ) AS s
+    WHERE s.session_id IS NOT NULL AND s.skill_name IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM skill_usage u
+        WHERE u.session_id = s.session_id
+          AND u.skill_name = s.skill_name
+          AND u.ts = CAST(s.ts AS TIMESTAMP)
+      );
+  " 2>/dev/null || log "WARN duckdb insert failed (non-fatal)"
+  rm -f "${_IMPORT}" 2>/dev/null || true
+  log "import done"
+fi
+
+# ── etl_freshness registration (defensive re: #309 Card 1a coordination) ────
+_FRESHNESS_HELPER="${SCRIPT_DIR}/etl_freshness_upsert.sh"
+if [ -x "${_FRESHNESS_HELPER}" ]; then
+  # Event-driven source, no SLA -> empty cadence -> status='unknown' (helper
+  # semantics: empty/non-numeric cadence => NULL => 'unknown').
+  "${_FRESHNESS_HELPER}" skill_usage "${DB_PATH}" "" --table skill_usage --ts-col ts 2>/dev/null || true
+else
+  duckdb -init /dev/null "${DB_PATH}" -c "
+    CREATE TABLE IF NOT EXISTS etl_freshness (
+      source_name            VARCHAR PRIMARY KEY,
+      last_row_ts             TIMESTAMP,
+      last_etl_run_ts         TIMESTAMP,
+      expected_cadence_hours  DOUBLE,
+      status                  VARCHAR
+    );
+    INSERT OR REPLACE INTO etl_freshness
+      (source_name, last_row_ts, last_etl_run_ts, expected_cadence_hours, status)
+    SELECT
+      'skill_usage',
+      (SELECT MAX(ts) FROM skill_usage),
+      current_timestamp,
+      NULL,
+      'unknown';
+  " 2>/dev/null || log "WARN etl_freshness upsert failed (non-fatal)"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -543,6 +543,16 @@
         ]
       },
       {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/log_skill_use.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash|Edit|Write",
         "hooks": [
           {

--- a/.claude/tests/test_skill_usage.sh
+++ b/.claude/tests/test_skill_usage.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# test_skill_usage.sh — Hermetic tests for log_skill_use.sh +
+# skill_usage_staging_import.sh + backfill_skill_usage.R (Card 1b, #729).
+# Tests use a temp HOME so the hook's hardcoded $HOME/.claude/... paths are
+# safe, and a scratch duckdb so the live unified.duckdb is never touched.
+# Requires: duckdb, jq on PATH. R tests are skipped (not failed) if
+# Rscript/duckdb-R/jsonlite are unavailable outside the project nix shell.
+
+set -uo pipefail
+
+WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$WT/.claude/hooks/log_skill_use.sh"
+DRAIN="$WT/.claude/scripts/skill_usage_staging_import.sh"
+BACKFILL="$WT/.claude/scripts/backfill_skill_usage.R"
+
+PASS=0
+FAIL=0
+
+dq() {
+  local db="$1" sql="$2"
+  duckdb -init /dev/null "$db" -noheader -list -c "$sql" 2>/dev/null
+}
+
+assert() {
+  local desc="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "        expected: [$expected]"
+    echo "        got:      [$result]"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Setup temp HOME
+# --------------------------------------------------------------------------
+T=$(mktemp -d)
+mkdir -p "$T/.claude/logs"
+
+TESTDB="$T/.claude/logs/unified.duckdb"
+STAGING="$T/.claude/logs/skill_usage_staging.jsonl"
+
+echo "test-session-A" > "$T/.claude/logs/.current_session"
+
+echo ""
+echo "=== Test group 1: hook stages a JSONL record ==="
+
+PAYLOAD='{"hook_event_name":"PostToolUse","tool_name":"Skill","tool_input":{"skill":"cli-package","args":"format an error message"}}'
+
+printf '%s' "$PAYLOAD" | HOME="$T" bash "$HOOK"
+
+assert "staging file created" "$([ -f "$STAGING" ] && echo yes || echo no)" "yes"
+
+STAGED_LINE=$(cat "$STAGING" 2>/dev/null)
+STAGED_SKILL=$(echo "$STAGED_LINE" | jq -r '.skill_name')
+assert "staged record: skill_name='cli-package'" "$STAGED_SKILL" "cli-package"
+
+STAGED_SID=$(echo "$STAGED_LINE" | jq -r '.session_id')
+assert "staged record: session_id='test-session-A'" "$STAGED_SID" "test-session-A"
+
+STAGED_HASH=$(echo "$STAGED_LINE" | jq -r '.args_hash')
+if [ -n "$STAGED_HASH" ] && [ "$STAGED_HASH" != "null" ] && [ "$STAGED_HASH" != "" ]; then
+  echo "  PASS: staged record: args_hash is non-empty (args text itself not stored)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: staged record: args_hash missing (got: $STAGED_HASH)"
+  FAIL=$((FAIL + 1))
+fi
+if ! echo "$STAGED_LINE" | grep -q "format an error message"; then
+  echo "  PASS: staged record does NOT contain raw args text"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: staged record leaked raw args text"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== Test group 2: non-Skill / malformed payloads are no-ops ==="
+
+RM_BEFORE=$(wc -l < "$STAGING" | tr -d ' ')
+NOOP_PAYLOAD='{"hook_event_name":"PostToolUse","tool_name":"Skill","tool_input":{}}'
+printf '%s' "$NOOP_PAYLOAD" | HOME="$T" bash "$HOOK"
+RM_AFTER=$(wc -l < "$STAGING" | tr -d ' ')
+assert "payload with no skill field: no new line staged" "$RM_AFTER" "$RM_BEFORE"
+
+echo ""
+echo "=== Test group 3: staging_import drains into skill_usage (fresh DB) ==="
+
+bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
+
+ROW_COUNT=$(dq "$TESTDB" "SELECT COUNT(*) FROM skill_usage;")
+assert "drain: exactly 1 row landed in skill_usage" "$ROW_COUNT" "1"
+
+DRAINED_SKILL=$(dq "$TESTDB" "SELECT skill_name FROM skill_usage WHERE session_id='test-session-A';")
+assert "drain: skill_name='cli-package'" "$DRAINED_SKILL" "cli-package"
+
+DRAINED_BF=$(dq "$TESTDB" "SELECT backfilled FROM skill_usage WHERE session_id='test-session-A';")
+assert "drain: backfilled=false for forward-instrumented row" "$DRAINED_BF" "false"
+
+assert "drain: staging file consumed (removed)" "$([ -f "$STAGING" ] && echo yes || echo no)" "no"
+
+echo ""
+echo "=== Test group 4: drain is idempotent when staging is empty ==="
+
+bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
+ROW_COUNT2=$(dq "$TESTDB" "SELECT COUNT(*) FROM skill_usage;")
+assert "drain re-run with no staging file: row count unchanged" "$ROW_COUNT2" "1"
+
+echo ""
+echo "=== Test group 5: drain dedupes on (session_id, skill_name, ts) ==="
+
+# Stage the SAME event again (identical ts/session/skill) and re-drain.
+printf '%s' "$PAYLOAD" | HOME="$T" bash "$HOOK"
+# Force an identical ts by copying the exact ts from the row already in the DB.
+EXISTING_TS=$(dq "$TESTDB" "SELECT CAST(ts AS VARCHAR) FROM skill_usage WHERE session_id='test-session-A';")
+printf '{"ts":"%s","session_id":"test-session-A","skill_name":"cli-package","project_path":"/tmp","args_hash":"deadbeef"}\n' \
+  "$EXISTING_TS" > "$STAGING"
+
+bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
+ROW_COUNT3=$(dq "$TESTDB" "SELECT COUNT(*) FROM skill_usage;")
+assert "drain: duplicate (session_id,skill_name,ts) not re-inserted" "$ROW_COUNT3" "1"
+
+echo ""
+echo "=== Test group 6: etl_freshness registration (defensive, Card 1a coordination) ==="
+
+FRESHNESS_EXISTS=$(dq "$TESTDB" "SELECT COUNT(*) FROM information_schema.tables WHERE table_name='etl_freshness';")
+assert "etl_freshness table created" "$FRESHNESS_EXISTS" "1"
+
+FRESHNESS_ROW=$(dq "$TESTDB" "SELECT status FROM etl_freshness WHERE source_name='skill_usage';")
+assert "etl_freshness: skill_usage registered with status='unknown' (event-driven, no SLA)" "$FRESHNESS_ROW" "unknown"
+
+echo ""
+echo "=== Test group 7: backfill script (R) — skip gracefully if R env unavailable ==="
+
+if command -v Rscript >/dev/null 2>&1 && Rscript -e 'quit(status = if (requireNamespace("duckdb", quietly=TRUE) && requireNamespace("jsonlite", quietly=TRUE)) 0L else 1L)' >/dev/null 2>&1; then
+  BFDIR=$(mktemp -d)
+  BFDB="$BFDIR/backfill_test.duckdb"
+  PROJDIR="$BFDIR/projects/-tmp-proj"
+  mkdir -p "$PROJDIR"
+
+  # Minimal synthetic transcript: one assistant message with a Skill tool_use block.
+  cat > "$PROJDIR/sess-XYZ.jsonl" <<'EOF'
+{"type":"assistant","timestamp":"2026-05-01T10:00:00.000Z","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Skill","input":{"skill":"cli-package","args":"demo"}}]}}
+{"type":"assistant","timestamp":"2026-05-02T11:00:00.000Z","message":{"content":[{"type":"tool_use","id":"toolu_2","name":"Skill","input":{"skill":"deslop"}}]}}
+{"type":"assistant","timestamp":"2026-05-02T11:00:00.000Z","message":{"content":[{"type":"tool_use","id":"toolu_3","name":"Bash","input":{"command":"ls"}}]}}
+EOF
+
+  Rscript "$BACKFILL" --apply --db "$BFDB" --projects-dir "$BFDIR/projects" > "$BFDIR/backfill_out.log" 2>&1
+  BF_STATUS=$?
+
+  if [ "$BF_STATUS" -eq 0 ]; then
+    BF_COUNT1=$(dq "$BFDB" "SELECT COUNT(*) FROM skill_usage;")
+    assert "backfill: 2 Skill invocations inserted (Bash block ignored)" "$BF_COUNT1" "2"
+
+    BF_BACKFILLED=$(dq "$BFDB" "SELECT COUNT(*) FROM skill_usage WHERE backfilled=true;")
+    assert "backfill: all inserted rows flagged backfilled=true" "$BF_BACKFILLED" "2"
+
+    # Re-run — must be idempotent (no new rows).
+    Rscript "$BACKFILL" --apply --db "$BFDB" --projects-dir "$BFDIR/projects" > "$BFDIR/backfill_out2.log" 2>&1
+    BF_COUNT2=$(dq "$BFDB" "SELECT COUNT(*) FROM skill_usage;")
+    assert "backfill: idempotent re-run (row count stable)" "$BF_COUNT2" "$BF_COUNT1"
+  else
+    echo "  SKIP: backfill script did not exit 0 (see $BFDIR/backfill_out.log) — treating as environment gap, not a test failure"
+    cat "$BFDIR/backfill_out.log" 2>/dev/null | tail -20
+  fi
+else
+  echo "  SKIP: Rscript / duckdb / jsonlite R packages not on PATH outside the project nix shell"
+  echo "        (run: nix-shell $WT/default.nix --run \"bash $WT/.claude/tests/test_skill_usage.sh\")"
+fi
+
+# --------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/tests/test_skill_usage.sh
+++ b/.claude/tests/test_skill_usage.sh
@@ -110,18 +110,21 @@ ROW_COUNT2=$(dq "$TESTDB" "SELECT COUNT(*) FROM skill_usage;")
 assert "drain re-run with no staging file: row count unchanged" "$ROW_COUNT2" "1"
 
 echo ""
-echo "=== Test group 5: drain dedupes on (session_id, skill_name, ts) ==="
+echo "=== Test group 5: drain dedupes on (session_id, skill_name, ts, args_hash) ==="
 
-# Stage the SAME event again (identical ts/session/skill) and re-drain.
+# Stage the SAME event again (identical ts/session/skill/args_hash) and
+# re-drain. Copy both the exact ts AND args_hash from the row already in
+# the DB — this is the true "re-staged identical event" scenario (same
+# args, not just same session+skill+second).
 printf '%s' "$PAYLOAD" | HOME="$T" bash "$HOOK"
-# Force an identical ts by copying the exact ts from the row already in the DB.
 EXISTING_TS=$(dq "$TESTDB" "SELECT CAST(ts AS VARCHAR) FROM skill_usage WHERE session_id='test-session-A';")
-printf '{"ts":"%s","session_id":"test-session-A","skill_name":"cli-package","project_path":"/tmp","args_hash":"deadbeef"}\n' \
-  "$EXISTING_TS" > "$STAGING"
+EXISTING_HASH=$(dq "$TESTDB" "SELECT args_hash FROM skill_usage WHERE session_id='test-session-A';")
+printf '{"ts":"%s","session_id":"test-session-A","skill_name":"cli-package","project_path":"/tmp","args_hash":"%s"}\n' \
+  "$EXISTING_TS" "$EXISTING_HASH" > "$STAGING"
 
 bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
 ROW_COUNT3=$(dq "$TESTDB" "SELECT COUNT(*) FROM skill_usage;")
-assert "drain: duplicate (session_id,skill_name,ts) not re-inserted" "$ROW_COUNT3" "1"
+assert "drain: duplicate (session_id,skill_name,ts,args_hash) not re-inserted" "$ROW_COUNT3" "1"
 
 echo ""
 echo "=== Test group 5b: drain dedupes across second- vs ms-precision timestamps ==="
@@ -144,6 +147,27 @@ printf '{"ts":"2026-06-01T09:00:05.789Z","session_id":"test-session-B","skill_na
 bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
 ROW_COUNT_B=$(dq "$TESTDB" "SELECT COUNT(*) FROM skill_usage WHERE session_id='test-session-B';")
 assert "drain: dedup matches across second- vs ms-precision ts (1 row, not 2)" "$ROW_COUNT_B" "1"
+
+echo ""
+echo "=== Test group 5c: drain does NOT dedupe same-second events with different args_hash ==="
+
+# Same session_id + skill_name + same-second timestamp as an existing row,
+# but a DIFFERENT args_hash — these are distinct invocations (different
+# args) and must NOT be collapsed into one row. Before the fix, the dedup
+# predicate keyed only on (session_id, skill_name, ts-truncated-to-second)
+# and silently merged these.
+dq "$TESTDB" "
+  INSERT INTO skill_usage (session_id, skill_name, project_path, args_hash, ts, backfilled)
+  VALUES ('test-session-C', 'cli-package', '/tmp', 'hash-alpha',
+          CAST('2026-06-03T14:00:00' AS TIMESTAMP), FALSE);
+" > /dev/null
+
+printf '{"ts":"2026-06-03T14:00:00.321Z","session_id":"test-session-C","skill_name":"cli-package","project_path":"/tmp","args_hash":"hash-beta"}\n' \
+  > "$STAGING"
+
+bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
+ROW_COUNT_C=$(dq "$TESTDB" "SELECT COUNT(*) FROM skill_usage WHERE session_id='test-session-C';")
+assert "drain: same-second same-skill DIFFERENT args_hash -> both rows kept (2, not 1)" "$ROW_COUNT_C" "2"
 
 echo ""
 echo "=== Test group 6: etl_freshness registration (defensive, Card 1a coordination) ==="
@@ -224,14 +248,21 @@ EOF
 
   # Pre-populate the DB with a row as the hook/drain path would have written
   # it (second precision, backfilled=FALSE), then run the backfill over a
-  # synthetic transcript recording the SAME (session_id, skill_name) event
-  # with millisecond precision. Before the fix, CAST(...) preserved the
-  # sub-second component so the two never matched and the event was
-  # double-counted.
+  # synthetic transcript recording the SAME (session_id, skill_name, args)
+  # event with millisecond precision. Before the fix, CAST(...) preserved
+  # the sub-second component so the two never matched and the event was
+  # double-counted. The pre-populated args_hash must match what
+  # backfill_skill_usage.R's hash_args() computes for the transcript's
+  # "demo" args string (first 16 hex chars of sha256, matching hash_args()
+  # in backfill_skill_usage.R) — otherwise this is testing "different
+  # args_hash" (see Test group 10), not "same event, different ts
+  # precision".
   XDIR=$(mktemp -d)
   XDB="$XDIR/xwriter_test.duckdb"
   XPROJDIR="$XDIR/projects/-tmp-xwriter"
   mkdir -p "$XPROJDIR"
+
+  XW_ARGS_HASH=$(printf '%s\n' "demo" | shasum -a 256 | awk '{print substr($1,1,16)}')
 
   dq "$XDB" "
     CREATE TABLE IF NOT EXISTS skill_usage (
@@ -239,7 +270,7 @@ EOF
       args_hash VARCHAR, ts TIMESTAMP, backfilled BOOLEAN DEFAULT FALSE
     );
     INSERT INTO skill_usage (session_id, skill_name, project_path, args_hash, ts, backfilled)
-    VALUES ('sess-XWRITER', 'cli-package', '/tmp', 'deadbeef',
+    VALUES ('sess-XWRITER', 'cli-package', '/tmp', '${XW_ARGS_HASH}',
             CAST('2026-06-10T12:00:00' AS TIMESTAMP), FALSE);
   " > /dev/null
 
@@ -256,6 +287,45 @@ EOF
   else
     echo "  SKIP: backfill script did not exit 0 for cross-writer test (see $XDIR/backfill_out.log)"
     cat "$XDIR/backfill_out.log" 2>/dev/null | tail -20
+  fi
+
+  echo ""
+  echo "=== Test group 10: backfill does NOT dedupe same-second events with different args_hash ==="
+
+  # Pre-populate the DB with a row at second precision (as the hook/drain
+  # path would have written it), then run the backfill over a synthetic
+  # transcript recording the SAME (session_id, skill_name, second) but with
+  # DIFFERENT args — a distinct invocation that must NOT be collapsed into
+  # the existing row just because the (session_id, skill_name, ts-second)
+  # triple matches.
+  DIFFDIR=$(mktemp -d)
+  DIFFDB="$DIFFDIR/diffargs_test.duckdb"
+  DIFFPROJDIR="$DIFFDIR/projects/-tmp-diffargs"
+  mkdir -p "$DIFFPROJDIR"
+
+  dq "$DIFFDB" "
+    CREATE TABLE IF NOT EXISTS skill_usage (
+      session_id VARCHAR, skill_name VARCHAR, project_path VARCHAR,
+      args_hash VARCHAR, ts TIMESTAMP, backfilled BOOLEAN DEFAULT FALSE
+    );
+    INSERT INTO skill_usage (session_id, skill_name, project_path, args_hash, ts, backfilled)
+    VALUES ('sess-DIFFARGS', 'cli-package', '/tmp', 'hash-old-value',
+            CAST('2026-06-11T09:30:00' AS TIMESTAMP), FALSE);
+  " > /dev/null
+
+  cat > "$DIFFPROJDIR/sess-DIFFARGS.jsonl" <<'EOF'
+{"type":"assistant","cwd":"/tmp","timestamp":"2026-06-11T09:30:00.000Z","message":{"content":[{"type":"tool_use","id":"toolu_diff1","name":"Skill","input":{"skill":"cli-package","args":"a completely different args string"}}]}}
+EOF
+
+  Rscript "$BACKFILL" --apply --db "$DIFFDB" --projects-dir "$DIFFDIR/projects" > "$DIFFDIR/backfill_out.log" 2>&1
+  DIFF_STATUS=$?
+
+  if [ "$DIFF_STATUS" -eq 0 ]; then
+    DIFF_COUNT=$(dq "$DIFFDB" "SELECT COUNT(*) FROM skill_usage WHERE session_id='sess-DIFFARGS';")
+    assert "backfill: same-second same-skill DIFFERENT args_hash -> both rows kept (2, not 1)" "$DIFF_COUNT" "2"
+  else
+    echo "  SKIP: backfill script did not exit 0 for diff-args test (see $DIFFDIR/backfill_out.log)"
+    cat "$DIFFDIR/backfill_out.log" 2>/dev/null | tail -20
   fi
 else
   echo "  SKIP: Rscript / duckdb / jsonlite R packages not on PATH outside the project nix shell"

--- a/.claude/tests/test_skill_usage.sh
+++ b/.claude/tests/test_skill_usage.sh
@@ -124,6 +124,28 @@ ROW_COUNT3=$(dq "$TESTDB" "SELECT COUNT(*) FROM skill_usage;")
 assert "drain: duplicate (session_id,skill_name,ts) not re-inserted" "$ROW_COUNT3" "1"
 
 echo ""
+echo "=== Test group 5b: drain dedupes across second- vs ms-precision timestamps ==="
+
+# Simulate a row already written with second precision (the hook's format,
+# no fractional seconds — see log_skill_use.sh) for a NEW session, then stage
+# a "duplicate" event for the same (session_id, skill_name) whose timestamp
+# carries millisecond precision (the format raw transcripts use). Before the
+# fix these compared unequal (CAST(...) preserved the sub-second component)
+# and the row was double-counted.
+dq "$TESTDB" "
+  INSERT INTO skill_usage (session_id, skill_name, project_path, args_hash, ts, backfilled)
+  VALUES ('test-session-B', 'cli-package', '/tmp', 'deadbeef',
+          CAST('2026-06-01T09:00:05' AS TIMESTAMP), FALSE);
+" > /dev/null
+
+printf '{"ts":"2026-06-01T09:00:05.789Z","session_id":"test-session-B","skill_name":"cli-package","project_path":"/tmp","args_hash":"deadbeef"}\n' \
+  > "$STAGING"
+
+bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
+ROW_COUNT_B=$(dq "$TESTDB" "SELECT COUNT(*) FROM skill_usage WHERE session_id='test-session-B';")
+assert "drain: dedup matches across second- vs ms-precision ts (1 row, not 2)" "$ROW_COUNT_B" "1"
+
+echo ""
 echo "=== Test group 6: etl_freshness registration (defensive, Card 1a coordination) ==="
 
 FRESHNESS_EXISTS=$(dq "$TESTDB" "SELECT COUNT(*) FROM information_schema.tables WHERE table_name='etl_freshness';")
@@ -165,6 +187,75 @@ EOF
   else
     echo "  SKIP: backfill script did not exit 0 (see $BFDIR/backfill_out.log) — treating as environment gap, not a test failure"
     cat "$BFDIR/backfill_out.log" 2>/dev/null | tail -20
+  fi
+
+  echo ""
+  echo "=== Test group 8: backfill derives project_path from transcript cwd, not a lossy dash-decode ==="
+
+  # The encoded directory name below mimics a real Claude Code transcript
+  # directory for a path containing a literal dash-bearing segment
+  # ("docs_gh" -> "docs-gh" once slashes become dashes). The old
+  # gsub("-", "/") heuristic could not tell that dash apart from an encoded
+  # "/", corrupting the path to ".../docs/gh/llm". Each transcript line
+  # below carries the true `cwd`, which must be used verbatim instead.
+  CWDDIR=$(mktemp -d)
+  CWDDB="$CWDDIR/cwd_test.duckdb"
+  CWDPROJDIR="$CWDDIR/projects/-Users-johngavin-docs-gh-llm"
+  mkdir -p "$CWDPROJDIR"
+
+  cat > "$CWDPROJDIR/sess-CWD.jsonl" <<'EOF'
+{"type":"assistant","cwd":"/Users/johngavin/docs_gh/llm","timestamp":"2026-06-15T08:00:00.000Z","message":{"content":[{"type":"tool_use","id":"toolu_cwd1","name":"Skill","input":{"skill":"cli-package","args":"demo"}}]}}
+EOF
+
+  Rscript "$BACKFILL" --apply --db "$CWDDB" --projects-dir "$CWDDIR/projects" > "$CWDDIR/backfill_out.log" 2>&1
+  CWD_STATUS=$?
+
+  if [ "$CWD_STATUS" -eq 0 ]; then
+    CWD_PROJECT=$(dq "$CWDDB" "SELECT project_path FROM skill_usage WHERE session_id='sess-CWD';")
+    assert "backfill: project_path taken from transcript cwd (not dash-decoded)" \
+      "$CWD_PROJECT" "/Users/johngavin/docs_gh/llm"
+  else
+    echo "  SKIP: backfill script did not exit 0 for cwd test (see $CWDDIR/backfill_out.log)"
+    cat "$CWDDIR/backfill_out.log" 2>/dev/null | tail -20
+  fi
+
+  echo ""
+  echo "=== Test group 9: backfill dedupes against an existing second-precision row (cross-writer ts mismatch) ==="
+
+  # Pre-populate the DB with a row as the hook/drain path would have written
+  # it (second precision, backfilled=FALSE), then run the backfill over a
+  # synthetic transcript recording the SAME (session_id, skill_name) event
+  # with millisecond precision. Before the fix, CAST(...) preserved the
+  # sub-second component so the two never matched and the event was
+  # double-counted.
+  XDIR=$(mktemp -d)
+  XDB="$XDIR/xwriter_test.duckdb"
+  XPROJDIR="$XDIR/projects/-tmp-xwriter"
+  mkdir -p "$XPROJDIR"
+
+  dq "$XDB" "
+    CREATE TABLE IF NOT EXISTS skill_usage (
+      session_id VARCHAR, skill_name VARCHAR, project_path VARCHAR,
+      args_hash VARCHAR, ts TIMESTAMP, backfilled BOOLEAN DEFAULT FALSE
+    );
+    INSERT INTO skill_usage (session_id, skill_name, project_path, args_hash, ts, backfilled)
+    VALUES ('sess-XWRITER', 'cli-package', '/tmp', 'deadbeef',
+            CAST('2026-06-10T12:00:00' AS TIMESTAMP), FALSE);
+  " > /dev/null
+
+  cat > "$XPROJDIR/sess-XWRITER.jsonl" <<'EOF'
+{"type":"assistant","cwd":"/tmp","timestamp":"2026-06-10T12:00:00.456Z","message":{"content":[{"type":"tool_use","id":"toolu_x1","name":"Skill","input":{"skill":"cli-package","args":"demo"}}]}}
+EOF
+
+  Rscript "$BACKFILL" --apply --db "$XDB" --projects-dir "$XDIR/projects" > "$XDIR/backfill_out.log" 2>&1
+  XW_STATUS=$?
+
+  if [ "$XW_STATUS" -eq 0 ]; then
+    XW_COUNT=$(dq "$XDB" "SELECT COUNT(*) FROM skill_usage WHERE session_id='sess-XWRITER';")
+    assert "backfill: cross-writer ts precision mismatch still dedups (1 row, not 2)" "$XW_COUNT" "1"
+  else
+    echo "  SKIP: backfill script did not exit 0 for cross-writer test (see $XDIR/backfill_out.log)"
+    cat "$XDIR/backfill_out.log" 2>/dev/null | tail -20
   fi
 else
   echo "  SKIP: Rscript / duckdb / jsonlite R packages not on PATH outside the project nix shell"

--- a/.claude/tests/test_skill_usage.sh
+++ b/.claude/tests/test_skill_usage.sh
@@ -244,6 +244,23 @@ EOF
   fi
 
   echo ""
+  echo "=== Test group 8b: hash_args() (R) parity with log_skill_use.sh's hook hash convention ==="
+
+  # Guard against regression of the cross-writer args_hash bug: extract just
+  # hash_args() from the backfill script (avoids a full --apply run) and
+  # confirm it produces byte-identical output to the hook's shell convention
+  # (printf '%s' "$_args" | shasum -a 256 | cut -c1-16 — no trailing newline)
+  # for the same input string.
+  HASH_GUARD_R=$(mktemp)
+  sed -n '/^hash_args <- function/,/^}/p' "$BACKFILL" > "$HASH_GUARD_R"
+  echo 'cat(hash_args("demo"))' >> "$HASH_GUARD_R"
+
+  R_HASH=$(Rscript "$HASH_GUARD_R" 2>/dev/null)
+  SHELL_HASH=$(printf '%s' "demo" | shasum -a 256 | cut -c1-16)
+  assert "hash_args(\"demo\") in R matches hook's shell hash convention" "$R_HASH" "$SHELL_HASH"
+  rm -f "$HASH_GUARD_R"
+
+  echo ""
   echo "=== Test group 9: backfill dedupes against an existing second-precision row (cross-writer ts mismatch) ==="
 
   # Pre-populate the DB with a row as the hook/drain path would have written
@@ -253,16 +270,19 @@ EOF
   # the sub-second component so the two never matched and the event was
   # double-counted. The pre-populated args_hash must match what
   # backfill_skill_usage.R's hash_args() computes for the transcript's
-  # "demo" args string (first 16 hex chars of sha256, matching hash_args()
-  # in backfill_skill_usage.R) — otherwise this is testing "different
-  # args_hash" (see Test group 10), not "same event, different ts
-  # precision".
+  # "demo" args string — which MUST be byte-identical to the hook's
+  # convention (log_skill_use.sh: `printf '%s' "$_args" | shasum -a 256 |
+  # cut -c1-16`, i.e. NO trailing newline). Using `printf '%s\n'` here would
+  # hash "demo\n" instead of "demo", producing a hash that never matches a
+  # real hook-written row — the exact cross-writer bug this test exists to
+  # catch — otherwise this is testing "different args_hash" (see Test
+  # group 10), not "same event, different ts precision".
   XDIR=$(mktemp -d)
   XDB="$XDIR/xwriter_test.duckdb"
   XPROJDIR="$XDIR/projects/-tmp-xwriter"
   mkdir -p "$XPROJDIR"
 
-  XW_ARGS_HASH=$(printf '%s\n' "demo" | shasum -a 256 | awk '{print substr($1,1,16)}')
+  XW_ARGS_HASH=$(printf '%s' "demo" | shasum -a 256 | cut -c1-16)
 
   dq "$XDB" "
     CREATE TABLE IF NOT EXISTS skill_usage (


### PR DESCRIPTION
## Summary

`skill_usage` in `unified.duckdb` had only ~29 rows against 3,783 sessions —
its only writer was a nightly ETL (`skill_usage_etl.R`) scanning raw JSONL
transcripts for a narrow literal pattern. This card adds a real-time forward
path and a repeatable historical backfill, additive alongside the existing
writer (does not replace it).

- **`.claude/hooks/log_skill_use.sh`** — new `PostToolUse(Skill)` hook.
  Stages one lock-free JSONL append per invocation (same convention as
  `log_session.sh`'s `hook` case / #710 — no duckdb CLI on the hot path, so
  no write-lock contention). Only a `sha256[0:16]` hash of `args` is staged,
  never the raw text.
- **`.claude/scripts/skill_usage_staging_import.sh`** — drains the staging
  file into `skill_usage`, using the identical atomic mv-then-import
  handoff already used for `hook_events_staging.jsonl` in
  `roborev_metrics_etl.sh`. Wired into that script as an additive step, so
  it runs on the existing `com.claude.roborev-metrics-etl` launchd
  schedule.
- **`.claude/scripts/backfill_skill_usage.R`** — parses
  `~/.claude/projects/**/*.jsonl` for historical `Skill` tool_use blocks
  and inserts `backfilled=TRUE` rows. Idempotent: dedupes on
  `(session_id, skill_name, ts)`.
- **Schema**: `skill_usage` gains `project_path` / `args_hash` / `ts` /
  `backfilled` via `ADD COLUMN IF NOT EXISTS` — additive alongside the
  legacy `session_date` / `project` / `invocations` / `etl_run_at` columns
  written by `skill_usage_etl.R`, so both writers coexist on one table.
- **`.claude/settings.json`** — new `PostToolUse` matcher `"Skill"` wired
  to the hook.

### Coordination with Card 1a (#309, separate PR, not yet merged)

Card 1a adds an `etl_freshness` registry table + `etl_freshness_upsert.sh`
helper. This PR's `etl_freshness` interaction is defensive so it works
whether or not 1a has merged first: both the drain script and the backfill
script call the shared helper *if present*, and otherwise fall back to an
inline `CREATE TABLE IF NOT EXISTS` + upsert using the identical schema
(verified against 1a's actual commit content). Neither script touches
`housekeeping_schema_init.sql` or `etl_freshness_upsert.sh` itself, so there
is no file-level overlap with 1a's diff.

## Test plan

- [x] `.claude/tests/test_skill_usage.sh` — 17 hermetic tests (temp `HOME`,
      scratch duckdb, never touches the live `unified.duckdb`): hook
      staging, non-Skill/malformed payloads are no-ops, drain into a fresh
      DB, idempotent re-drain, dedupe on `(session_id, skill_name, ts)`,
      `etl_freshness` registration, and R backfill insert + idempotent
      re-run. All pass, including the R portion run inside
      `nix-shell default.nix`.
- [x] `bash -n` clean on all shell edits.
- [x] R script: `parse()` succeeds; `~/.claude/scripts/r_code_check.sh`
      (ast-grep + jarl + fence-parity) reports zero violations.
- [x] Demonstrated against a **scratch copy** of the real transcript
      archive (1,764 JSONL files, copied to `/tmp`, live DB never opened
      for writing): backfill found 10 genuine literal `Skill` tool_use
      blocks; scratch DB went from 0 → 10 rows on `--apply`, stayed at 10
      on re-apply (idempotent).

## Deferred / follow-up

- Some of this repo's slash-commands (`bye`, `issue-triage`,
  `cleanup-worktrees`, etc.) are sometimes logged as bare top-level
  `tool_use` blocks (`name` == the command) rather than wrapped in a
  `Skill` block with `input.skill`. The existing ETL and this PR's
  backfill both only match the literal `Skill`-wrapped form (per the task
  spec), so those bare-name invocations are still undercounted. Filing as
  a follow-up rather than expanding this card's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Dispatch-Id: 6562af0f-b413-4588-a445-3c0c8b76acad