### PR TITLE
feat(command-usage): instrument slash-command usage (Card 1e, #745)

### DIFF
--- a/.claude/hooks/log_command_use.sh
+++ b/.claude/hooks/log_command_use.sh
@@ -63,6 +63,31 @@ _input=$(cat 2>/dev/null || echo "")   # consume stdin once
 
 _jq() { echo "$_input" | jq -r "$1" 2>/dev/null || echo ""; }
 
+# Detectable-failure signal (#747 review): the stdin field name carrying the
+# prompt text (user_prompt / prompt) was inferred from a generic plugin doc,
+# not a confirmed live payload shape. If that inference is wrong, extraction
+# below silently returns empty forever with no way to notice. When a
+# genuinely non-empty payload yields nothing, leave a throttled trace of its
+# top-level keys so the failure is diagnosable. Override path for tests.
+_debug_log="${CMD_USE_DEBUG_LOG:-$HOME/.claude/logs/command_use_debug.log}"
+_log_unrecognized_payload() {
+  mkdir -p "$(dirname "$_debug_log")" 2>/dev/null || true
+  # Throttle to at most once per hour so a persistently-wrong field name
+  # doesn't spam the log on every keystroke-driven prompt submission.
+  if [ -f "$_debug_log" ] && [ -n "$(find "$_debug_log" -mmin -60 2>/dev/null)" ]; then
+    return 0
+  fi
+  local _keys
+  if command -v jq >/dev/null 2>&1; then
+    _keys=$(echo "$_input" | jq -r 'keys | join(",")' 2>/dev/null || echo "")
+  else
+    _keys="jq-unavailable"
+  fi
+  printf '%s unrecognized UserPromptSubmit payload; top-level keys=[%s]\n' \
+    "$(date -u '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')" "$_keys" \
+    >> "$_debug_log" 2>/dev/null || true
+}
+
 if [ -n "$_input" ] && command -v jq >/dev/null 2>&1; then
   _prompt=$(_jq '.user_prompt // .prompt // empty')
 else
@@ -71,7 +96,10 @@ else
   [ -n "$_prompt" ] || _prompt=$(echo "$_input" | grep -o '"prompt":"[^"]*"' | head -1 | cut -d'"' -f4)
 fi
 
-[ -n "$_prompt" ] || exit 0   # no prompt text — nothing to inspect
+if [ -z "$_prompt" ]; then
+  [ -n "$_input" ] && _log_unrecognized_payload
+  exit 0   # no prompt text — nothing to inspect
+fi
 
 # Strip leading whitespace, then require the FIRST character to be '/'
 # followed by a letter (excludes absolute paths like "/Users/..." typed as
@@ -88,10 +116,24 @@ fi
 _command=$(printf '%s' "$_trimmed" | grep -Eo '^/[A-Za-z][A-Za-z0-9_-]*' | sed 's#^/##')
 [ -n "$_command" ] || exit 0
 
+_proj="$(pwd)"
+
+# False-positive guard (#747 review): the regex above matches any leading
+# "/word" token, so a prompt like "/tmp needs cleaning" or "/etc is broken"
+# (a typed absolute path, not a command invocation) would otherwise stage a
+# bogus "tmp"/"etc" command. Require the extracted name to correspond to an
+# installed command file — user-level (~/.claude/commands/) or project-level
+# (<cwd>/.claude/commands/) — before staging anything. This intentionally
+# narrows capture to file-backed custom commands; unrecognized names
+# (including Claude Code built-ins with no .md file) are silently ignored.
+if [ ! -f "$HOME/.claude/commands/${_command}.md" ] && \
+   [ ! -f "$_proj/.claude/commands/${_command}.md" ]; then
+  exit 0
+fi
+
 _rest=$(printf '%s' "$_trimmed" | sed -E 's#^/[A-Za-z][A-Za-z0-9_-]*##')
 _args=$(printf '%s' "$_rest" | sed -E 's/^[[:space:]]+//')
 
-_proj="$(pwd)"
 _ts=$(date -u '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')
 
 # args_hash: short non-reversible fingerprint of the args string, same

--- a/.claude/hooks/log_command_use.sh
+++ b/.claude/hooks/log_command_use.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# log_command_use.sh — Stage slash-command invocations for command_usage
+# instrumentation. Hook: UserPromptSubmit in settings.json.
+#
+# Card 1e (own-your-context plan, #745). skill_usage (Card 1b, #729/#744)
+# captures invocations of the `Skill` tool, but Claude Code slash commands
+# (/bye, /check, /cleanup, /issue-triage, ...) are NOT logged as Skill
+# tool_use blocks. Investigation of real transcripts under
+# ~/.claude/projects/*/*.jsonl (2026-07-07) found two distinct mechanisms:
+#
+#   1. Built-in commands (e.g. /model, /usage, /exit) are recorded as a
+#      plain "user" turn whose `message.content` is a STRING containing
+#      `<command-name>/x</command-name>` (+ optional <command-args>).
+#   2. Project/user *custom* commands — the ones this card cares about,
+#      e.g. /bye (~/.claude/commands/bye.md), /issue-triage,
+#      /cleanup-worktrees — instead produce a top-level
+#      `{"type":"attachment","attachment":{"type":"invoked_skills",
+#      "skills":[{"name":"bye","path":"userSettings:bye","content":"..."}]}}`
+#      record. This is the "bare tool name" signal referenced in #745: the
+#      command name appears bare (not wrapped in a "Skill" tool_use block).
+#      Confirmed empirically: /issue-triage (a pure custom command with no
+#      built-in override) produces ONLY the invoked_skills record — no
+#      <command-name> tag at all. See backfill_command_usage.R for the
+#      corresponding historical parser of that record shape.
+#
+# Neither of those records is available at UserPromptSubmit time (Claude
+# Code hasn't resolved/loaded the command file yet) — but the RAW prompt
+# text the user just typed IS available then, as `/name args...`. This hook
+# captures that raw text at submission time so every slash-command
+# invocation is captured going forward, independent of which downstream
+# transcript shape it later produces.
+#
+# Field-name caveat: the exact stdin field carrying the prompt text is not
+# fully pinned down for this Claude Code version from static docs alone —
+# a generic plugin-dev skill doc and the shipped `hookify` plugin
+# (core/rule_engine.py: `input_data.get('user_prompt', '')`) both name it
+# `user_prompt`, so that is tried first, with `.prompt` as a defensive
+# fallback. Recommended follow-up (documented in the PR): once installed,
+# invoke a real slash command and confirm a row lands in
+# command_usage_staging.jsonl.
+#
+# CONCURRENCY: mirrors log_skill_use.sh — no duckdb CLI here (a hot loop of
+# UserPromptSubmit events must not contend for the exclusive write lock on
+# unified.duckdb). Append one JSON line per event to an append-only staging
+# file (each printf/>> is an atomic kernel write <= PIPE_BUF).
+# command_usage_staging_import.sh drains this file into the command_usage
+# table on the existing roborev-metrics-etl schedule.
+#
+# Reads the hook payload as JSON on stdin. ALWAYS exits 0 — must never
+# block prompt submission.
+set -uo pipefail
+
+_staging="$HOME/.claude/logs/command_usage_staging.jsonl"
+mkdir -p "$(dirname "$_staging")" 2>/dev/null || true
+
+_sid=""
+if [ -f "$HOME/.claude/logs/.current_session" ]; then
+  _sid=$(cat "$HOME/.claude/logs/.current_session" 2>/dev/null || echo "")
+fi
+[ -n "$_sid" ] || _sid="unknown"
+
+_input=$(cat 2>/dev/null || echo "")   # consume stdin once
+
+_jq() { echo "$_input" | jq -r "$1" 2>/dev/null || echo ""; }
+
+if [ -n "$_input" ] && command -v jq >/dev/null 2>&1; then
+  _prompt=$(_jq '.user_prompt // .prompt // empty')
+else
+  # Legacy fallback: crude grep extraction when jq is unavailable.
+  _prompt=$(echo "$_input" | grep -o '"user_prompt":"[^"]*"' | head -1 | cut -d'"' -f4)
+  [ -n "$_prompt" ] || _prompt=$(echo "$_input" | grep -o '"prompt":"[^"]*"' | head -1 | cut -d'"' -f4)
+fi
+
+[ -n "$_prompt" ] || exit 0   # no prompt text — nothing to inspect
+
+# Strip leading whitespace, then require the FIRST character to be '/'
+# followed by a letter (excludes absolute paths like "/Users/..." typed as
+# plain text, since those continue with another "/" rather than whitespace
+# or end-of-string after the leading token).
+_trimmed=$(printf '%s' "$_prompt" | sed -e 's/^[[:space:]]*//')
+# Require the command token to be followed by whitespace or end-of-string —
+# NOT another "/" — so a typed absolute path (e.g. "/Users/johngavin/...")
+# is never mistaken for a slash-command invocation.
+if ! printf '%s' "$_trimmed" | grep -Eq '^/[A-Za-z][A-Za-z0-9_-]*([[:space:]]|$)'; then
+  exit 0
+fi
+
+_command=$(printf '%s' "$_trimmed" | grep -Eo '^/[A-Za-z][A-Za-z0-9_-]*' | sed 's#^/##')
+[ -n "$_command" ] || exit 0
+
+_rest=$(printf '%s' "$_trimmed" | sed -E 's#^/[A-Za-z][A-Za-z0-9_-]*##')
+_args=$(printf '%s' "$_rest" | sed -E 's/^[[:space:]]+//')
+
+_proj="$(pwd)"
+_ts=$(date -u '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')
+
+# args_hash: short non-reversible fingerprint of the args string, same
+# privacy stance as log_skill_use.sh — never store the args text itself.
+_args_hash=""
+if [ -n "$_args" ] && command -v shasum >/dev/null 2>&1; then
+  _args_hash=$(printf '%s' "$_args" | shasum -a 256 | cut -c1-16)
+fi
+
+# JSON-escape (same convention as log_skill_use.sh / log_session.sh).
+_esc() {
+  printf '%s' "$1" | tr '\n\r\t' '   ' | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+_command_esc=$(_esc "$_command")
+_proj_esc=$(_esc "$_proj")
+_sid_esc=$(_esc "$_sid")
+
+printf '{"ts":"%s","session_id":"%s","command_name":"%s","project_path":"%s","args_hash":"%s"}\n' \
+  "$_ts" "$_sid_esc" "$_command_esc" "$_proj_esc" "$_args_hash" \
+  >> "$_staging" 2>/dev/null || true
+
+exit 0

--- a/.claude/scripts/backfill_command_usage.R
+++ b/.claude/scripts/backfill_command_usage.R
@@ -1,0 +1,273 @@
+#!/usr/bin/env Rscript
+# backfill_command_usage.R — one-time (repeatable) historical backfill for
+# the command_usage table from Claude Code session transcripts.
+#
+# Card 1e (own-your-context plan, #745). skill_usage (Card 1b, #729/#744)
+# only captures invocations of the `Skill` tool. Slash commands such as
+# /bye, /check, /cleanup, /issue-triage are NOT logged as Skill tool_use
+# blocks. Investigation of real transcripts (2026-07-07) found that
+# *custom* project/user commands — the ones this card targets — are
+# recorded as a top-level record:
+#
+#   {"type":"attachment","attachment":{"type":"invoked_skills",
+#    "skills":[{"name":"bye","path":"userSettings:bye","content":"..."}]},
+#    "sessionId":"...","cwd":"...","timestamp":"..."}
+#
+# This is a DIFFERENT mechanism from the `<command-name>/x</command-name>`
+# XML tag embedded in a "user" turn's `message.content` string, which is
+# used for Claude Code *built-in* commands (/model, /usage, /exit, ...).
+# Confirmed empirically: /issue-triage (a pure custom command with no
+# built-in override) produces ONLY the invoked_skills attachment record —
+# no <command-name> tag at all in that session. This script parses ONLY
+# the invoked_skills attachment shape, matching the "bare tool name, not
+# Skill-wrapped" signal called out in #745 (attachment.skills[].name is
+# the bare command name, not nested under a "Skill" tool_use block the way
+# skill_usage's rows are).
+#
+# Known data-shape limitation: invoked_skills records observed in the wild
+# carry only {name, path, content} per skill — no per-invocation args
+# field. args_hash is therefore NA for every historically-backfilled row.
+# The forward-capture hook (log_command_use.sh, a UserPromptSubmit hook)
+# DOES see per-invocation args, because it reads the raw "/name args..."
+# prompt text at submission time — before Claude Code resolves/loads the
+# command file into an invoked_skills record. extract_command_events()
+# below defensively also checks for an `args` field on the skill object
+# (hashed via hash_args(), same convention as the hook) in case a future
+# Claude Code version adds one; this keeps the parser forward-compatible
+# and lets tests exercise the hashing/dedup logic without contradicting
+# today's real transcript shape.
+#
+# Extracts ONLY: session_id, command_name, timestamp, project path, and
+# (when present) a fixed-length args hash. It does NOT store the `content`
+# field (the full command markdown body) — that would duplicate the
+# command definition file itself in the DB for no analytic benefit.
+#
+# Idempotent: dedupes on (session_id, command_name, ts, args_hash) via NOT
+# EXISTS at insert time, so re-running never increases the row count.
+# args_hash is matched with IS NOT DISTINCT FROM (NULL-safe) so two
+# invocations differing only in args are never conflated into one row.
+#
+# Usage:
+#   Rscript backfill_command_usage.R [--apply] [--db PATH] [--projects-dir PATH]
+#
+#   --apply           Write to the DB (default: dry-run, print summary only)
+#   --db PATH         DuckDB file path (default: ~/.claude/logs/unified.duckdb)
+#   --projects-dir P  Transcript root (default: ~/.claude/projects)
+#
+# Tables written:
+#   command_usage(session_id, command_name, project_path, args_hash, ts, backfilled)
+#     — mirrors skill_usage's event-level shape exactly.
+#
+# Also registers/refreshes the `command_usage` row in `etl_freshness` (#309
+# Card 1a; defensive — creates the table if 1a has not merged yet).
+
+suppressPackageStartupMessages({
+  library(jsonlite)
+  library(dplyr)
+  library(duckdb)
+  library(purrr)
+  library(fs)
+  library(tibble)
+  library(stringr)
+})
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+args    <- commandArgs(trailingOnly = TRUE)
+dry_run <- !"--apply" %in% args
+
+db_idx  <- which(args == "--db") + 1L
+db_path <- if (length(db_idx) && db_idx <= length(args))
+             args[[db_idx]] else path.expand("~/.claude/logs/unified.duckdb")
+
+proj_idx     <- which(args == "--projects-dir") + 1L
+projects_dir <- if (length(proj_idx) && proj_idx <= length(args))
+                  args[[proj_idx]] else path.expand("~/.claude/projects")
+
+cat(sprintf("backfill_command_usage: dry_run=%s db=%s projects_dir=%s\n",
+            dry_run, db_path, projects_dir))
+
+# ── args_hash: fixed-length fingerprint, never store args text itself ───────
+# MUST match log_command_use.sh's hook-time hash exactly: that hook computes
+# `printf '%s' "$_args" | shasum -a 256 | cut -c1-16` — i.e. it hashes the raw
+# args bytes with NO trailing newline (identical convention to
+# log_skill_use.sh / backfill_skill_usage.R's hash_args()). system2(...,
+# input = x) is NOT equivalent: it writes x via writeLines(), which appends
+# a trailing "\n", producing a different hash for the same string and
+# silently breaking cross-writer dedup. Write the bytes to a temp file with
+# no newline (cat(..., sep = "")) and hash the file instead of piping via
+# stdin, so both writers hash byte-identical input.
+hash_args <- function(x) {
+  if (is.null(x) || !nzchar(x)) return(NA_character_)
+  tmp <- tempfile()
+  on.exit(unlink(tmp), add = TRUE)
+  cat(x, file = tmp, sep = "")
+  out <- tryCatch(
+    system2("shasum", c("-a", "256", tmp), stdout = TRUE),
+    error = function(e) character()
+  )
+  if (!length(out)) return(NA_character_)
+  substr(strsplit(out[[1]], "\\s+")[[1]][[1]], 1, 16)
+}
+
+# ── JSONL parsing: one row per invoked_skills[[i]] entry ─────────────────────
+extract_command_events <- function(msg, session_id, project) {
+  att <- msg$attachment
+  if (is.null(att)) return(NULL)
+  if (!identical(att$type %||% "", "invoked_skills")) return(NULL)
+  skills <- att$skills
+  if (!is.list(skills) || !length(skills)) return(NULL)
+  ts <- msg$timestamp %||% NA_character_
+
+  rows <- compact(map(skills, function(sk) {
+    nm <- sk$name %||% NA_character_
+    if (is.na(nm) || !nzchar(nm)) return(NULL)
+    tibble(
+      session_id   = session_id,
+      command_name = nm,
+      project_path = project,
+      args_hash    = hash_args(sk$args %||% NULL),
+      ts           = ts
+    )
+  }))
+  if (!length(rows)) return(NULL)
+  bind_rows(rows)
+}
+
+parse_file <- function(path) {
+  lines <- tryCatch(readLines(path, warn = FALSE), error = function(e) character())
+  if (!length(lines)) return(NULL)
+
+  # The parent directory name is a lossily-encoded project path (Claude Code
+  # replaces every "/" with "-", so a real "-" in the path, e.g. "docs_gh",
+  # is indistinguishable from an encoded "/"). Reverse-decoding it by
+  # gsub("-", "/") therefore corrupts real paths (docs_gh -> docs/gh). Every
+  # record type in these transcripts (user/assistant/attachment) carries a
+  # top-level `cwd` field with the real, unambiguous path, so prefer that;
+  # only fall back to the (deliberately un-decoded) encoded directory name
+  # when no line in the transcript carries `cwd`.
+  project_enc <- basename(dirname(as.character(path)))
+  session_id  <- tools::file_path_sans_ext(basename(as.character(path)))
+  if (!nzchar(session_id)) return(NULL)
+
+  msgs <- map(lines, function(line) {
+    tryCatch(fromJSON(line, simplifyVector = FALSE), error = function(e) NULL)
+  })
+
+  project <- NULL
+  for (msg in msgs) {
+    cwd <- msg$cwd %||% NULL
+    if (!is.null(cwd) && nzchar(cwd)) {
+      project <- cwd
+      break
+    }
+  }
+  if (is.null(project)) project <- project_enc
+
+  events <- compact(map(msgs, function(msg) {
+    if (is.null(msg) || !identical(msg$type, "attachment")) return(NULL)
+    extract_command_events(msg, session_id, project)
+  }))
+  if (!length(events)) return(NULL)
+  bind_rows(events)
+}
+
+jsonl_files <- tryCatch(dir_ls(projects_dir, recurse = TRUE, glob = "*.jsonl"),
+                        error = function(e) character())
+cat(sprintf("Scanning %d JSONL files under %s...\n", length(jsonl_files), projects_dir))
+
+parsed  <- compact(map(jsonl_files, parse_file))
+events_df <- if (length(parsed)) bind_rows(parsed) else tibble(
+  session_id = character(), command_name = character(),
+  project_path = character(), args_hash = character(), ts = character()
+)
+
+cat(sprintf("Found %d historical slash-command invocations across %d files\n",
+            nrow(events_df), length(jsonl_files)))
+
+if (nrow(events_df) > 0) {
+  cat("\nTop commands by historical invocation count:\n")
+  events_df |> count(command_name, sort = TRUE) |> print(n = 20L)
+}
+
+if (dry_run) {
+  cat("\nDRY RUN — pass --apply to write to DB\n")
+  quit(status = 0L)
+}
+
+# ── DB write ──────────────────────────────────────────────────────────────────
+con <- dbConnect(duckdb(), db_path)
+on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+invisible(dbExecute(con, "
+  CREATE TABLE IF NOT EXISTS command_usage (
+    session_id   VARCHAR,
+    command_name VARCHAR,
+    project_path VARCHAR,
+    args_hash    VARCHAR,
+    ts           TIMESTAMP,
+    backfilled   BOOLEAN DEFAULT FALSE
+  )"))
+
+if (nrow(events_df) > 0) {
+  # Register the candidate rows in a temp view, then insert only the ones
+  # not already present (dedupe on session_id, command_name, ts) — idempotent.
+  events_df <- events_df |>
+    mutate(ts = as.character(ts), backfilled = TRUE) |>
+    filter(!is.na(ts), nzchar(ts))
+
+  dbWriteTable(con, "command_usage_backfill_staging", events_df, overwrite = TRUE)
+
+  n_inserted <- dbExecute(con, "
+    INSERT INTO command_usage (session_id, command_name, project_path, args_hash, ts, backfilled)
+    SELECT
+      s.session_id, s.command_name, s.project_path, s.args_hash,
+      CAST(s.ts AS TIMESTAMP) AS ts, TRUE
+    FROM command_usage_backfill_staging s
+    WHERE NOT EXISTS (
+      SELECT 1 FROM command_usage u
+      WHERE u.session_id = s.session_id
+        AND u.command_name = s.command_name
+        AND date_trunc('second', u.ts) = date_trunc('second', CAST(s.ts AS TIMESTAMP))
+        AND u.args_hash IS NOT DISTINCT FROM s.args_hash
+    )
+  ")
+  invisible(dbExecute(con, "DROP TABLE IF EXISTS command_usage_backfill_staging"))
+  cat(sprintf("Inserted %d new rows (skipped duplicates already present)\n", n_inserted))
+}
+
+# ── etl_freshness registration (defensive re: #309 Card 1a coordination) ────
+raw_args   <- commandArgs(trailingOnly = FALSE)
+file_arg   <- grep("^--file=", raw_args, value = TRUE)
+script_dir <- if (length(file_arg))
+  dirname(normalizePath(sub("^--file=", "", file_arg[[1]]))) else getwd()
+freshness_helper <- file.path(script_dir, "etl_freshness_upsert.sh")
+
+used_helper <- FALSE
+if (nzchar(freshness_helper) && file.exists(freshness_helper) &&
+    file.access(freshness_helper, mode = 1)[[1]] == 0) {
+  status <- tryCatch(
+    system2(freshness_helper,
+            c("command_usage", shQuote(db_path), "", "--table", "command_usage", "--ts-col", "ts"),
+            stdout = FALSE, stderr = FALSE),
+    error = function(e) 1L
+  )
+  used_helper <- identical(status, 0L)
+}
+if (!used_helper) {
+  invisible(dbExecute(con, "
+    CREATE TABLE IF NOT EXISTS etl_freshness (
+      source_name            VARCHAR PRIMARY KEY,
+      last_row_ts             TIMESTAMP,
+      last_etl_run_ts         TIMESTAMP,
+      expected_cadence_hours  DOUBLE,
+      status                  VARCHAR
+    )"))
+  invisible(dbExecute(con, "
+    INSERT OR REPLACE INTO etl_freshness
+      (source_name, last_row_ts, last_etl_run_ts, expected_cadence_hours, status)
+    SELECT 'command_usage', (SELECT MAX(ts) FROM command_usage), current_timestamp, NULL, 'unknown'
+  "))
+}
+
+final_count <- dbGetQuery(con, "SELECT COUNT(*) AS n FROM command_usage")$n
+cat(sprintf("\nDone. command_usage now has %d total rows. DB: %s\n", final_count, db_path))

--- a/.claude/scripts/backfill_command_usage.R
+++ b/.claude/scripts/backfill_command_usage.R
@@ -44,8 +44,13 @@
 #
 # Idempotent: dedupes on (session_id, command_name, ts, args_hash) via NOT
 # EXISTS at insert time, so re-running never increases the row count.
-# args_hash is matched with IS NOT DISTINCT FROM (NULL-safe) so two
-# invocations differing only in args are never conflated into one row.
+# args_hash is compared with COALESCE(..., '') = COALESCE(..., '') so NULL
+# (this script's hash_args() for a no-args command) and '' (the forward
+# hook's args_hash for a no-args command) are treated as the SAME value —
+# otherwise IS NOT DISTINCT FROM would treat NULL and '' as distinct and
+# double-count every no-args command re-seen across the two writers (#747
+# review). Two invocations differing only in actual (non-empty) args are
+# still never conflated into one row.
 #
 # Usage:
 #   Rscript backfill_command_usage.R [--apply] [--db PATH] [--projects-dir PATH]
@@ -228,7 +233,7 @@ if (nrow(events_df) > 0) {
       WHERE u.session_id = s.session_id
         AND u.command_name = s.command_name
         AND date_trunc('second', u.ts) = date_trunc('second', CAST(s.ts AS TIMESTAMP))
-        AND u.args_hash IS NOT DISTINCT FROM s.args_hash
+        AND COALESCE(u.args_hash, '') = COALESCE(s.args_hash, '')
     )
   ")
   invisible(dbExecute(con, "DROP TABLE IF EXISTS command_usage_backfill_staging"))

--- a/.claude/scripts/command_usage_staging_import.sh
+++ b/.claude/scripts/command_usage_staging_import.sh
@@ -30,8 +30,13 @@
 #
 # Idempotent: dedupes on (session_id, command_name, ts, args_hash) at
 # insert time via NOT EXISTS, so re-running against a leftover import file
-# is a no-op. args_hash is matched with IS NOT DISTINCT FROM (NULL-safe) so
-# two invocations differing only in args are never conflated into one row.
+# is a no-op. args_hash is compared with COALESCE(..., '') = COALESCE(..., '')
+# so NULL (backfill's hash_args() for a no-args command) and '' (the hook's
+# args_hash for a no-args command) are treated as the SAME value — otherwise
+# IS NOT DISTINCT FROM would treat NULL and '' as distinct and double-count
+# every no-args command re-seen across the two writers (#747 review). Two
+# invocations differing only in actual (non-empty) args are still never
+# conflated into one row.
 # Non-fatal: never aborts the caller — always exits 0.
 set -uo pipefail
 
@@ -91,7 +96,7 @@ if [ -f "${_IMPORT}" ]; then
         WHERE u.session_id = s.session_id
           AND u.command_name = s.command_name
           AND date_trunc('second', u.ts) = date_trunc('second', CAST(s.ts AS TIMESTAMP))
-          AND u.args_hash IS NOT DISTINCT FROM s.args_hash
+          AND COALESCE(u.args_hash, '') = COALESCE(s.args_hash, '')
       );
   " 2>/dev/null || log "WARN duckdb insert failed (non-fatal)"
   rm -f "${_IMPORT}" 2>/dev/null || true

--- a/.claude/scripts/command_usage_staging_import.sh
+++ b/.claude/scripts/command_usage_staging_import.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# command_usage_staging_import.sh — drain command_usage_staging.jsonl into
+# command_usage.
+#
+# Card 1e (own-your-context plan, #745). Companion to
+# .claude/hooks/log_command_use.sh: the hook stages one JSON line per
+# slash-command invocation (no duckdb CLI, no lock contention — mirrors
+# skill_usage_staging_import.sh / log_session.sh #710). This script imports
+# the staging file into the `command_usage` table on the same cadence as
+# the rest of the ETL — called from roborev_metrics_etl.sh right next to
+# the skill_usage staging import, using the identical atomic-handoff
+# pattern (mv staging file aside before reading it, so new events during
+# the import land in a fresh file).
+#
+# Schema mirrors skill_usage exactly (session_id, command_name,
+# project_path, args_hash, ts, backfilled) — see backfill_command_usage.R
+# for the historical counterpart that writes the same shape.
+#
+# etl_freshness coordination (#309 Card 1a): if the shared
+# etl_freshness_upsert.sh helper is present alongside this script, use it;
+# otherwise fall back to an inline CREATE TABLE IF NOT EXISTS + INSERT OR
+# REPLACE with the identical schema.
+#
+# Usage:
+#   command_usage_staging_import.sh [db_path] [staging_path]
+#
+#   db_path        Defaults to ~/.claude/logs/unified.duckdb
+#   staging_path   Defaults to ~/.claude/logs/command_usage_staging.jsonl
+#                  (override for tests against a scratch DB/staging file)
+#
+# Idempotent: dedupes on (session_id, command_name, ts, args_hash) at
+# insert time via NOT EXISTS, so re-running against a leftover import file
+# is a no-op. args_hash is matched with IS NOT DISTINCT FROM (NULL-safe) so
+# two invocations differing only in args are never conflated into one row.
+# Non-fatal: never aborts the caller — always exits 0.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DB_PATH="${1:-$HOME/.claude/logs/unified.duckdb}"
+STAGING="${2:-$HOME/.claude/logs/command_usage_staging.jsonl}"
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') command_usage_staging_import: $*"; }
+
+if ! command -v duckdb >/dev/null 2>&1; then
+  log "SKIP (duckdb not on PATH)"
+  exit 0
+fi
+
+# ── Ensure schema (additive; mirrors skill_usage) ───────────────────────────
+duckdb -init /dev/null "${DB_PATH}" -c "
+  CREATE TABLE IF NOT EXISTS command_usage (
+    session_id   VARCHAR,
+    command_name VARCHAR,
+    project_path VARCHAR,
+    args_hash    VARCHAR,
+    ts           TIMESTAMP,
+    backfilled   BOOLEAN DEFAULT FALSE
+  );
+" 2>/dev/null || { log "WARN schema ensure failed (non-fatal)"; }
+
+# ── Drain staging file (atomic handoff, mirrors skill_usage import) ─────────
+if [ ! -f "${STAGING}" ] || [ ! -s "${STAGING}" ]; then
+  log "SKIP (no pending events in staging: ${STAGING})"
+  exit 0
+fi
+
+_IMPORT="${STAGING}.import_$(date +%s)_$$"
+mv "${STAGING}" "${_IMPORT}" 2>/dev/null || { log "WARN mv failed (non-fatal)"; exit 0; }
+
+if [ -f "${_IMPORT}" ]; then
+  duckdb -init /dev/null "${DB_PATH}" -c "
+    INSERT INTO command_usage (session_id, command_name, project_path, args_hash, ts, backfilled)
+    SELECT
+      s.session_id,
+      s.command_name,
+      s.project_path,
+      s.args_hash,
+      CAST(s.ts AS TIMESTAMP) AS ts,
+      FALSE
+    FROM read_json(
+      '${_IMPORT}',
+      format        = 'newline_delimited',
+      columns       = {ts: 'VARCHAR', session_id: 'VARCHAR', command_name: 'VARCHAR',
+                       project_path: 'VARCHAR', args_hash: 'VARCHAR'},
+      ignore_errors = true
+    ) AS s
+    WHERE s.session_id IS NOT NULL AND s.command_name IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM command_usage u
+        WHERE u.session_id = s.session_id
+          AND u.command_name = s.command_name
+          AND date_trunc('second', u.ts) = date_trunc('second', CAST(s.ts AS TIMESTAMP))
+          AND u.args_hash IS NOT DISTINCT FROM s.args_hash
+      );
+  " 2>/dev/null || log "WARN duckdb insert failed (non-fatal)"
+  rm -f "${_IMPORT}" 2>/dev/null || true
+  log "import done"
+fi
+
+# ── etl_freshness registration (defensive re: #309 Card 1a coordination) ────
+_FRESHNESS_HELPER="${SCRIPT_DIR}/etl_freshness_upsert.sh"
+if [ -x "${_FRESHNESS_HELPER}" ]; then
+  # Event-driven source, no SLA -> empty cadence -> status='unknown' (helper
+  # semantics: empty/non-numeric cadence => NULL => 'unknown').
+  "${_FRESHNESS_HELPER}" command_usage "${DB_PATH}" "" --table command_usage --ts-col ts 2>/dev/null || true
+else
+  duckdb -init /dev/null "${DB_PATH}" -c "
+    CREATE TABLE IF NOT EXISTS etl_freshness (
+      source_name            VARCHAR PRIMARY KEY,
+      last_row_ts             TIMESTAMP,
+      last_etl_run_ts         TIMESTAMP,
+      expected_cadence_hours  DOUBLE,
+      status                  VARCHAR
+    );
+    INSERT OR REPLACE INTO etl_freshness
+      (source_name, last_row_ts, last_etl_run_ts, expected_cadence_hours, status)
+    SELECT
+      'command_usage',
+      (SELECT MAX(ts) FROM command_usage),
+      current_timestamp,
+      NULL,
+      'unknown';
+  " 2>/dev/null || log "WARN etl_freshness upsert failed (non-fatal)"
+fi
+
+exit 0

--- a/.claude/scripts/roborev_metrics_etl.sh
+++ b/.claude/scripts/roborev_metrics_etl.sh
@@ -397,6 +397,21 @@ else
   log "skill_usage_staging_import: SKIP (script not found or not executable: ${SKILL_STAGING_IMPORT})"
 fi
 
+# ── Command usage: drain real-time staging (Card 1e, #745) ──────────────────
+# log_command_use.sh (UserPromptSubmit hook) appends one JSON line per
+# slash-command invocation to command_usage_staging.jsonl (lock-free — same
+# pattern as the skill_usage staging import immediately above). Import it
+# here, right next to that import, using the identical atomic-handoff
+# pattern.
+COMMAND_STAGING_IMPORT="${SCRIPT_DIR}/command_usage_staging_import.sh"
+if [ -x "$COMMAND_STAGING_IMPORT" ]; then
+  log "command_usage_staging_import: start"
+  "$COMMAND_STAGING_IMPORT" "$UNIFIED_DB" >> "$LOGFILE" 2>&1 || true
+  log "command_usage_staging_import: end"
+else
+  log "command_usage_staging_import: SKIP (script not found or not executable: ${COMMAND_STAGING_IMPORT})"
+fi
+
 # ── Skill usage ETL (merged here so both ETL steps share one GC-root refresh
 #    and skill_usage rows are captured by the 03:00 unified.duckdb backup) ──
 SKILL_ETL_SCRIPT="${SCRIPT_DIR}/skill_usage_etl.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -374,6 +374,17 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/log_command_use.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.claude/tests/test_command_usage.sh
+++ b/.claude/tests/test_command_usage.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# test_command_usage.sh — Hermetic tests for log_command_use.sh +
+# command_usage_staging_import.sh + backfill_command_usage.R (Card 1e,
+# #745). Mirrors test_skill_usage.sh's conventions. Tests use a temp HOME so
+# the hook's hardcoded $HOME/.claude/... paths are safe, and a scratch
+# duckdb so the live unified.duckdb is never touched. Requires: duckdb, jq
+# on PATH. R tests are skipped (not failed) if Rscript/duckdb-R/jsonlite
+# are unavailable outside the project nix shell.
+
+set -uo pipefail
+
+WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$WT/.claude/hooks/log_command_use.sh"
+DRAIN="$WT/.claude/scripts/command_usage_staging_import.sh"
+BACKFILL="$WT/.claude/scripts/backfill_command_usage.R"
+
+PASS=0
+FAIL=0
+
+dq() {
+  local db="$1" sql="$2"
+  duckdb -init /dev/null "$db" -noheader -list -c "$sql" 2>/dev/null
+}
+
+assert() {
+  local desc="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "        expected: [$expected]"
+    echo "        got:      [$result]"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Setup temp HOME
+# --------------------------------------------------------------------------
+T=$(mktemp -d)
+mkdir -p "$T/.claude/logs"
+
+TESTDB="$T/.claude/logs/unified.duckdb"
+STAGING="$T/.claude/logs/command_usage_staging.jsonl"
+
+echo "test-session-A" > "$T/.claude/logs/.current_session"
+
+echo ""
+echo "=== Test group 1: hook stages a JSONL record for a slash command ==="
+
+PAYLOAD='{"hook_event_name":"UserPromptSubmit","user_prompt":"/check verbose"}'
+
+printf '%s' "$PAYLOAD" | HOME="$T" bash "$HOOK"
+
+assert "staging file created" "$([ -f "$STAGING" ] && echo yes || echo no)" "yes"
+
+STAGED_LINE=$(cat "$STAGING" 2>/dev/null)
+STAGED_CMD=$(echo "$STAGED_LINE" | jq -r '.command_name')
+assert "staged record: command_name='check'" "$STAGED_CMD" "check"
+
+STAGED_SID=$(echo "$STAGED_LINE" | jq -r '.session_id')
+assert "staged record: session_id='test-session-A'" "$STAGED_SID" "test-session-A"
+
+STAGED_HASH=$(echo "$STAGED_LINE" | jq -r '.args_hash')
+if [ -n "$STAGED_HASH" ] && [ "$STAGED_HASH" != "null" ] && [ "$STAGED_HASH" != "" ]; then
+  echo "  PASS: staged record: args_hash is non-empty (args text itself not stored)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: staged record: args_hash missing (got: $STAGED_HASH)"
+  FAIL=$((FAIL + 1))
+fi
+if ! echo "$STAGED_LINE" | grep -q "verbose"; then
+  echo "  PASS: staged record does NOT contain raw args text"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: staged record leaked raw args text"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== Test group 2: non-slash prompts and edge cases are no-ops ==="
+
+RM_BEFORE=$(wc -l < "$STAGING" | tr -d ' ')
+NOOP_PAYLOAD='{"hook_event_name":"UserPromptSubmit","user_prompt":"please run the tests for me"}'
+printf '%s' "$NOOP_PAYLOAD" | HOME="$T" bash "$HOOK"
+RM_AFTER=$(wc -l < "$STAGING" | tr -d ' ')
+assert "plain-text prompt (no leading slash): no new line staged" "$RM_AFTER" "$RM_BEFORE"
+
+RM_BEFORE2=$(wc -l < "$STAGING" | tr -d ' ')
+PATH_PAYLOAD='{"hook_event_name":"UserPromptSubmit","user_prompt":"/Users/johngavin/docs_gh/llm/R/foo.R has a bug"}'
+printf '%s' "$PATH_PAYLOAD" | HOME="$T" bash "$HOOK"
+RM_AFTER2=$(wc -l < "$STAGING" | tr -d ' ')
+assert "absolute path typed as prompt (not a command): no new line staged" "$RM_AFTER2" "$RM_BEFORE2"
+
+echo ""
+echo "=== Test group 3: staging_import drains into command_usage (fresh DB) ==="
+
+bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
+
+ROW_COUNT=$(dq "$TESTDB" "SELECT COUNT(*) FROM command_usage;")
+assert "drain: exactly 1 row landed in command_usage" "$ROW_COUNT" "1"
+
+DRAINED_CMD=$(dq "$TESTDB" "SELECT command_name FROM command_usage WHERE session_id='test-session-A';")
+assert "drain: command_name='check'" "$DRAINED_CMD" "check"
+
+DRAINED_BF=$(dq "$TESTDB" "SELECT backfilled FROM command_usage WHERE session_id='test-session-A';")
+assert "drain: backfilled=false for forward-instrumented row" "$DRAINED_BF" "false"
+
+assert "drain: staging file consumed (removed)" "$([ -f "$STAGING" ] && echo yes || echo no)" "no"
+
+echo ""
+echo "=== Test group 4: drain is idempotent when staging is empty ==="
+
+bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
+ROW_COUNT2=$(dq "$TESTDB" "SELECT COUNT(*) FROM command_usage;")
+assert "drain re-run with no staging file: row count unchanged" "$ROW_COUNT2" "1"
+
+echo ""
+echo "=== Test group 5: drain dedupes on (session_id, command_name, ts, args_hash) ==="
+
+printf '%s' "$PAYLOAD" | HOME="$T" bash "$HOOK"
+EXISTING_TS=$(dq "$TESTDB" "SELECT CAST(ts AS VARCHAR) FROM command_usage WHERE session_id='test-session-A';")
+EXISTING_HASH=$(dq "$TESTDB" "SELECT args_hash FROM command_usage WHERE session_id='test-session-A';")
+printf '{"ts":"%s","session_id":"test-session-A","command_name":"check","project_path":"/tmp","args_hash":"%s"}\n' \
+  "$EXISTING_TS" "$EXISTING_HASH" > "$STAGING"
+
+bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
+ROW_COUNT3=$(dq "$TESTDB" "SELECT COUNT(*) FROM command_usage;")
+assert "drain: duplicate (session_id,command_name,ts,args_hash) not re-inserted" "$ROW_COUNT3" "1"
+
+echo ""
+echo "=== Test group 5b: drain does NOT dedupe same-second events with different args_hash ==="
+
+dq "$TESTDB" "
+  INSERT INTO command_usage (session_id, command_name, project_path, args_hash, ts, backfilled)
+  VALUES ('test-session-C', 'issue-triage', '/tmp', 'hash-alpha',
+          CAST('2026-06-03T14:00:00' AS TIMESTAMP), FALSE);
+" > /dev/null
+
+printf '{"ts":"2026-06-03T14:00:00.321Z","session_id":"test-session-C","command_name":"issue-triage","project_path":"/tmp","args_hash":"hash-beta"}\n' \
+  > "$STAGING"
+
+bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
+ROW_COUNT_C=$(dq "$TESTDB" "SELECT COUNT(*) FROM command_usage WHERE session_id='test-session-C';")
+assert "drain: same-second same-command DIFFERENT args_hash -> both rows kept (2, not 1)" "$ROW_COUNT_C" "2"
+
+echo ""
+echo "=== Test group 6: etl_freshness registration (defensive, Card 1a coordination) ==="
+
+FRESHNESS_EXISTS=$(dq "$TESTDB" "SELECT COUNT(*) FROM information_schema.tables WHERE table_name='etl_freshness';")
+assert "etl_freshness table created" "$FRESHNESS_EXISTS" "1"
+
+FRESHNESS_ROW=$(dq "$TESTDB" "SELECT status FROM etl_freshness WHERE source_name='command_usage';")
+assert "etl_freshness: command_usage registered with status='unknown' (event-driven, no SLA)" "$FRESHNESS_ROW" "unknown"
+
+echo ""
+echo "=== Test group 7: backfill script (R) — skip gracefully if R env unavailable ==="
+
+if command -v Rscript >/dev/null 2>&1 && Rscript -e 'quit(status = if (requireNamespace("duckdb", quietly=TRUE) && requireNamespace("jsonlite", quietly=TRUE)) 0L else 1L)' >/dev/null 2>&1; then
+  BFDIR=$(mktemp -d)
+  BFDB="$BFDIR/backfill_test.duckdb"
+  PROJDIR="$BFDIR/projects/-tmp-proj"
+  mkdir -p "$PROJDIR"
+
+  # Minimal synthetic transcript: two invoked_skills attachment records
+  # (the real record shape for custom slash commands, confirmed against
+  # live transcripts — see backfill_command_usage.R header) plus one
+  # unrelated assistant/tool_use line that must be ignored.
+  cat > "$PROJDIR/sess-XYZ.jsonl" <<'EOF'
+{"type":"attachment","cwd":"/tmp/proj","timestamp":"2026-05-01T10:00:00.000Z","attachment":{"type":"invoked_skills","skills":[{"name":"bye","path":"userSettings:bye","content":"..."}]}}
+{"type":"attachment","cwd":"/tmp/proj","timestamp":"2026-05-02T11:00:00.000Z","attachment":{"type":"invoked_skills","skills":[{"name":"issue-triage","path":"userSettings:issue-triage","content":"..."}]}}
+{"type":"assistant","timestamp":"2026-05-02T11:00:00.000Z","message":{"content":[{"type":"tool_use","id":"toolu_3","name":"Bash","input":{"command":"ls"}}]}}
+EOF
+
+  Rscript "$BACKFILL" --apply --db "$BFDB" --projects-dir "$BFDIR/projects" > "$BFDIR/backfill_out.log" 2>&1
+  BF_STATUS=$?
+
+  if [ "$BF_STATUS" -eq 0 ]; then
+    BF_COUNT1=$(dq "$BFDB" "SELECT COUNT(*) FROM command_usage;")
+    assert "backfill: 2 slash-command invocations inserted (Bash tool_use ignored)" "$BF_COUNT1" "2"
+
+    BF_BACKFILLED=$(dq "$BFDB" "SELECT COUNT(*) FROM command_usage WHERE backfilled=true;")
+    assert "backfill: all inserted rows flagged backfilled=true" "$BF_BACKFILLED" "2"
+
+    # Re-run — must be idempotent (no new rows).
+    Rscript "$BACKFILL" --apply --db "$BFDB" --projects-dir "$BFDIR/projects" > "$BFDIR/backfill_out2.log" 2>&1
+    BF_COUNT2=$(dq "$BFDB" "SELECT COUNT(*) FROM command_usage;")
+    assert "backfill: idempotent re-run (row count stable)" "$BF_COUNT2" "$BF_COUNT1"
+  else
+    echo "  SKIP: backfill script did not exit 0 (see $BFDIR/backfill_out.log) — treating as environment gap, not a test failure"
+    cat "$BFDIR/backfill_out.log" 2>/dev/null | tail -20
+  fi
+
+  echo ""
+  echo "=== Test group 8: backfill derives project_path from transcript cwd, not a lossy dash-decode ==="
+
+  # The encoded directory name below mimics a real Claude Code transcript
+  # directory for a path containing a literal dash-bearing segment
+  # ("docs_gh" -> "docs-gh" once slashes become dashes). Each transcript
+  # line below carries the true `cwd`, which must be used verbatim instead
+  # of gsub("-", "/")-decoding the directory name (which would corrupt this
+  # path to ".../docs/gh/llm").
+  CWDDIR=$(mktemp -d)
+  CWDDB="$CWDDIR/cwd_test.duckdb"
+  CWDPROJDIR="$CWDDIR/projects/-Users-johngavin-docs-gh-llm"
+  mkdir -p "$CWDPROJDIR"
+
+  cat > "$CWDPROJDIR/sess-CWD.jsonl" <<'EOF'
+{"type":"attachment","cwd":"/Users/johngavin/docs_gh/llm","timestamp":"2026-06-15T08:00:00.000Z","attachment":{"type":"invoked_skills","skills":[{"name":"cleanup-worktrees","path":"userSettings:cleanup-worktrees","content":"..."}]}}
+EOF
+
+  Rscript "$BACKFILL" --apply --db "$CWDDB" --projects-dir "$CWDDIR/projects" > "$CWDDIR/backfill_out.log" 2>&1
+  CWD_STATUS=$?
+
+  if [ "$CWD_STATUS" -eq 0 ]; then
+    CWD_PROJECT=$(dq "$CWDDB" "SELECT project_path FROM command_usage WHERE session_id='sess-CWD';")
+    assert "backfill: project_path taken from transcript cwd (not dash-decoded)" \
+      "$CWD_PROJECT" "/Users/johngavin/docs_gh/llm"
+  else
+    echo "  SKIP: backfill script did not exit 0 for cwd test (see $CWDDIR/backfill_out.log)"
+    cat "$CWDDIR/backfill_out.log" 2>/dev/null | tail -20
+  fi
+
+  echo ""
+  echo "=== Test group 8b: hash_args() (R) parity with log_command_use.sh's hook hash convention ==="
+
+  # Guard against the cross-writer args_hash bug that took skill_usage 3
+  # review rounds to get right (#744): extract just hash_args() from the
+  # backfill script (avoids a full --apply run) and confirm it produces
+  # byte-identical output to the hook's shell convention
+  # (printf '%s' "$_args" | shasum -a 256 | cut -c1-16 — no trailing
+  # newline) for the same input string.
+  HASH_GUARD_R=$(mktemp)
+  sed -n '/^hash_args <- function/,/^}/p' "$BACKFILL" > "$HASH_GUARD_R"
+  echo 'cat(hash_args("verbose"))' >> "$HASH_GUARD_R"
+
+  R_HASH=$(Rscript "$HASH_GUARD_R" 2>/dev/null)
+  SHELL_HASH=$(printf '%s' "verbose" | shasum -a 256 | cut -c1-16)
+  assert "hash_args(\"verbose\") in R matches hook's shell hash convention" "$R_HASH" "$SHELL_HASH"
+  rm -f "$HASH_GUARD_R"
+
+  echo ""
+  echo "=== Test group 9: backfill dedupes against an existing second-precision row (cross-writer ts mismatch) ==="
+
+  # Pre-populate the DB with a row as the hook/drain path would have
+  # written it (second precision, backfilled=FALSE, args_hash matching the
+  # hook's convention for "verbose"), then run the backfill over a
+  # synthetic transcript recording the SAME (session_id, command_name)
+  # event with millisecond precision AND an `args` field on the skill
+  # object hashing to the identical value (defensive parser support — see
+  # backfill_command_usage.R header for why args aren't present in real
+  # invoked_skills records today).
+  XDIR=$(mktemp -d)
+  XDB="$XDIR/xwriter_test.duckdb"
+  XPROJDIR="$XDIR/projects/-tmp-xwriter"
+  mkdir -p "$XPROJDIR"
+
+  XW_ARGS_HASH=$(printf '%s' "verbose" | shasum -a 256 | cut -c1-16)
+
+  dq "$XDB" "
+    CREATE TABLE IF NOT EXISTS command_usage (
+      session_id VARCHAR, command_name VARCHAR, project_path VARCHAR,
+      args_hash VARCHAR, ts TIMESTAMP, backfilled BOOLEAN DEFAULT FALSE
+    );
+    INSERT INTO command_usage (session_id, command_name, project_path, args_hash, ts, backfilled)
+    VALUES ('sess-XWRITER', 'check', '/tmp', '${XW_ARGS_HASH}',
+            CAST('2026-06-10T12:00:00' AS TIMESTAMP), FALSE);
+  " > /dev/null
+
+  cat > "$XPROJDIR/sess-XWRITER.jsonl" <<'EOF'
+{"type":"attachment","cwd":"/tmp","timestamp":"2026-06-10T12:00:00.456Z","attachment":{"type":"invoked_skills","skills":[{"name":"check","path":"userSettings:check","content":"...","args":"verbose"}]}}
+EOF
+
+  Rscript "$BACKFILL" --apply --db "$XDB" --projects-dir "$XDIR/projects" > "$XDIR/backfill_out.log" 2>&1
+  XW_STATUS=$?
+
+  if [ "$XW_STATUS" -eq 0 ]; then
+    XW_COUNT=$(dq "$XDB" "SELECT COUNT(*) FROM command_usage WHERE session_id='sess-XWRITER';")
+    assert "backfill: cross-writer ts precision mismatch still dedups (1 row, not 2)" "$XW_COUNT" "1"
+  else
+    echo "  SKIP: backfill script did not exit 0 for cross-writer test (see $XDIR/backfill_out.log)"
+    cat "$XDIR/backfill_out.log" 2>/dev/null | tail -20
+  fi
+
+  echo ""
+  echo "=== Test group 10: backfill does NOT dedupe same-second events with different args_hash ==="
+
+  DIFFDIR=$(mktemp -d)
+  DIFFDB="$DIFFDIR/diffargs_test.duckdb"
+  DIFFPROJDIR="$DIFFDIR/projects/-tmp-diffargs"
+  mkdir -p "$DIFFPROJDIR"
+
+  dq "$DIFFDB" "
+    CREATE TABLE IF NOT EXISTS command_usage (
+      session_id VARCHAR, command_name VARCHAR, project_path VARCHAR,
+      args_hash VARCHAR, ts TIMESTAMP, backfilled BOOLEAN DEFAULT FALSE
+    );
+    INSERT INTO command_usage (session_id, command_name, project_path, args_hash, ts, backfilled)
+    VALUES ('sess-DIFFARGS', 'check', '/tmp', 'hash-old-value',
+            CAST('2026-06-11T09:30:00' AS TIMESTAMP), FALSE);
+  " > /dev/null
+
+  cat > "$DIFFPROJDIR/sess-DIFFARGS.jsonl" <<'EOF'
+{"type":"attachment","cwd":"/tmp","timestamp":"2026-06-11T09:30:00.000Z","attachment":{"type":"invoked_skills","skills":[{"name":"check","path":"userSettings:check","content":"...","args":"a completely different args string"}]}}
+EOF
+
+  Rscript "$BACKFILL" --apply --db "$DIFFDB" --projects-dir "$DIFFDIR/projects" > "$DIFFDIR/backfill_out.log" 2>&1
+  DIFF_STATUS=$?
+
+  if [ "$DIFF_STATUS" -eq 0 ]; then
+    DIFF_COUNT=$(dq "$DIFFDB" "SELECT COUNT(*) FROM command_usage WHERE session_id='sess-DIFFARGS';")
+    assert "backfill: same-second same-command DIFFERENT args_hash -> both rows kept (2, not 1)" "$DIFF_COUNT" "2"
+  else
+    echo "  SKIP: backfill script did not exit 0 for diff-args test (see $DIFFDIR/backfill_out.log)"
+    cat "$DIFFDIR/backfill_out.log" 2>/dev/null | tail -20
+  fi
+else
+  echo "  SKIP: Rscript / duckdb / jsonlite R packages not on PATH outside the project nix shell"
+  echo "        (run: nix-shell $WT/default.nix --run \"bash $WT/.claude/tests/test_command_usage.sh\")"
+fi
+
+# --------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.claude/tests/test_command_usage.sh
+++ b/.claude/tests/test_command_usage.sh
@@ -40,11 +40,19 @@ assert() {
 # --------------------------------------------------------------------------
 T=$(mktemp -d)
 mkdir -p "$T/.claude/logs"
+mkdir -p "$T/.claude/commands"
 
 TESTDB="$T/.claude/logs/unified.duckdb"
 STAGING="$T/.claude/logs/command_usage_staging.jsonl"
 
 echo "test-session-A" > "$T/.claude/logs/.current_session"
+
+# Fixture: installed-command files for the Fix-2 cross-check gate in
+# log_command_use.sh (a leading-slash token is only staged when it matches
+# an installed command's .md file). Real repo commands used across these
+# tests: check (group 1/5), bye (group 6b).
+echo "# check stub fixture" > "$T/.claude/commands/check.md"
+echo "# bye stub fixture"   > "$T/.claude/commands/bye.md"
 
 echo ""
 echo "=== Test group 1: hook stages a JSONL record for a slash command ==="
@@ -146,6 +154,27 @@ ROW_COUNT_C=$(dq "$TESTDB" "SELECT COUNT(*) FROM command_usage WHERE session_id=
 assert "drain: same-second same-command DIFFERENT args_hash -> both rows kept (2, not 1)" "$ROW_COUNT_C" "2"
 
 echo ""
+echo "=== Test group 5c: drain treats NULL and '' args_hash as the SAME value for a no-args command (cross-writer dedup, #747 review Fix 1) ==="
+
+# Simulates the exact bug found in review: the hook writes args_hash=""
+# (empty string) for a no-args command, while the R backfill's hash_args()
+# writes SQL NULL for the same case. Before the fix, IS NOT DISTINCT FROM
+# treated '' and NULL as different values, so re-running the backfill after
+# the hook was live double-counted every no-args command.
+dq "$TESTDB" "
+  INSERT INTO command_usage (session_id, command_name, project_path, args_hash, ts, backfilled)
+  VALUES ('test-session-D', 'bye', '/tmp', '',
+          CAST('2026-06-04T09:00:00' AS TIMESTAMP), FALSE);
+" > /dev/null
+
+printf '{"ts":"2026-06-04T09:00:00.789Z","session_id":"test-session-D","command_name":"bye","project_path":"/tmp","args_hash":null}\n' \
+  > "$STAGING"
+
+bash "$DRAIN" "$TESTDB" "$STAGING" > /dev/null 2>&1
+ROW_COUNT_D=$(dq "$TESTDB" "SELECT COUNT(*) FROM command_usage WHERE session_id='test-session-D';")
+assert "drain: hook's '' and backfill/staging's NULL args_hash dedup to 1 row (not 2)" "$ROW_COUNT_D" "1"
+
+echo ""
 echo "=== Test group 6: etl_freshness registration (defensive, Card 1a coordination) ==="
 
 FRESHNESS_EXISTS=$(dq "$TESTDB" "SELECT COUNT(*) FROM information_schema.tables WHERE table_name='etl_freshness';")
@@ -153,6 +182,62 @@ assert "etl_freshness table created" "$FRESHNESS_EXISTS" "1"
 
 FRESHNESS_ROW=$(dq "$TESTDB" "SELECT status FROM etl_freshness WHERE source_name='command_usage';")
 assert "etl_freshness: command_usage registered with status='unknown' (event-driven, no SLA)" "$FRESHNESS_ROW" "unknown"
+
+echo ""
+echo "=== Test group 6b: leading-slash tokens that aren't installed commands are ignored (#747 review Fix 2) ==="
+
+# Before the fix, the hook's regex matched ANY leading "/word" token, so a
+# plain-English prompt like "/tmp needs cleaning" or "/etc is broken" (not a
+# command invocation) staged a bogus "tmp"/"etc" command. The fix requires
+# the extracted name to match an installed command file.
+rm -f "$STAGING"
+
+TMP_PAYLOAD='{"hook_event_name":"UserPromptSubmit","user_prompt":"/tmp needs cleaning"}'
+printf '%s' "$TMP_PAYLOAD" | HOME="$T" bash "$HOOK"
+assert "'/tmp needs cleaning' (not an installed command): no staging file created" \
+  "$([ -f "$STAGING" ] && echo yes || echo no)" "no"
+
+ETC_PAYLOAD='{"hook_event_name":"UserPromptSubmit","user_prompt":"/etc is broken"}'
+printf '%s' "$ETC_PAYLOAD" | HOME="$T" bash "$HOOK"
+assert "'/etc is broken' (not an installed command): no staging file created" \
+  "$([ -f "$STAGING" ] && echo yes || echo no)" "no"
+
+BYE_PAYLOAD='{"hook_event_name":"UserPromptSubmit","user_prompt":"/bye"}'
+printf '%s' "$BYE_PAYLOAD" | HOME="$T" bash "$HOOK"
+BYE_CMD=$([ -f "$STAGING" ] && jq -r '.command_name' < "$STAGING" 2>/dev/null || echo "")
+assert "real installed command '/bye' still records" "$BYE_CMD" "bye"
+
+rm -f "$STAGING"
+
+echo ""
+echo "=== Test group 6c: unrecognized payload shape triggers a throttled debug signal (#747 review Fix 3) ==="
+
+DEBUGLOG="$T/.claude/logs/command_use_debug_test.log"
+rm -f "$DEBUGLOG"
+UNKNOWN_PAYLOAD='{"hook_event_name":"UserPromptSubmit","some_other_field":"/bye"}'
+
+printf '%s' "$UNKNOWN_PAYLOAD" | HOME="$T" CMD_USE_DEBUG_LOG="$DEBUGLOG" bash "$HOOK"
+HOOK_EXIT=$?
+assert "hook exits 0 for unrecognized payload (never blocks prompt submission)" "$HOOK_EXIT" "0"
+
+assert "debug log created when no recognized prompt field is found" \
+  "$([ -f "$DEBUGLOG" ] && echo yes || echo no)" "yes"
+
+if [ -f "$DEBUGLOG" ] && grep -q "some_other_field" "$DEBUGLOG"; then
+  echo "  PASS: debug log records the unrecognized payload's top-level keys"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: debug log missing expected key name"
+  FAIL=$((FAIL + 1))
+fi
+
+LINES_BEFORE=$(wc -l < "$DEBUGLOG" | tr -d ' ')
+printf '%s' "$UNKNOWN_PAYLOAD" | HOME="$T" CMD_USE_DEBUG_LOG="$DEBUGLOG" bash "$HOOK"
+LINES_AFTER=$(wc -l < "$DEBUGLOG" | tr -d ' ')
+assert "debug signal throttled: a second unrecognized payload in the same window adds no new line" \
+  "$LINES_AFTER" "$LINES_BEFORE"
+
+rm -f "$DEBUGLOG"
 
 echo ""
 echo "=== Test group 7: backfill script (R) — skip gracefully if R env unavailable ==="
@@ -314,6 +399,45 @@ EOF
   else
     echo "  SKIP: backfill script did not exit 0 for diff-args test (see $DIFFDIR/backfill_out.log)"
     cat "$DIFFDIR/backfill_out.log" 2>/dev/null | tail -20
+  fi
+
+  echo ""
+  echo "=== Test group 10b: backfill treats NULL and '' args_hash as the SAME value for a no-args command (cross-writer dedup, #747 review Fix 1) ==="
+
+  # Pre-populate the DB with a row exactly as the hook/drain path writes it
+  # for a no-args command: args_hash='' (empty string), NOT NULL. The
+  # synthetic transcript's invoked_skills record has no `args` field (the
+  # real-world shape — see header), so hash_args(NULL) yields SQL NULL.
+  # Before the fix, IS NOT DISTINCT FROM treated '' and NULL as different
+  # values, producing 2 rows instead of 1.
+  NULLDIR=$(mktemp -d)
+  NULLDB="$NULLDIR/nullargs_test.duckdb"
+  NULLPROJDIR="$NULLDIR/projects/-tmp-nullargs"
+  mkdir -p "$NULLPROJDIR"
+
+  dq "$NULLDB" "
+    CREATE TABLE IF NOT EXISTS command_usage (
+      session_id VARCHAR, command_name VARCHAR, project_path VARCHAR,
+      args_hash VARCHAR, ts TIMESTAMP, backfilled BOOLEAN DEFAULT FALSE
+    );
+    INSERT INTO command_usage (session_id, command_name, project_path, args_hash, ts, backfilled)
+    VALUES ('sess-NULLARGS', 'bye', '/tmp', '',
+            CAST('2026-06-12T08:00:00' AS TIMESTAMP), FALSE);
+  " > /dev/null
+
+  cat > "$NULLPROJDIR/sess-NULLARGS.jsonl" <<'EOF'
+{"type":"attachment","cwd":"/tmp","timestamp":"2026-06-12T08:00:00.000Z","attachment":{"type":"invoked_skills","skills":[{"name":"bye","path":"userSettings:bye","content":"..."}]}}
+EOF
+
+  Rscript "$BACKFILL" --apply --db "$NULLDB" --projects-dir "$NULLDIR/projects" > "$NULLDIR/backfill_out.log" 2>&1
+  NULL_STATUS=$?
+
+  if [ "$NULL_STATUS" -eq 0 ]; then
+    NULL_COUNT=$(dq "$NULLDB" "SELECT COUNT(*) FROM command_usage WHERE session_id='sess-NULLARGS';")
+    assert "backfill: hook's '' and backfill's NULL args_hash for a no-args command dedup to 1 row (not 2)" "$NULL_COUNT" "1"
+  else
+    echo "  SKIP: backfill script did not exit 0 for null-args test (see $NULLDIR/backfill_out.log)"
+    cat "$NULLDIR/backfill_out.log" 2>/dev/null | tail -20
   fi
 else
   echo "  SKIP: Rscript / duckdb / jsonlite R packages not on PATH outside the project nix shell"


### PR DESCRIPTION
## Summary

- skill_usage (#729/#744) only captures `Skill` tool_use invocations. Custom slash commands (`/bye`, `/check`, `/cleanup`, `/issue-triage`, ...) never produce a `Skill` tool_use block, so their usage was invisible.
- Investigated real transcripts under `~/.claude/projects/*/*.jsonl` and found custom commands produce a distinct record shape: `{"type":"attachment","attachment":{"type":"invoked_skills","skills":[{"name":"bye","path":"userSettings:bye","content":"..."}]}}`. Confirmed empirically that a pure custom command (`/issue-triage`, no built-in override) produces **only** this record — no `<command-name>` XML tag (that mechanism is reserved for Claude Code's built-in commands like `/model`, `/usage`, `/exit`).
- Adds a new `command_usage` table mirroring `skill_usage`'s event-level schema exactly: `(session_id, command_name, project_path, args_hash, ts, backfilled)`.

## Capture point validated

- **Forward hook**: `UserPromptSubmit` — fires at prompt-submission time with the raw `/name args...` text, before Claude Code resolves which command file to load (so it's available before the `invoked_skills` record exists). Field name `user_prompt` chosen based on the shipped `hookify` plugin's `core/rule_engine.py` (`input_data.get('user_prompt', '')`) plus the generic hook-development skill doc; `.prompt` is tried as a defensive fallback since the exact schema isn't independently confirmed for this CC version from a live test. Recommended follow-up noted in the hook's header: trigger a real slash command once installed and confirm a row lands in `command_usage_staging.jsonl`.
- **Backfill**: parses `type=="attachment" && attachment.type=="invoked_skills"` blocks — the confirmed, universal marker for custom-command invocations.

## Files

- `.claude/hooks/log_command_use.sh` — new UserPromptSubmit hook, lock-free JSONL staging (mirrors `log_skill_use.sh`). Captures per-invocation args (hashed, never stored raw) from the raw prompt text — richer than backfill, since `invoked_skills` records carry no per-invocation args field.
- `.claude/scripts/command_usage_staging_import.sh` — drains staging into `command_usage`; wired into `roborev_metrics_etl.sh` right next to the `skill_usage` staging import.
- `.claude/scripts/backfill_command_usage.R` — historical backfill; `hash_args()` is byte-identical to the hook's `shasum` convention (no trailing newline) so cross-writer dedup works.
- `.claude/tests/test_command_usage.sh` — 23 tests.
- `.claude/settings.json` — wires the hook under `UserPromptSubmit`.
- `.claude/scripts/roborev_metrics_etl.sh` — wires the drain script.

## Test plan

- [x] `bash -n` clean on all new/modified shell files
- [x] `parse()` clean on the new R script
- [x] `~/.claude/scripts/r_code_check.sh` clean (ast-grep 8 rules, jarl, quarto fence parity) on `backfill_command_usage.R`
- [x] `.claude/tests/test_command_usage.sh`: **23 passed, 0 failed** against a scratch DB (temp `$HOME`, no writes to live `unified.duckdb`)
- [x] Dry-run backfill against real transcripts: 11 historical invocations found (bye:7, issue-triage:3, cleanup-worktrees:1), zero writes (dry-run exits before `dbConnect`)
- [x] `--apply` backfill against a throwaway **scratch copy** of `unified.duckdb` (never the live file): 11 rows inserted, confirmed idempotent

### Cross-writer hash-agreement proof (quoted from test run)

```
=== Test group 8b: hash_args() (R) parity with log_command_use.sh's hook hash convention ===
  PASS: hash_args("verbose") in R matches hook's shell hash convention
```

Both `hash_args()` in R (temp file + `shasum -a 256`, no trailing newline via `cat(x, file=tmp, sep="")`) and the hook's shell convention (`printf '%s' "$_args" | shasum -a 256 | cut -c1-16`) produce byte-identical output for the same input — this is the exact bug class that took #744 three review rounds to fix.

Full test output:

```
=== Test group 1: hook stages a JSONL record for a slash command ===
  PASS: staging file created
  PASS: staged record: command_name='check'
  PASS: staged record: session_id='test-session-A'
  PASS: staged record: args_hash is non-empty (args text itself not stored)
  PASS: staged record does NOT contain raw args text

=== Test group 2: non-slash prompts and edge cases are no-ops ===
  PASS: plain-text prompt (no leading slash): no new line staged
  PASS: absolute path typed as prompt (not a command): no new line staged

=== Test group 3: staging_import drains into command_usage (fresh DB) ===
  PASS: drain: exactly 1 row landed in command_usage
  PASS: drain: command_name='check'
  PASS: drain: backfilled=false for forward-instrumented row
  PASS: drain: staging file consumed (removed)

=== Test group 4: drain is idempotent when staging is empty ===
  PASS: drain re-run with no staging file: row count unchanged

=== Test group 5: drain dedupes on (session_id, command_name, ts, args_hash) ===
  PASS: drain: duplicate (session_id,command_name,ts,args_hash) not re-inserted

=== Test group 5b: drain does NOT dedupe same-second events with different args_hash ===
  PASS: drain: same-second same-command DIFFERENT args_hash -> both rows kept (2, not 1)

=== Test group 6: etl_freshness registration (defensive, Card 1a coordination) ===
  PASS: etl_freshness table created
  PASS: etl_freshness: command_usage registered with status='unknown' (event-driven, no SLA)

=== Test group 7: backfill script (R) — skip gracefully if R env unavailable ===
  PASS: backfill: 2 slash-command invocations inserted (Bash tool_use ignored)
  PASS: backfill: all inserted rows flagged backfilled=true
  PASS: backfill: idempotent re-run (row count stable)

=== Test group 8: backfill derives project_path from transcript cwd, not a lossy dash-decode ===
  PASS: backfill: project_path taken from transcript cwd (not dash-decoded)

=== Test group 8b: hash_args() (R) parity with log_command_use.sh's hook hash convention ===
  PASS: hash_args("verbose") in R matches hook's shell hash convention

=== Test group 9: backfill dedupes against an existing second-precision row (cross-writer ts mismatch) ===
  PASS: backfill: cross-writer ts precision mismatch still dedups (1 row, not 2)

=== Test group 10: backfill does NOT dedupe same-second events with different args_hash ===
  PASS: backfill: same-second same-command DIFFERENT args_hash -> both rows kept (2, not 1)

==============================
Results: 23 passed, 0 failed
==============================
```

## Known limitation

The `UserPromptSubmit` field name (`user_prompt`) is corroborated by a shipped plugin's source and generic docs, but not independently confirmed via a live hook trigger in this sandboxed session (no interactive Claude Code session under this agent's control to fire a real `UserPromptSubmit` event). Recommend a quick manual check after merge: run any slash command and confirm `~/.claude/logs/command_usage_staging.jsonl` gets a line.

Refs #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)