### PR TITLE
feat(wiki): migrate consensus_level vocab + exempt-marker mechanism (llm#759 1B/2B)

### DIFF
--- a/.claude/rules/wiki-conventions.md
+++ b/.claude/rules/wiki-conventions.md
@@ -65,10 +65,10 @@ Required fields and enum values (`status`, `consensus_level`) are validated
 against `.claude/schema/wiki-frontmatter.schema.json` — the single source of
 truth `wiki_health_check.sh` reads via `jq` (llm#759 Phase 1). Update the
 schema file, not the hardcoded lists in the script, when the frontmatter
-contract changes. Note: as of Phase 1 the schema's `consensus_level` enum is
-`high | direct` (the vocabulary actually in use across the wiki), which
-diverges from the broader `unanimous | strong | split | divergent | direct`
-vocabulary documented below — reconciling the two is an open follow-up.
+contract changes. As of llm#759 Phase 2 the schema's `consensus_level` enum
+is `unanimous | strong | split | divergent | direct` — the same vocabulary
+documented below (Part 5). The interim Phase-1 `high | direct` vocabulary is
+retired; existing pages using `high` are migrated to `strong` separately.
 
 Every `wiki/*.md` file starts with:
 
@@ -94,6 +94,24 @@ tags: [list]                        # may
 | Market structure | 30-60 days |
 | Strategy details | 90 days |
 | Historical/theoretical | 1 year |
+
+### Exempt Pages (`<!-- wiki:exempt -->`)
+
+Hub, index, and worksheet pages that are not themselves source-compiled
+content (e.g. a topic-index page listing links, a scratch worksheet) do not
+carry frontmatter or a `## Sources` section. Mark such a page by making its
+**first line** exactly:
+
+```
+<!-- wiki:exempt -->
+```
+
+`wiki_health_check.sh` (llm#759 Phase 2) skips the frontmatter, provenance,
+staleness, and lifecycle checks for exempt pages in both `--single` and full
+mode, and excludes them from the frontmatter/sources denominators in the
+full-mode report (`exempt_pages` count). The dead-`[[wiki-link]]` check still
+runs — exemption is not a license for broken links. Use sparingly: `INDEX.md`
+and `LOG.md` are already exempt by filename and do not need the marker.
 
 ---
 

--- a/.claude/schema/wiki-frontmatter.schema.json
+++ b/.claude/schema/wiki-frontmatter.schema.json
@@ -37,8 +37,8 @@
     },
     "consensus_level": {
       "type": "string",
-      "enum": ["high", "direct"],
-      "description": "Page-level agreement across sources. NOTE: this enum reflects the vocabulary actually in use across the 10 conforming wiki pages as of llm#759 Phase 1 (high, direct), NOT the older 5-value vocabulary (unanimous/strong/split/divergent/direct) documented in wiki-conventions.md. Reconciling the two vocabularies is a follow-up — see llm#759 PR discussion."
+      "enum": ["unanimous", "strong", "split", "divergent", "direct"],
+      "description": "Page-level agreement across sources: unanimous=all sources agree, strong=agree on core/differ on edges, split=substantive divergence, divergent=fundamentally different conclusions, direct=single source/summary. Migrated from the interim Phase-1 (high, direct) vocabulary to this 5-value vocabulary in llm#759 Phase 2 — see wiki-conventions.md Part 5."
     },
     "sources": {
       "type": "array",

--- a/.claude/scripts/wiki_health_check.sh
+++ b/.claude/scripts/wiki_health_check.sh
@@ -170,6 +170,17 @@ check_consensus() {
   [ "$ok" -eq 0 ] && log_error "$file: invalid consensus_level '$consensus' (must be one of: ${CONSENSUS_ENUM[*]})"
 }
 
+# Exempt hub/worksheet pages (llm#759 Phase 2) — a page whose first line is
+# exactly "<!-- wiki:exempt -->" is not source-compiled content (e.g. a hub,
+# index, or worksheet page) and is skipped for frontmatter, provenance,
+# staleness, and lifecycle checks. It still runs the dead-[[wiki-link]] check.
+is_exempt() {
+  local file="$1"
+  local first_line
+  first_line=$(head -1 "$file" 2>/dev/null)
+  [ "$first_line" = "<!-- wiki:exempt -->" ]
+}
+
 # Check 1: Provenance — every wiki/*.md has ## Sources section
 check_provenance() {
   local file="$1"
@@ -210,8 +221,8 @@ if [ -n "$SINGLE_FILE" ]; then
   case "$SINGLE_FILE" in
     */wiki/*.md)
       base=$(basename "$SINGLE_FILE")
-      # INDEX.md and LOG.md don't need frontmatter or provenance
-      if [ "$base" != "INDEX.md" ] && [ "$base" != "LOG.md" ]; then
+      # INDEX.md, LOG.md, and wiki:exempt pages don't need frontmatter or provenance
+      if [ "$base" != "INDEX.md" ] && [ "$base" != "LOG.md" ] && ! is_exempt "$SINGLE_FILE"; then
         check_frontmatter "$SINGLE_FILE"
         check_provenance "$SINGLE_FILE"
         check_staleness "$SINGLE_FILE"
@@ -248,6 +259,7 @@ superseded_pages=0
 total_inferred=0
 total_hypothesis=0
 total_conflicting=0
+exempt_pages=0
 dead_links=()
 declare -A consensus_counts=()
 
@@ -256,6 +268,18 @@ for f in "$WIKI_DIR"/*.md; do
   base=$(basename "$f")
   [ "$base" = "INDEX.md" ] && continue
   [ "$base" = "LOG.md" ] && continue
+
+  # wiki:exempt pages (hub/index/worksheet, not source-compiled content):
+  # skip frontmatter/provenance/staleness/lifecycle checks and exclude from
+  # the frontmatter/sources denominators, but still check dead wiki links.
+  if is_exempt "$f"; then
+    exempt_pages=$((exempt_pages + 1))
+    while IFS= read -r line; do
+      [ -n "$line" ] && dead_links+=("$line")
+    done < <(check_wiki_links "$f")
+    continue
+  fi
+
   total_files=$((total_files + 1))
 
   # Frontmatter check
@@ -332,6 +356,7 @@ fi
 if [ $JSON -eq 1 ]; then
   echo "{"
   echo "  \"total_files\": $total_files,"
+  echo "  \"exempt_pages\": $exempt_pages,"
   echo "  \"files_with_frontmatter\": $files_with_frontmatter,"
   echo "  \"files_with_sources\": $files_with_sources,"
   echo "  \"stale_pages\": $stale_pages,"
@@ -351,6 +376,7 @@ else
   echo "Today:      $TODAY"
   echo ""
   echo "Files:                $total_files"
+  echo "Exempt pages:         $exempt_pages"
   echo "With frontmatter:     $files_with_frontmatter / $total_files"
   echo "With ## Sources:      $files_with_sources / $total_files"
   echo "Stale pages:          $stale_pages"


### PR DESCRIPTION
Phase 2 of llm#759 (the knowledge-DAG architecture). Follow-ups **1B** and **2B** — the **code half**. The paired content migration (knowledge pages) is committed separately to the local-only `knowledge/` repo (it is never pushed).

## 1B — migrate the `consensus_level` vocabulary

`.claude/schema/wiki-frontmatter.schema.json`: enum `["high","direct"]` → `["unanimous","strong","split","divergent","direct"]`. The interim `{high,direct}` set from Phase 1 conflated a confidence word (`high`) with a provenance word (`direct`); the 5-value set is a real agreement scale. This is exactly the fix roborev flagged in review id=1260 (2026-05-16). The 6 evidence-investing pages that used `high` were migrated to `strong` in the knowledge repo.

## 2B — exempt hub/worksheet pages so `exit 2` stays a real alarm

`.claude/scripts/wiki_health_check.sh`: a page whose **first line is `<!-- wiki:exempt -->`** is skipped for frontmatter / provenance / staleness / lifecycle checks (like `INDEX.md`/`LOG.md` are by basename), but still runs the dead-`[[link]]` check. Full mode tracks and reports `exempt_pages` in both text and `--json`. Applied to the two genuine non-content pages (`lessons-learned.md` hub, `roborev-eval-sample.md` worksheet); the two real content pages (`roborev-patterns.md`, `lessons-learned-pkgdown-deploy-gap.md`) had frontmatter backfilled instead.

## Docs

`.claude/rules/wiki-conventions.md`: documents the new vocabulary (schema is source of truth) and the `<!-- wiki:exempt -->` marker.

## Verification (end-to-end, against the migrated knowledge pages)

```
Files: 13   Exempt pages: 2   With frontmatter: 13/13   With ## Sources: 13/13
Consensus levels: strong: 6, direct: 7
Errors: 0     (exit 1 — warnings only)
```

Down from **exit 2** before this work. Remaining warnings are legitimate/pre-existing (an orphan raw file, three `INDEX.md`-missing-entry notes, no `LOG.md`) — all WARN, not ERROR, so the `exit 2` alarm is meaningful again.

## Notes

- Interim salvage: the dispatched fixer completed and staged all edits but its stream stalled at the commit step; the orchestrator verified the diff end-to-end (above) and finalized the commit. Dispatch-Id `3f907ce9` preserved in the commit footer.
- Merging this + pulling `main` locally makes the on-disk checker/schema consistent with the already-migrated knowledge pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
