### PR TITLE
fix(roborev-email): show 7d p50 in 24h headline (was structurally n/a)

### DIFF
--- a/.claude/scripts/send_roborev_email.R
+++ b/.claude/scripts/send_roborev_email.R
@@ -147,6 +147,13 @@ ttc_p90 <- sp[["ttc_p90_hrs"]]
 close_rate <- sp[["close_rate"]]
 att_p50 <- sp[["att_p50"]]
 att_p90 <- sp[["att_p90"]]
+# 7-day headline aliases (llm#738/#739): the 24h window is right-censored to
+# near-empty because median close latency (13-49h) usually exceeds 24h, so
+# d1_ttc_p50/d1_att_p50 are structurally "n/a" by design, not a defect. The
+# 7d p50s below are shown in the 24h headline block instead, explicitly
+# labelled "(7d)" so the window is unambiguous.
+d7_ttc_p50 <- d7[["speed"]][["ttc_p50_hrs"]]
+d7_att_p50 <- d7[["speed"]][["att_p50"]]
 
 # §3 Trends
 tr <- d7[["trends"]]
@@ -315,8 +322,8 @@ if (is.null(d1) || d1_n_reviews == 0L) {
     c("24h: clean (closed)",          fmt_int(d1_clean_closed)),
     c("24h: clean (open)",            fmt_int(d1_clean_open)),
     c("24h: close rate",              fmt_rate(d1_close_rate)),
-    c("24h: hours to close p50",      fmt_num(d1_ttc_p50)),
-    c("24h: attempts p50",            fmt_att(d1_att_p50))
+    c("hours to close p50 (7d)",      fmt_num(d7_ttc_p50)),
+    c("attempts p50 (7d)",            fmt_att(d7_att_p50))
   )
   # llm#484: append Other verdicts row when there are unmatched entries
   if (d1_other_n > 0L) {


### PR DESCRIPTION
## Summary

The daily roborev email's headline metrics table showed `24h: hours to close p50` and `24h: attempts p50` as `n/a` on essentially every run. This is not a bug: median close latency is 13-49h, so any 24h-window close-latency median is right-censored to near-empty by design ([#738](https://github.com/JohnGavin/llm/issues/738), [#739](https://github.com/JohnGavin/llm/issues/739)). The zero-action trap already correctly does NOT fire on this condition (it checks source-of-truth throughput, not the censored p50).

This PR fixes the **presentation**, not the underlying data: the two structurally-empty 24h cells now source the already-computed 7-day p50 (`d7` speed slice, same data used lower in the email) instead, and are relabelled `hours to close p50 (7d)` / `attempts p50 (7d)` so the window stays unambiguous inside the 24h-captioned headline block.

## Changes

- `.claude/scripts/send_roborev_email.R`:
  - Added `d7_ttc_p50` / `d7_att_p50` aliases (mirrors the existing `d1_*` pattern) derived from the already-extracted `d7` window slice.
  - Headline table rows now read from `d7_ttc_p50` / `d7_att_p50` instead of `d1_ttc_p50` / `d1_att_p50`, with updated labels.
  - No other rows (24h counts, close rate) or the zero-action trap logic were touched.

## Test plan

- [x] `Rscript -e 'invisible(parse("send_roborev_email.R"))'` — parses cleanly
- [x] `EMAIL_DRY_RUN=1 Rscript send_roborev_email.R` against today's real snapshot (`~/.claude/logs/roborev_daily_report/2026-07-10.json`) — headline table now renders `hours to close p50 (7d): 18.6` and `attempts p50 (7d): 1.0` instead of `n/a`
- [ ] Reviewer confirms wording/placement is acceptable in the live email template

🤖 Generated with [Claude Code](https://claude.com/claude-code)