### PR TITLE
fix(roborev): pin review backup agent/model to claude-code/sonnet

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -281,7 +281,11 @@ classify_backup_agent = ''
 # Override classifier backup model for this repo.
 classify_backup_model = ''
 # Backup agent for review in this repo.
-review_backup_agent = ''
+# #746: primary gemini pin (review_model_thorough) poisons the fallback when these
+# backup keys are empty — the backup inherits gemini's model. Pin the review backup
+# to claude-code/sonnet (the verified-working combo). If roborev's binary still
+# ignores these on the next gemini outage, the per-agent-pin fix is upstream.
+review_backup_agent = 'claude-code'
 # Backup agent for refine in this repo.
 refine_backup_agent = ''
 # Backup agent for fix in this repo.
@@ -291,7 +295,7 @@ security_backup_agent = ''
 # Backup agent for design review in this repo.
 design_backup_agent = ''
 # Backup model for review in this repo.
-review_backup_model = ''
+review_backup_model = 'sonnet'
 # Backup model for refine in this repo.
 refine_backup_model = ''
 # Backup model for fix in this repo.


### PR DESCRIPTION
## Summary

- Root cause: [#746](https://github.com/JohnGavin/llm/issues/746) — the primary gemini pin (`review_model_thorough = 'gemini-2.5-flash-lite'`, set in [#733](https://github.com/JohnGavin/llm/issues/733)) poisons the fallback when `review_backup_agent`/`review_backup_model` are left empty. The config's own comment on line ~176 ("codex backup uses `review_backup_model`") confirms the backup keys were meant to be set — they were empty, so on a gemini quota outage the backup silently inherited gemini's model instead of falling over to a working alternative.
- Fix: pin `review_backup_agent = 'claude-code'` and `review_backup_model = 'sonnet'` — the verified-working combo — and add a comment above `review_backup_agent` explaining why.
- Scope: only the two `review_backup_*` keys changed. `review_model` / `review_model_thorough` (the gemini primary pin) are untouched, and no other backup key (refine/fix/security/design) was touched.

## Caveat

roborev is a compiled binary, so this is a config-level lever, not a source fix. If roborev's fallback logic still ignores these keys on the next gemini outage, the correct fix is an upstream per-agent-pin change (tracked separately) rather than further config tweaks here.

## Test plan

- [x] `.roborev.toml` is TOML — no parser/build surface in this repo, verified by inspection only (only the two target keys changed, diff is `1 file changed, 6 insertions(+), 2 deletions(-)`).
- [ ] Verify empirically on the next gemini quota outage that the review backup now falls over to claude-code/sonnet instead of gemini.

Refs #746, #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)