### PR TITLE
docs(governance): add Simplicity principle + embed-issue-link rule

### DIFF
--- a/.claude/rules/housekeeping-framework.md
+++ b/.claude/rules/housekeeping-framework.md
@@ -178,6 +178,12 @@ Before considering a task "shipped":
 
 ---
 
+## Unused-surface census (subtractive-first enforcement)
+
+Realises the Simplicity principle (see `AGENTS.md` Core Rules). Automation/config surface accretes; periodically flag what is unused so it can be pruned under the Chesterton guard. Data sources: the `command_usage` (#747) and `skill_usage` (#744) tables in `~/.claude/logs/unified.duckdb`. A command/skill/rule with zero recorded invocations is a *candidate*, not an automatic deletion: it must ALSO be confirmed covered elsewhere (a hook, pulse, banner field, or sibling command) before removal. This census is advisory — it produces a review list for a human, never auto-deletes. Follow-up: automate it as a `*-pulse` job (tracked separately).
+
+---
+
 ## Existing Task Inventory
 
 | Task | Script | Launchd plist | Events table | Email section | Session-init phase |

--- a/.claude/rules/pr-shipping-discipline.md
+++ b/.claude/rules/pr-shipping-discipline.md
@@ -68,6 +68,10 @@ Mental check: after reading the phrase, the question to answer is:
 
 Default answer: PR. Override only on explicit "merge" / "merge to main" / "land directly" wording with no qualifier.
 
+## Always embed the issue/PR link
+
+When reporting a merge, PR, or issue action to the user — or in session-end / CHANGELOG-adjacent prose — render the reference as an embedded markdown link to the exact GitHub URL (e.g. `[#750](https://github.com/JohnGavin/llm/pull/750)`), never a bare `#750`. A bare number forces the reader to hunt for the URL; a link is one click. Applies to all projects. Origin: user request 2026-07-08.
+
 ## Origin
 
 [#469](https://github.com/JohnGavin/llm/issues/469) — Show Us Your (Agent) Skills Episode 1, Jeremiah Lowin's `ship-it` skill which "retrains 'ship it' to mean opening a PR rather than merging." This rule applies the same discipline to OUR shorthand vocabulary so the same surprise can't reach us via a future Claude version or a future contributor reading shorthand differently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ Single trailing `\| head -N` / `\| tail -N` / `\| wc -l` / `\| sort -u` / `\| un
 
 **Versioning:** Semver. Patch=bugfix, Minor=feature, Major=breaking. Pre-1.0: breaking=minor bump. **NEVER ship `0.0.0.9000` to users.** Bump to `0.1.0` before first public deploy (GH Pages, pkgdown, vignette).
 
+**Simplicity — subtractive-first (ALL PROJECTS):** Prefer removing over adding. Automation, config, rules, skills, and commands accrete; nothing reverses that by default. Before building a new mechanism, check whether an existing one already covers it — a hook/pulse/banner field often does (e.g. #750 pruned 7 slash-commands whose deterministic core already ran in hooks/launchd). Periodically census unused surface using the `command_usage`/`skill_usage` tables (#747/#744) via the `housekeeping-framework` rule. **Chesterton guard:** remove something only after verifying it is BOTH unused AND its function is covered elsewhere — essential complexity (provenance redundancy, safety guards) stays; only accidental complexity goes. Advisory, not hook-gated.
+
 **Session:** Start: read `CHANGELOG.md`, avoid failed approaches. End: commit -> append CHANGELOG -> push. **Commits:** After every meaningful unit. Never break tests. Git log = lab notes. Speed must not silence errors.
 
 **Pipeline Validation (ALL PROJECTS):** Before every commit: `parse("_targets.R")` MUST succeed. Code-as-string targets MUST `parse(text=code)` for R or `bash -n` for bash.


### PR DESCRIPTION
## Summary

- Adds a **Simplicity — subtractive-first** governing principle to `AGENTS.md` Core Rules (Option B: named principle + advisory housekeeping enforcement + Chesterton guard). Motivated by [#750](https://github.com/JohnGavin/llm/pull/750), which pruned 7 slash-commands whose deterministic core already ran in hooks/launchd.
- Adds an **Unused-surface census** section to `.claude/rules/housekeeping-framework.md`, wiring the principle to the `command_usage` ([#747](https://github.com/JohnGavin/llm/issues/747)) and `skill_usage` ([#744](https://github.com/JohnGavin/llm/issues/744)) tables — advisory only, never auto-deletes, requires the Chesterton guard (unused AND covered elsewhere) before removal.
- Adds an **"Always embed the issue/PR link"** rule to `.claude/rules/pr-shipping-discipline.md`: PR/issue references reported to the user must be rendered as embedded markdown links (e.g. `[#750](https://github.com/JohnGavin/llm/pull/750)`), never bare `#750`.

## Test plan

- [x] Prose-only changes to `AGENTS.md` and two rule files under `.claude/rules/` — no code/parsing surface.
- [ ] Reviewer confirms placement of the new principle/sections reads naturally in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)