### PR TITLE
refactor(rules): split oversized mandatory rules into _companions (1/3: agent-identity)

### DIFF
--- a/.claude/rules/_companions/agent-identity-details.md
+++ b/.claude/rules/_companions/agent-identity-details.md
@@ -1,0 +1,63 @@
+# Companion: Agent Identity & Task Scopes — Worked Example + Phase Roadmap
+
+Illustrative detail split out of the always-loaded [`agent-identity-and-task-scopes`](../agent-identity-and-task-scopes.md) rule to keep that mandatory rule lean. The normative content (CRITICAL statements, dispatch-ID propagation table, scope-block format, Forbidden Patterns) stays in the rule; this file is the worked example and roadmap, loaded on demand.
+
+## Worked Example
+
+```
+# Orchestrator mints identity
+DISPATCH_ID="3f8a1c2d-4b5e-6f7a-8c9d-0e1f2a3b4c5d"
+EXPIRES_AT="2026-06-05T15:00:00Z"   # 45 minutes from now
+
+# Orchestrator dispatches
+Agent(
+  subagent_type = "fixer",
+  isolation     = "worktree",
+  prompt = """
+**CRITICAL — Bash discipline:** [standard prefix]
+
+**CRITICAL — Worktree isolation:** Your worktree is /path/to/worktree
+[standard prefix]
+
+TASK SCOPE (dispatch_id=3f8a1c2d, expires=2026-06-05T15:00:00Z):
+  write-paths:
+    - /path/to/worktree/**
+  allowed-external-ops:
+    - gh pr create
+    - git push origin feat/fix-foo
+  forbidden-external-ops:
+    - gh pr merge
+    - writes to ~/.claude/**
+  ttl-minutes: 45
+
+Fix R/foo.R line 42: add NA check before division.
+Include in every commit footer:
+  Dispatch-Id: 3f8a1c2d
+  Agent-Type: fixer
+"""
+)
+
+# After agent completes, orchestrator runs post-verify
+~/.claude/scripts/agent-post-verify.sh check ~/docs_gh/llm --id "$DISPATCH_ID"
+
+# Audit: find everything the agent touched
+git log --all --grep="Dispatch-Id: 3f8a1c2d" --name-only --format=""
+```
+
+The agent commits with:
+
+```
+fix(R/foo.R): add NA check before division (#476)
+
+Dispatch-Id: 3f8a1c2d
+Agent-Type: fixer
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+## Phase Roadmap
+
+| Phase | What lands | Status |
+|---|---|---|
+| 1 (parent rule) | Dispatch ID protocol documented; commit footer format; scope block format | Shipped |
+| 2 | Hooks read identity env vars for expiry + scope checks | Future (llm#476) |
+| 3 | Helper script `mint-dispatch.sh` automates ID + scope block generation | Future |

--- a/.claude/rules/_companions/auto-delegation-cost-and-parallel.md
+++ b/.claude/rules/_companions/auto-delegation-cost-and-parallel.md
@@ -1,0 +1,30 @@
+# Companion: Auto-Delegation — Context Summarisation + Parallel Worktree Sessions
+
+Illustrative/edge-case detail split out of the always-loaded [`auto-delegation`](../auto-delegation.md) rule. The normative tier model, delegation tables, burn-rate escalation table, and `isolation:"worktree"` mandate stay in the rule; these two example-driven sections load on demand.
+
+## Lightweight Tier for Context Summarisation (Cost Compression)
+
+When `context_monitor.sh` reports ≥ 65% context usage, or before a loop expected to exceed 20 turns, **the orchestrator tier decides to delegate** the summarisation of `CURRENT_WORK.md` to the lightweight tier. This is a deliberate delegation decision by the orchestrator — it is not the lightweight tier autonomously writing session state. The orchestrator determines what to summarise and when; the lightweight tier executes the write:
+
+```
+Agent(
+  subagent_type = "quick-fix",
+  model = "haiku",  # lightweight tier
+  prompt = "Read CURRENT_WORK.md and the recent conversation state. Write a concise prose summary (max 300 words) of: (1) what was accomplished this session, (2) key decisions made and why, (3) exact next step. Overwrite CURRENT_WORK.md with this summary. No preamble."
+)
+```
+
+Triggers: context ≥ 65%, starting a `/loop`, or spawning 3+ sequential subagents. Do NOT trigger when context < 40% or during active debugging. The orchestrator tier retains ownership of CURRENT_WORK.md; the lightweight tier is a delegate writer, not an autonomous updater.
+
+## Parallel Worktree Sessions
+
+For independent tasks, spawn a worker-tier worktree session:
+
+```bash
+# Orchestrator creates worktree for delegated work
+git worktree add ../<repo>-<task> feat/<task>
+# User runs: cd ../<repo>-<task> && claude --model sonnet
+```
+
+Worktrees share `.git` and `.claude/` config. Each gets its own branch.
+Use `tar_config_set(store = "_targets_<branch>")` to isolate targets stores.

--- a/.claude/rules/_companions/nix-regen-overlay-recovery.md
+++ b/.claude/rules/_companions/nix-regen-overlay-recovery.md
@@ -1,0 +1,53 @@
+# Companion: Nix Agent Shell — Overlay-Recovery Workflow + Incident Log
+
+Detailed recovery workflow and the dated incident narratives split out of the always-loaded [`nix-agent-shell-protocol`](../nix-agent-shell-protocol.md) rule. The **normative MANDATORY pattern** (use cwd-safe Form A / Form B, never a bare absolute path) stays in the rule (see its "MANDATORY pattern when an agent regenerates a worktree's `default.nix`" section). This file is the incident evidence + the step-by-step overlay-recovery procedure, loaded on demand when actually regenerating a `default.nix` that carries hand-edited overlays.
+
+### Lesson logged 2026-05-02
+
+In the acd_area_climate_design project, a Stage 2 OSM agent regenerated default.nix in its worktree but the cwd resolved to the orchestrator's main checkout, stripping the udunits + shellHook patches. Detected when the orchestrator's render failed. Restored from HEAD. Filed observation issue and amended the rule.
+
+### Lesson logged 2026-05-08
+
+In the mycare project, regenerating default.nix to add testthat/here/withr stripped a manual `python312Packages.overrideScope` (`twisted.doCheck = false`) overlay needed to bypass the upstream pdfplumber → pandas → ibis → twisted test-failure cascade (JohnGavin/llm#62). The shellHook itself survived (it lives in default.R), but the nixpkgs overlay block — between the `let` keyword and the `pkgs = ...` line — does not, because rix() does not preserve hand-edited overlays.
+
+**Defensive workflow when regenerating default.nix:**
+
+Every regeneration call MUST use cwd-safe Form A (subshell) or Form B
+(`setwd()`), as documented in the parent rule. There is no safe exception: even when
+the caller appears to be in the right directory, worktree-orchestrator cwd
+drift can silently overwrite the wrong checkout.
+
+- **Form A** (subshell): `(cd /absolute/path/to/project && nix-shell ~/docs_gh/llm/default.nix --run "Rscript default.R")`
+- **Form B** (setwd): `nix-shell ~/docs_gh/llm/default.nix --run "Rscript -e 'setwd(\"/absolute/path/to/project\"); source(\"default.R\")'")`
+- **NEVER** use a bare absolute path: `nix-shell ... --run "Rscript /absolute/path/to/project/default.R"` — this is the pattern that caused the 2026-05-02 and 2026-05-08 incidents.
+
+Preferred — use a `default.post.sh` per project (idempotent shell script
+that re-applies the project's overlays):
+
+1. Regenerate using Form A:
+   `(cd /absolute/path/to/project && nix-shell ~/docs_gh/llm/default.nix --run "Rscript default.R")`
+2. `(cd /absolute/path/to/project && ./default.post.sh)` —
+   re-apply overlays. Script must be idempotent and detect
+   "already applied" via a `grep -q "marker" "$NIX_FILE"` guard.
+3. Verify by entering the shell and loading affected packages.
+
+Fallback — when no `default.post.sh` exists yet:
+
+1. `cp /absolute/path/to/project/default.nix /absolute/path/to/project/default.nix.pre-regen.bak`
+2. Regenerate using Form A:
+   `(cd /absolute/path/to/project && nix-shell ~/docs_gh/llm/default.nix --run "Rscript default.R")`
+3. `diff /absolute/path/to/project/default.nix.pre-regen.bak /absolute/path/to/project/default.nix` — eyeball stripped sections
+4. Re-apply overlays manually
+5. Verify
+6. `rm /absolute/path/to/project/default.nix.pre-regen.bak`
+7. **Capture the manual steps as a `default.post.sh`** so the next regen
+   is automatic (and add `default.nix.bak` to `.gitignore`).
+
+Survey for hand-crafted overlays before regen with:
+`grep -E "extend|overrideScope|overridePythonAttrs|disabledTestPaths" default.nix`
+
+Known projects with `default.post.sh`:
+
+| Project | Overlay re-applied | Reason |
+|---|---|---|
+| `mycare` | `python312Packages.twisted.doCheck = false` | pdfplumber→pandas→ibis→twisted build cascade (JohnGavin/llm#62) |

--- a/.claude/rules/agent-identity-and-task-scopes.md
+++ b/.claude/rules/agent-identity-and-task-scopes.md
@@ -171,67 +171,11 @@ unambiguous.
 
 ---
 
-## Worked Example
+## Worked Example & Phase Roadmap
 
-```
-# Orchestrator mints identity
-DISPATCH_ID="3f8a1c2d-4b5e-6f7a-8c9d-0e1f2a3b4c5d"
-EXPIRES_AT="2026-06-05T15:00:00Z"   # 45 minutes from now
-
-# Orchestrator dispatches
-Agent(
-  subagent_type = "fixer",
-  isolation     = "worktree",
-  prompt = """
-**CRITICAL — Bash discipline:** [standard prefix]
-
-**CRITICAL — Worktree isolation:** Your worktree is /path/to/worktree
-[standard prefix]
-
-TASK SCOPE (dispatch_id=3f8a1c2d, expires=2026-06-05T15:00:00Z):
-  write-paths:
-    - /path/to/worktree/**
-  allowed-external-ops:
-    - gh pr create
-    - git push origin feat/fix-foo
-  forbidden-external-ops:
-    - gh pr merge
-    - writes to ~/.claude/**
-  ttl-minutes: 45
-
-Fix R/foo.R line 42: add NA check before division.
-Include in every commit footer:
-  Dispatch-Id: 3f8a1c2d
-  Agent-Type: fixer
-"""
-)
-
-# After agent completes, orchestrator runs post-verify
-~/.claude/scripts/agent-post-verify.sh check ~/docs_gh/llm --id "$DISPATCH_ID"
-
-# Audit: find everything the agent touched
-git log --all --grep="Dispatch-Id: 3f8a1c2d" --name-only --format=""
-```
-
-The agent commits with:
-
-```
-fix(R/foo.R): add NA check before division (#476)
-
-Dispatch-Id: 3f8a1c2d
-Agent-Type: fixer
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
-```
-
----
-
-## Phase Roadmap
-
-| Phase | What lands | Status |
-|---|---|---|
-| 1 (this rule) | Dispatch ID protocol documented; commit footer format; scope block format | Shipped |
-| 2 | Hooks read identity env vars for expiry + scope checks | Future (llm#476) |
-| 3 | Helper script `mint-dispatch.sh` automates ID + scope block generation | Future |
+See [`_companions/agent-identity-details.md`](_companions/agent-identity-details.md)
+for the full dispatch worked example (mint → dispatch → post-verify → audit) and
+the phase roadmap. The normative protocol above is complete without it.
 
 ---
 

--- a/.claude/rules/auto-delegation.md
+++ b/.claude/rules/auto-delegation.md
@@ -67,17 +67,7 @@ Agent(subagent_type="quick-fix", model="haiku",  # lightweight tier
 
 ## Lightweight Tier for Context Summarisation (Cost Compression)
 
-When `context_monitor.sh` reports ≥ 65% context usage, or before a loop expected to exceed 20 turns, **the orchestrator tier decides to delegate** the summarisation of `CURRENT_WORK.md` to the lightweight tier. This is a deliberate delegation decision by the orchestrator — it is not the lightweight tier autonomously writing session state. The orchestrator determines what to summarise and when; the lightweight tier executes the write:
-
-```
-Agent(
-  subagent_type = "quick-fix",
-  model = "haiku",  # lightweight tier
-  prompt = "Read CURRENT_WORK.md and the recent conversation state. Write a concise prose summary (max 300 words) of: (1) what was accomplished this session, (2) key decisions made and why, (3) exact next step. Overwrite CURRENT_WORK.md with this summary. No preamble."
-)
-```
-
-Triggers: context ≥ 65%, starting a `/loop`, or spawning 3+ sequential subagents. Do NOT trigger when context < 40% or during active debugging. The orchestrator tier retains ownership of CURRENT_WORK.md; the lightweight tier is a delegate writer, not an autonomous updater.
+At ≥ 65% context usage (or before a >20-turn `/loop`, or when spawning 3+ sequential subagents), the orchestrator tier delegates the `CURRENT_WORK.md` summary write to the lightweight tier — it decides what/when; the lightweight tier only executes. Do NOT trigger below 40% or during active debugging. Trigger detail + example prompt: [`_companions/auto-delegation-cost-and-parallel.md`](_companions/auto-delegation-cost-and-parallel.md).
 
 ## CRITICAL: Do Not Use Orchestrator Tier for Worker-Tier Work
 
@@ -224,13 +214,4 @@ read-only re-audit ran with no worktrees. See `agent-identity-and-task-scopes`
 
 ## Parallel Worktree Sessions
 
-For independent tasks, spawn a worker-tier worktree session:
-
-```bash
-# Orchestrator creates worktree for delegated work
-git worktree add ../<repo>-<task> feat/<task>
-# User runs: cd ../<repo>-<task> && claude --model sonnet
-```
-
-Worktrees share `.git` and `.claude/` config. Each gets its own branch.
-Use `tar_config_set(store = "_targets_<branch>")` to isolate targets stores.
+For independent tasks, spawn a worker-tier worktree session (`git worktree add` + `claude --model sonnet`); worktrees share `.git`/`.claude/`, each on its own branch. Full example + targets-store isolation: [`_companions/auto-delegation-cost-and-parallel.md`](_companions/auto-delegation-cost-and-parallel.md).

--- a/.claude/rules/nix-agent-shell-protocol.md
+++ b/.claude/rules/nix-agent-shell-protocol.md
@@ -153,55 +153,14 @@ grep -c gnu89 <main-checkout>/default.nix  # 0 means patches were stripped
 
 Recovery: `git -C <main-checkout> checkout HEAD -- default.nix`.
 
-### Lesson logged 2026-05-02
+### Incident log + overlay-recovery workflow
 
-In the acd_area_climate_design project, a Stage 2 OSM agent regenerated default.nix in its worktree but the cwd resolved to the orchestrator's main checkout, stripping the udunits + shellHook patches. Detected when the orchestrator's render failed. Restored from HEAD. Filed observation issue and amended this rule.
-
-### Lesson logged 2026-05-08
-
-In the mycare project, regenerating default.nix to add testthat/here/withr stripped a manual `python312Packages.overrideScope` (`twisted.doCheck = false`) overlay needed to bypass the upstream pdfplumber → pandas → ibis → twisted test-failure cascade (JohnGavin/llm#62). The shellHook itself survived (it lives in default.R), but the nixpkgs overlay block — between the `let` keyword and the `pkgs = ...` line — does not, because rix() does not preserve hand-edited overlays.
-
-**Defensive workflow when regenerating default.nix:**
-
-Every regeneration call MUST use cwd-safe Form A (subshell) or Form B
-(`setwd()`), as documented above. There is no safe exception: even when
-the caller appears to be in the right directory, worktree-orchestrator cwd
-drift can silently overwrite the wrong checkout.
-
-- **Form A** (subshell): `(cd /absolute/path/to/project && nix-shell ~/docs_gh/llm/default.nix --run "Rscript default.R")`
-- **Form B** (setwd): `nix-shell ~/docs_gh/llm/default.nix --run "Rscript -e 'setwd(\"/absolute/path/to/project\"); source(\"default.R\")'")`
-- **NEVER** use a bare absolute path: `nix-shell ... --run "Rscript /absolute/path/to/project/default.R"` — this is the pattern that caused the 2026-05-02 and 2026-05-08 incidents.
-
-Preferred — use a `default.post.sh` per project (idempotent shell script
-that re-applies the project's overlays):
-
-1. Regenerate using Form A:
-   `(cd /absolute/path/to/project && nix-shell ~/docs_gh/llm/default.nix --run "Rscript default.R")`
-2. `(cd /absolute/path/to/project && ./default.post.sh)` —
-   re-apply overlays. Script must be idempotent and detect
-   "already applied" via a `grep -q "marker" "$NIX_FILE"` guard.
-3. Verify by entering the shell and loading affected packages.
-
-Fallback — when no `default.post.sh` exists yet:
-
-1. `cp /absolute/path/to/project/default.nix /absolute/path/to/project/default.nix.pre-regen.bak`
-2. Regenerate using Form A:
-   `(cd /absolute/path/to/project && nix-shell ~/docs_gh/llm/default.nix --run "Rscript default.R")`
-3. `diff /absolute/path/to/project/default.nix.pre-regen.bak /absolute/path/to/project/default.nix` — eyeball stripped sections
-4. Re-apply overlays manually
-5. Verify
-6. `rm /absolute/path/to/project/default.nix.pre-regen.bak`
-7. **Capture the manual steps as a `default.post.sh`** so the next regen
-   is automatic (and add `default.nix.bak` to `.gitignore`).
-
-Survey for hand-crafted overlays before regen with:
-`grep -E "extend|overrideScope|overridePythonAttrs|disabledTestPaths" default.nix`
-
-Known projects with `default.post.sh`:
-
-| Project | Overlay re-applied | Reason |
-|---|---|---|
-| `mycare` | `python312Packages.twisted.doCheck = false` | pdfplumber→pandas→ibis→twisted build cascade (JohnGavin/llm#62) |
+Two real incidents (2026-05-02 acd_area_climate_design, 2026-05-08 mycare) where a
+bare-path regeneration stripped hand-edited overlays, plus the full `default.post.sh`
+overlay-recovery procedure (preferred + fallback steps, and the known-projects table),
+are in [`_companions/nix-regen-overlay-recovery.md`](_companions/nix-regen-overlay-recovery.md).
+The MANDATORY rule is unchanged and stated above: every regeneration MUST use cwd-safe
+Form A or Form B, NEVER a bare absolute path.
 
 ## Why This Architecture
 


### PR DESCRIPTION
## What

Reduces the always-loaded context cost of the mandatory rules the config-audit FAIL tier ([#754](https://github.com/JohnGavin/llm/pull/754)) flagged, by moving **purely-illustrative** content into on-demand `_companions/` files. These rules load into *every session and every subagent* (doubled in worktree sessions), so their size is paid constantly.

## This PR (1 of 3)

**`agent-identity-and-task-scopes.md`: 246 → 190** (−56 always-loaded lines). Moved the dispatch **Worked Example** and **Phase Roadmap** into `_companions/agent-identity-details.md` (63 lines, on-demand), leaving a pointer.

**Nothing a dispatch decision depends on was moved.** Every normative section stays in the rule: the CRITICAL identity statement, the dispatch-ID propagation table, the scope-block format, symlink-trapped paths, the expiring-permissions table, and the Forbidden Patterns table.

## Follow-ups (same pattern, on your go-ahead)

- `auto-delegation.md` (236) — move the context-summarisation example, burn-rate table, and parallel-worktree example to a companion.
- `nix-agent-shell-protocol.md` (218) — move the two dated incident "Lessons logged" narratives to a companion.

Held separately because these are safety-critical dispatch/environment rules and worth reviewing the pattern (this PR) before applying it twice more.

`Refs #749`