### PR TITLE
docs(changelog): session log 2026-07-07→08 + roborev memory

### DIFF
--- a/.claude/memory/roborev-gemini-dead-silent-failure.md
+++ b/.claude/memory/roborev-gemini-dead-silent-failure.md
@@ -37,3 +37,19 @@ and `session_init.sh` banner to read `overview.failed`/crashes not
 `verdicts.failed`; project `.roborev.toml` `backup_agent='gemini'` → `'codex'`.
 See [[startup-cost-is-mcp-not-hook]] for the sibling "verify the metric, don't
 trust the summary" lesson.
+
+**Recurrence 2026-07-07 — different root cause, same silent-failure surface.**
+All reviews failed with `codex quota exceeded` even for jobs assigned to
+gemini/claude-code, and the daemon **ignored `--agent`**. Root cause: the
+per-reasoning **model pin** `review_model_thorough=gemini-2.5-flash-lite` (from
+#733) is applied to WHATEVER agent runs — so when gemini quota-fails and it
+falls back, the backup agent is handed a gemini model it can't use
+(`404 model_not_found` for claude-code; codex separately quota-dead) and the
+whole job aborts. `default_backup_agent` had also reloaded to `codex` on daemon
+restart. **Escape hatch that WORKS:**
+`roborev review <sha> --local --agent claude-code --model sonnet` — bypasses the
+daemon AND overrides the poisoned model pin, producing a real verdict on
+claude-sonnet-5 (this is how #744/#747 got reviewed). Also set
+`default_backup_agent=claude-code` via `config set --global`. Proper fix
+(per-agent model pinning, so a single-provider outage can't take down all
+reviews) tracked in #746.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ Cumulative lab notes. Track completed work, **failed approaches**, accuracy chec
 
 Convention: newest entries at top. Each entry has a date, what was done, and why.
 
+## 2026-07-07 → 07-08 — own-your-context evidence layer (Phase 1a/1b/1e), roborev daemon repair
+
+### Completed
+- Plan authored (fable model): 4-phase capture→analytics→evidence roadmap (`.claude/plans/`, gitignored/ephemeral).
+- Phase 1a (#743, #309): `etl_freshness` registry + `etl_freshness_upsert.sh` + session-start stale banner; root-caused & fixed the `burn:err` guard (npx-cache ENOTEMPTY).
+- Phase 1b (#744): `skill_usage` hook (`log_skill_use.sh`) + backfill (`backfill_skill_usage.R`). Roborev caught 4 real bugs across 3 fix rounds (lossy dash path-decode → use transcript `cwd`; dedup second-truncation; `args_hash` missing from key; hook-vs-R `args_hash` newline mismatch). 23 tests.
+- Phase 1e (#747, #745): `command_usage` slash-command hook (`log_command_use.sh`, UserPromptSubmit) + backfill; slash-commands live in `invoked_skills` attachment records, not Skill blocks. Roborev caught 3 more (args_hash NULL/'' dedup; single-segment path false-positive; unverified field-name → detectable-failure signal). 32 tests.
+- Live backfills: `skill_usage` 29→39, `command_usage` 0→11 (/bye×7, /issue-triage×3, /cleanup-worktrees×1).
+- Capability-registry Artifact (Phase 2 preview): published + archived; framing corrected (skill-tool usage genuinely sparse; real signal = slash-commands) + live-backfill commands panel.
+- roborev daemon repaired: `default_backup_agent`→`claude-code`; `--local` escape hatch. Filed #746.
+- #715 reopened then re-closed — verified #717 already fixed it (live site correct via fetch); corrected my inaccurate reopen comment.
+- Memory updated: `roborev-gemini-dead-silent-failure.md` (model-pin recurrence + `--local` escape hatch).
+
+### Failed Approaches
+- roborev daemon IGNORES `--agent`; `config set default_backup_agent` + restart alone did NOT fix (the `review_model` gemini pin poisons whatever fallback agent runs). Only `roborev review --local --agent claude-code --model sonnet` bypasses it.
+- Reopened #715 on incomplete investigation (stale local `docs/` mistaken for a live defect); #717 had already fixed it. Lesson: check for a prior fix PR before asserting "never resolved".
+- Card 1e first dispatch died on a transport error mid-investigation (retried fresh, no work lost).
+
+### Accuracy / Metrics
+- 3 PRs merged (#743/#744/#747). Adversarial review (roborev via `--local` claude-code) caught 7 real telemetry-corrupting bugs that passing unit tests missed.
+
+### Known Limitations
+- Phase 1c (dispatch lineage) and 1d (#325 dashboard CI) not started; #746 (roborev per-agent model pinning) open.
+- #747 needs one live check: type `/check` → confirm a `command_usage` row + empty `command_use_debug.log`.
+- Plan doc + registry snapshot are gitignored (`.claude/plans/`) — ephemeral, not in git.
+- Stray uncommitted `.claude/settings.json` change in the main checkout (origin unknown).
+
 ## 2026-07-04 → 07-07 — roborev→gemini migration, reporting-bug sweep, token-min
 
 ### Completed


### PR DESCRIPTION
Session-end CHANGELOG entry (own-your-context evidence layer — Phase 1a/1b/1e merged as #743/#744/#747, live backfills, roborev daemon repair #746) + memory update on the roborev model-pin fallback bug and the `--local` escape hatch.

Prose only (CHANGELOG + memory). Based on clean `origin/main` to avoid the main checkout's stale/dirty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)