### PR TITLE
fix(#749): source GMAIL creds in launchd-health-weekly so email step exits 0

### DIFF
--- a/bin/launchd_health_weekly_cron.sh
+++ b/bin/launchd_health_weekly_cron.sh
@@ -80,6 +80,17 @@ if [[ -f "$ENV_FILE" ]]; then
   log "sourced credentials from $ENV_FILE"
 fi
 
+# GMAIL creds for the Step 2 health email live in a separate secured env file
+# (the same one the roborev email cron sources — bin/roborev_weekly_rollup_cron.sh).
+# Without this, send_launchd_health_email.R aborts with "GMAIL_USERNAME or
+# GMAIL_APP_PASSWORD not set" and the whole job exits 1 (#749 Part A).
+EMAIL_ENV_FILE="$HOME/.claude/env/roborev_email.env"
+if [[ -f "$EMAIL_ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$EMAIL_ENV_FILE"
+  log "sourced email credentials from $EMAIL_ENV_FILE"
+fi
+
 # ── Deploy: pull latest main before running (llm#510) ─────────────────────────
 # Cron wrappers run against ${REPO_ROOT}; without this step every gh pr merge
 # ships nothing — the cron uses whatever was last manually pulled to the main


### PR DESCRIPTION
## What

`launchd-health-weekly` (the weekly cron-health monitor) exits `1` on every run. It was the **only** genuinely-failing job of the three flagged in #749 Part A — the other two (`self-review-stage1`, `roborev-weekly-rollup-email`) were misdiagnosed and are healthy (see the [#749 re-verification comment](https://github.com/JohnGavin/llm/issues/749#issuecomment-4915545868)).

## Root cause

Step 2 (`send_launchd_health_email.R`) aborts with `GMAIL_USERNAME or GMAIL_APP_PASSWORD not set`, which makes the job exit 1. The cron sources only `~/.claude/.env`, which does not carry the GMAIL creds. Those creds live in `~/.claude/env/roborev_email.env` — the file the *working* roborev email cron (`bin/roborev_weekly_rollup_cron.sh:40`) already sources.

## Fix

Also source `~/.claude/env/roborev_email.env` (guarded/optional), mirroring the roborev pattern. Minimal and reversible; `bash -n` clean.

## Not in scope (deliberately)

- The `fatal: not in a git directory` line is a cosmetic warning from a bare `git` call inside the R aggregator (report still generates) — not the exit-1 cause.
- `launchd_runs.duckdb ledger not found — first run` is self-healing.
- The Jun-28 `launchd_health_report_<date>.md: No such file` errors are **stale** (old script version), not present in the current code path.

`Refs #749` — leaves the issue open for its Part B email redesign.