### PR TITLE
feat(config-audit): FAIL tier + persisted oversized-config report

### DIFF
--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -292,15 +292,23 @@ phase_mappings() {
 }
 
 # ── Phase 3: Size Audit ──────────────────────────────────────────────
+# FAIL thresholds are ~2x the WARN limit per category (llm#749 Part B):
+# breaches are no longer scroll-past-only — they are counted (n_fail) and
+# persisted to $HOME/.claude/logs/oversized_config.txt for a future
+# pulse/overnight-email to surface as an owned artifact.
 phase_sizes() {
+  local -a _breaches=()
+
   check_file() {
     local file="$1" warn="$2" fail="$3" label="$4"
     [ -f "$file" ] || return
     local lines; lines=$(timeout 5 wc -l < "$file" 2>/dev/null || echo 0)
     if [ "$lines" -gt "$fail" ]; then
       echo "$label: $lines lines  FAIL (>$fail)"
+      _breaches+=("FAIL  $label  ${lines}/${fail}  $file")
     elif [ "$lines" -gt "$warn" ]; then
       echo "$label: $lines lines  WARN (>$warn)"
+      _breaches+=("WARN  $label  ${lines}/${warn}  $file")
     else
       echo "$label: $lines lines  OK"
     fi
@@ -310,10 +318,11 @@ phase_sizes() {
   [ -n "$MEMORY_DIR" ] && [ -f "$MEMORY_DIR/MEMORY.md" ] && check_file "$MEMORY_DIR/MEMORY.md" 150 200 "MEMORY.md"
 
   # Directory summaries (rules, skills, agents, commands)
-  for dir_info in "$RULES_DIR:150:Rules" "$SKILLS_DIR:500:Skills" "$AGENTS_DIR:300:Agents" "$COMMANDS_DIR:200:Commands"; do
-    IFS=: read -r dir limit label <<< "$dir_info"
+  # dir:warn:fail:label — fail is ~2x warn per category
+  for dir_info in "$RULES_DIR:150:300:Rules" "$SKILLS_DIR:500:800:Skills" "$AGENTS_DIR:300:450:Agents" "$COMMANDS_DIR:200:350:Commands"; do
+    IFS=: read -r dir limit faillimit label <<< "$dir_info"
     [ -d "$dir" ] || continue
-    local n=0 max_l=0 max_f="" total=0 n_warn=0
+    local n=0 max_l=0 max_f="" total=0 n_warn=0 n_fail=0
     local find_pattern="*.md"
     if [ "$label" = "Skills" ]; then
       while IFS= read -r -d '' f; do
@@ -321,7 +330,13 @@ phase_sizes() {
         n=$((n + 1)); total=$((total + l))
         local parent; parent=$(basename "$(dirname "$f")")
         [ "$l" -gt "$max_l" ] && { max_l=$l; max_f="$parent"; }
-        [ "$l" -gt "$limit" ] && n_warn=$((n_warn + 1))
+        if [ "$l" -gt "$faillimit" ]; then
+          n_fail=$((n_fail + 1))
+          _breaches+=("FAIL  $label  ${l}/${faillimit}  $f")
+        elif [ "$l" -gt "$limit" ]; then
+          n_warn=$((n_warn + 1))
+          _breaches+=("WARN  $label  ${l}/${limit}  $f")
+        fi
       done < <(find -L "$dir" -name "SKILL.md" -print0 2>/dev/null)
     else
       for f in "$dir"/*.md; do
@@ -329,16 +344,34 @@ phase_sizes() {
         local l; l=$(timeout 5 wc -l < "$f" 2>/dev/null || echo 0)
         n=$((n + 1)); total=$((total + l))
         [ "$l" -gt "$max_l" ] && { max_l=$l; max_f=$(basename "$f"); }
-        [ "$l" -gt "$limit" ] && n_warn=$((n_warn + 1))
+        if [ "$l" -gt "$faillimit" ]; then
+          n_fail=$((n_fail + 1))
+          _breaches+=("FAIL  $label  ${l}/${faillimit}  $f")
+        elif [ "$l" -gt "$limit" ]; then
+          n_warn=$((n_warn + 1))
+          _breaches+=("WARN  $label  ${l}/${limit}  $f")
+        fi
       done
     fi
     if [ "$n" -gt 0 ]; then
       local avg=$((total / n))
       local msg="$label ($n):  avg $avg, max $max_l ($max_f)"
-      [ "$n_warn" -gt 0 ] && msg="$msg  WARN: $n_warn files >$limit" || msg="$msg  OK"
+      [ "$n_fail" -gt 0 ] && msg="$msg  FAIL: $n_fail files >$faillimit"
+      [ "$n_warn" -gt 0 ] && msg="$msg  WARN: $n_warn files >$limit"
+      [ "$n_fail" -eq 0 ] && [ "$n_warn" -eq 0 ] && msg="$msg  OK"
       echo "$msg"
     fi
   done
+
+  # Persist an actionable oversized-config report (never block/error the hook)
+  {
+    local _report="${HOME}/.claude/logs/oversized_config.txt"
+    mkdir -p "$(dirname "$_report")" 2>/dev/null
+    {
+      echo "# oversized config as of $(date -u '+%Y-%m-%dT%H:%M:%S')"
+      [ "${#_breaches[@]}" -gt 0 ] && printf '%s\n' "${_breaches[@]}"
+    } > "$_report" 2>/dev/null
+  } 2>/dev/null || true
 }
 
 # ── Phase 4: Skill Token Audit ────────────────────────────────────────


### PR DESCRIPTION
## What

Gives the `session_init.sh` config-size audit **teeth**. It was WARN-only for rules/skills/agents/commands — breaches scrolled past the startup banner with no FAIL signal and no persisted record, so nobody acted on them. This is the accretion failure the Simplicity principle names ([#751](https://github.com/JohnGavin/llm/pull/751)).

## Changes (`.claude/hooks/session_init.sh` only)

1. **FAIL tier** per category (~2× the WARN limit): Rules `FAIL>300`, Skills `>800`, Agents `>450`, Commands `>350`. The directory summary now shows both `FAIL: N files >X` and `WARN: N files >Y`.
2. **Persisted actionable report** at `~/.claude/logs/oversized_config.txt`, overwritten each run, one `LEVEL  category  lines/limit  path` row per breach — an owned artifact a pulse/overnight-email can surface ([#749](https://github.com/JohnGavin/llm/issues/749) Part B).

## Verified (functional, not just `bash -n`)

Ran `phase_sizes` against the real config dirs with a sandboxed `HOME`:

```
Rules (76):  avg 132, max 608 (roborev-resolution.md)  FAIL: 2 files >300  WARN: 18 files >150
```

The 2 FAILs: `roborev-resolution.md` (608) and `mermaid-dashboard-pattern.md` (346). `oversized_config.txt` written correctly.

## Provenance

Recovered from a dispatch that authored this edit but died on a **spend-limit** API error before committing; the uncommitted patch was replayed clean onto `main` and re-verified.

## Follow-ups (not in this PR)

- Split the 3 always-loaded mandatory rules >200 lines (`auto-delegation` 236, `agent-identity` 246, `nix-agent-shell-protocol` 218) via `_companions/`.
- Surface `oversized_config.txt` in the #749 overnight-email redesign.

`Refs #749`