### PR TITLE
docs(memory): add embed-issue-link-on-merge feedback + index pointer

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -112,3 +112,6 @@ One hook line per topic; full detail lives in the linked file. Keep under ~140 l
 
 ## cc Startup Hang = npx/burn-rate no timeout (see cc-startup-hang-npx-timeout.md)
 - `cc` hangs after "Switched to worktree" = unbounded `npx ccusage` in burn_rate_check (GNU timeout absent on macOS → `${TIMEOUT_CMD:+…}` empty); unblock `npx --yes ccusage --version`; fix = perl-alarm fallback + npx --yes + </dev/null (#716, 2026-07-03)
+
+## Embed Issue/PR Links on Merge (see feedback_embed-issue-link-on-merge.md)
+- When reporting a merge/PR/issue action, embed a clickable link (`[#750](url)`) never a bare `#750`; codified in pr-shipping-discipline rule (#751, 2026-07-08)

--- a/.claude/memory/feedback_embed-issue-link-on-merge.md
+++ b/.claude/memory/feedback_embed-issue-link-on-merge.md
@@ -1,0 +1,18 @@
+---
+name: feedback-embed-issue-link-on-merge
+description: When merging/reporting a PR or issue, always embed a clickable link, never a bare number
+metadata:
+  type: feedback
+---
+
+When reporting a merge, a PR action, or referencing an issue to be merged/closed,
+ALWAYS include an embedded markdown link (e.g. `[#750](https://github.com/JohnGavin/llm/pull/750)`)
+rather than a bare `#750`. Applies to all projects, all future work — PR/merge
+summaries, session-end notes, CHANGELOG-adjacent prose reported to the user.
+
+**Why:** a bare number forces the user to hunt for the URL; an embedded link is
+one click. The user asked for this explicitly on 2026-07-08 right after merging #750.
+
+**How to apply:** in any user-facing report that names a PR/issue as the subject
+of an action (merge, close, open), render it as a clickable link to the exact
+GitHub URL. Codified in the `pr-shipping-discipline` rule (llm#751).


### PR DESCRIPTION
Persists the 2026-07-08 session feedback that PR/issue references in user-facing reports must be embedded markdown links (`[#750](url)`), never bare numbers. The enforced rule already merged in [#751](https://github.com/JohnGavin/llm/pull/751) (pr-shipping-discipline); this is its recall-memory twin. Committing so the main checkout stops showing the file as untracked. Two files, +21 lines.