### PR TITLE
feat(wiki): schema-driven frontmatter validation (llm#759 Phase 1)

### DIFF
--- a/.claude/rules/wiki-conventions.md
+++ b/.claude/rules/wiki-conventions.md
@@ -61,6 +61,15 @@ Modifying `raw/` corrupts provenance chain and creates "AI output → input" fee
 
 ## Part 3: Wiki Frontmatter (MANDATORY)
 
+Required fields and enum values (`status`, `consensus_level`) are validated
+against `.claude/schema/wiki-frontmatter.schema.json` — the single source of
+truth `wiki_health_check.sh` reads via `jq` (llm#759 Phase 1). Update the
+schema file, not the hardcoded lists in the script, when the frontmatter
+contract changes. Note: as of Phase 1 the schema's `consensus_level` enum is
+`high | direct` (the vocabulary actually in use across the wiki), which
+diverges from the broader `unanimous | strong | split | divergent | direct`
+vocabulary documented below — reconciling the two is an open follow-up.
+
 Every `wiki/*.md` file starts with:
 
 ```yaml

--- a/.claude/schema/wiki-frontmatter.schema.json
+++ b/.claude/schema/wiki-frontmatter.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/JohnGavin/llm/main/.claude/schema/wiki-frontmatter.schema.json",
+  "title": "Wiki Page Frontmatter",
+  "description": "Single source of truth for required fields and enum values in ~/docs_gh/llm/knowledge/wiki/*.md YAML frontmatter. Consumed by .claude/scripts/wiki_health_check.sh (jq-driven); the wiki-conventions rule documents the same fields for humans. See llm#759 (Phase 1: knowledge-DAG architecture).",
+  "type": "object",
+  "required": [
+    "title",
+    "canonical_question",
+    "status",
+    "fresh_until",
+    "consensus_level",
+    "sources"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable page title."
+    },
+    "canonical_question": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The single question this page answers — the DAG node's identity."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["active", "stale", "superseded"],
+      "description": "Lifecycle status. active=current, stale=past fresh_until and unreviewed, superseded=replaced by a newer page."
+    },
+    "fresh_until": {
+      "type": "string",
+      "format": "date",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "description": "ISO 8601 date (YYYY-MM-DD) after which the page should be reviewed for staleness."
+    },
+    "consensus_level": {
+      "type": "string",
+      "enum": ["high", "direct"],
+      "description": "Page-level agreement across sources. NOTE: this enum reflects the vocabulary actually in use across the 10 conforming wiki pages as of llm#759 Phase 1 (high, direct), NOT the older 5-value vocabulary (unanimous/strong/split/divergent/direct) documented in wiki-conventions.md. Reconciling the two vocabularies is a follow-up — see llm#759 PR discussion."
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "description": "List of raw/ source files this page was compiled from.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "description": "Optional free-form tags.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "compiled_by": {
+      "type": "string",
+      "description": "Optional. Tier that compiled the page (do not hardcode model IDs — see auto-delegation rule)."
+    },
+    "compiled_on": {
+      "type": "string",
+      "format": "date",
+      "description": "Optional. ISO 8601 date the page was compiled."
+    }
+  }
+}

--- a/.claude/scripts/wiki_health_check.sh
+++ b/.claude/scripts/wiki_health_check.sh
@@ -57,6 +57,35 @@ report=""
 log_error() { errors=$((errors + 1)); report="$report\n  ERROR: $1"; }
 log_warn()  { warnings=$((warnings + 1)); report="$report\n  WARN: $1"; }
 
+# ── Frontmatter schema (llm#759 Phase 1) ──
+# Required fields, status enum, and consensus_level enum are derived from
+# .claude/schema/wiki-frontmatter.schema.json (single source of truth) via
+# jq. If jq or the schema file is unavailable, fail open: fall back to the
+# pre-schema hardcoded lists and skip consensus_level enum validation
+# (matches historical behaviour exactly — do not fail the hook on machines
+# without jq).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SCHEMA_FILE="$SCRIPT_DIR/../schema/wiki-frontmatter.schema.json"
+
+SCHEMA_OK=0
+if command -v jq >/dev/null 2>&1 && [ -f "$SCHEMA_FILE" ]; then
+  if mapfile -t REQUIRED_FIELDS < <(jq -r '.required[]' "$SCHEMA_FILE" 2>/dev/null) \
+     && [ "${#REQUIRED_FIELDS[@]}" -gt 0 ] \
+     && mapfile -t STATUS_ENUM < <(jq -r '.properties.status.enum[]' "$SCHEMA_FILE" 2>/dev/null) \
+     && [ "${#STATUS_ENUM[@]}" -gt 0 ] \
+     && mapfile -t CONSENSUS_ENUM < <(jq -r '.properties.consensus_level.enum[]' "$SCHEMA_FILE" 2>/dev/null) \
+     && [ "${#CONSENSUS_ENUM[@]}" -gt 0 ]; then
+    SCHEMA_OK=1
+  fi
+fi
+
+if [ "$SCHEMA_OK" -eq 0 ]; then
+  echo "WARN: jq or $SCHEMA_FILE unavailable — falling back to built-in frontmatter lists (no consensus_level enum validation)" >&2
+  REQUIRED_FIELDS=(title canonical_question status fresh_until consensus_level sources)
+  STATUS_ENUM=(active stale superseded)
+  CONSENSUS_ENUM=(unanimous strong split divergent direct)
+fi
+
 # ── Frontmatter extraction ──
 # Extract a single field from YAML frontmatter. Usage: get_fm FILE FIELD
 get_fm() {
@@ -81,8 +110,7 @@ check_frontmatter() {
     return 1
   fi
 
-  local required=("title" "canonical_question" "status" "fresh_until" "consensus_level" "sources")
-  for field in "${required[@]}"; do
+  for field in "${REQUIRED_FIELDS[@]}"; do
     if [ -z "$(get_fm "$file" "$field")" ]; then
       # sources is a list; check differently
       if [ "$field" = "sources" ]; then
@@ -118,11 +146,28 @@ check_lifecycle() {
   local file="$1"
   local status
   status=$(get_fm "$file" "status")
-  case "$status" in
-    active|stale|superseded) ;;
-    "") ;;  # handled by check_frontmatter
-    *) log_error "$file: invalid status '$status' (must be active|stale|superseded)" ;;
-  esac
+  [ -z "$status" ] && return 0  # handled by check_frontmatter
+  local ok=0
+  for v in "${STATUS_ENUM[@]}"; do
+    [ "$status" = "$v" ] && { ok=1; break; }
+  done
+  [ "$ok" -eq 0 ] && log_error "$file: invalid status '$status' (must be one of: ${STATUS_ENUM[*]})"
+}
+
+# Check consensus_level against schema enum (llm#759 Phase 1 — previously
+# unvalidated). No-op in fallback mode (SCHEMA_OK=0) since the fallback
+# vocabulary is display-only, matching pre-schema behaviour exactly.
+check_consensus() {
+  [ "$SCHEMA_OK" -eq 0 ] && return 0
+  local file="$1"
+  local consensus
+  consensus=$(get_fm "$file" "consensus_level")
+  [ -z "$consensus" ] && return 0  # handled by check_frontmatter
+  local ok=0
+  for v in "${CONSENSUS_ENUM[@]}"; do
+    [ "$consensus" = "$v" ] && { ok=1; break; }
+  done
+  [ "$ok" -eq 0 ] && log_error "$file: invalid consensus_level '$consensus' (must be one of: ${CONSENSUS_ENUM[*]})"
 }
 
 # Check 1: Provenance — every wiki/*.md has ## Sources section
@@ -171,6 +216,7 @@ if [ -n "$SINGLE_FILE" ]; then
         check_provenance "$SINGLE_FILE"
         check_staleness "$SINGLE_FILE"
         check_lifecycle "$SINGLE_FILE"
+        check_consensus "$SINGLE_FILE"
       fi
       dead=$(check_wiki_links "$SINGLE_FILE")
       if [ -n "$dead" ]; then
@@ -216,6 +262,7 @@ for f in "$WIKI_DIR"/*.md; do
   if head -1 "$f" 2>/dev/null | grep -q "^---$"; then
     files_with_frontmatter=$((files_with_frontmatter + 1))
     check_frontmatter "$f" 2>/dev/null
+    check_consensus "$f" 2>/dev/null
 
     status=$(get_fm "$f" "status")
     [ "$status" = "stale" ] && stale_pages=$((stale_pages + 1))
@@ -318,7 +365,7 @@ else
   if [ "${#consensus_counts[@]}" -gt 0 ]; then
     echo ""
     echo "Consensus levels (frontmatter):"
-    for level in unanimous strong split divergent direct; do
+    for level in "${CONSENSUS_ENUM[@]}"; do
       count="${consensus_counts[$level]:-0}"
       [ "$count" -gt 0 ] && echo "  $level: $count"
     done


### PR DESCRIPTION
## Summary

Phase 1 of the knowledge-DAG architecture ([llm#759](https://github.com/JohnGavin/llm/issues/759)): a machine-checkable JSON Schema for wiki frontmatter that becomes the single source of truth for required fields + enum values, replacing the hardcoded lists inside `.claude/scripts/wiki_health_check.sh`.

- New `.claude/schema/wiki-frontmatter.schema.json` (JSON Schema draft 2020-12): required fields (`title`, `canonical_question`, `status`, `fresh_until`, `consensus_level`, `sources`), `status` enum (`active|stale|superseded`), `consensus_level` enum (`high|direct`).
- `wiki_health_check.sh` now derives `REQUIRED_FIELDS`, `STATUS_ENUM`, and `CONSENSUS_ENUM` from the schema via `jq` instead of hardcoding them, and adds `consensus_level` enum validation (previously absent — an out-of-enum value is now an ERROR, exit 2, same class as an invalid `status`).
- Fixes a silent display bug: the full-mode consensus-level summary iterated a fixed 5-value list (`unanimous strong split divergent direct`) that never included `high`, so 6 of the 10 real wiki pages were silently dropped from the report even though they were counted internally. Confirmed live: before this PR the report showed `direct: 4` only; after, it shows `high: 6` / `direct: 4`.
- **Fail-open fallback**: if `jq` or the schema file is unavailable, the script emits one `WARN` and falls back to the pre-schema hardcoded lists with `consensus_level` validation disabled — byte-for-byte the old behaviour. Verified by running the script with the schema file absent.
- `wiki-conventions.md` updated with a pointer to the schema as the source of truth.

## Schema location deviation

llm#759 (and the fable plan referenced in the dispatch) named `knowledge/schema/` as the target location. `knowledge/` is a separate, local-only git repo (never pushed, per the `knowledge-base-wiki` skill) and is not present in agent worktrees — it was read-only for this change. Co-locating the schema with its only consumer (the checker) in this repo is the correct call: it is versioned with the checker, ships in CI, and is testable here. Used `.claude/schema/wiki-frontmatter.schema.json` instead.

## Follow-up needed from a human

The `consensus_level` vocabulary actually in use across the 10 conforming wiki pages is `high` / `direct` only. This diverges from the broader vocabulary documented in `wiki-conventions.md` (`unanimous | strong | split | divergent | direct`) and from the vocabulary discussed in `roborev-eval-sample.md`, which flags `high` itself as an inconsistent addition. Phase 1 adopts reality (`high`/`direct`) into the schema to stay non-breaking against existing pages — no page's `consensus_level` value was changed in this PR. Someone should decide the canonical vocabulary going forward as a content-design follow-up (either broaden the schema enum to the original 5 values, or migrate existing `high` pages to a value from that set).

## Test plan

All commands run against the real wiki data (read-only) and fixtures under `/tmp` (not committed):

- [x] `bash -n .claude/scripts/wiki_health_check.sh` — syntax OK
- [x] Full run against `/Users/johngavin/docs_gh/llm/knowledge/wiki` (10 conforming pages + 4 pre-existing non-conforming legacy pages unrelated to this change): exit `2`, unchanged from baseline (9 errors / 5 warnings before and after — no new errors introduced). **Note:** this diverges from the dispatch's literal acceptance criterion of "exit 0 or 1" — that assumed a clean baseline, but the real wiki directory already contained 4 non-conforming legacy pages (`lessons-learned.md`, `lessons-learned-pkgdown-deploy-gap.md`, `roborev-eval-sample.md`, `roborev-patterns.md`) that fail frontmatter checks independent of this PR. Fixing those is out of scope (would mean editing the read-only `knowledge/` repo or changing unrelated check behaviour).
- [x] Consensus summary now shows `high: 6` / `direct: 4` (previously silently dropped `high`).
- [x] Fixture dir with 3 pages (clean, missing required field, invalid `consensus_level: bogus`):
  - `--single` on clean page: exit `0`
  - `--single` on missing-field page: exit `2` (`ERROR: ... missing 'status' in frontmatter`)
  - `--single` on bad-consensus page: exit `2` (`ERROR: ... invalid consensus_level 'bogus' (must be one of: high direct)`)
  - Full-mode run on the 3-file fixture dir: exit `2`, both errors reported
- [x] `--json` and `--quiet` modes still work
- [x] jq/schema-absent fallback verified (schema file hidden, `jq` still present): one `WARN` emitted, `consensus_level` validation skipped, required-field check still fires — byte-for-byte old behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)