### PR TITLE
feat(housekeeping): regenerate capability-registry HTML from unified.duckdb

### DIFF
--- a/.claude/launchd/README.md
+++ b/.claude/launchd/README.md
@@ -20,6 +20,7 @@ canonical, version-controlled copies; the live copies live at
 | `com.claude.wiki-health-pulse` | Daily 09:45 | Runs `wiki_health_check.sh` against the local knowledge wiki. Part of #137 Phase 4. |
 | `com.claude.codex-overnight-learning` | Daily 06:10 | Scans recent Codex sessions and writes a nightly learning digest to `~/.codex/learning/`. Startup surfacing comes from `.claude/scripts/codex-start.sh`. Tracked in #231. |
 | `com.claude.overnight-self-review-email` | Daily 06:30 | Queries unified.duckdb for 24h deltas across 4 ETL source tables (sessions, agent_runs, hook_events, errors); sends collapsible HTML digest surfacing stale/dead tables and new self-review findings. Part of #491. |
+| `com.claude.capability-registry` | Daily 07:05 | Regenerates the "Capability Registry — Own Your Context" self-contained HTML file (`.claude/reports/capability-registry.html`) from the current skill/agent/rule inventory + unified.duckdb usage counters. FILE ONLY — does not republish the live claude.ai artifact; that requires a session using the Artifact tool. See `.claude/scripts/capability_registry_regen_cron.sh` and `capability_registry_regen.R`. |
 
 ## Retired jobs
 

--- a/.claude/launchd/com.claude.capability-registry.plist
+++ b/.claude/launchd/com.claude.capability-registry.plist
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- com.claude.capability-registry.plist
+     Daily regeneration of the "Capability Registry — Own Your Context"
+     self-contained HTML file at .claude/reports/capability-registry.html.
+
+     IMPORTANT: this job regenerates the FILE ON DISK only. Republishing to
+     the live claude.ai artifact URL is a session-only step (the Artifact
+     tool, which needs a Claude Code session + claude.ai auth) — a launchd
+     cron cannot do that. See the header comment in
+     capability_registry_regen_cron.sh and capability_registry_regen.R.
+
+     Runs at 07:05 local time (digest slot, 5 min after the 07:00
+     kb-digest-email job).
+
+     Install:
+       cp .claude/launchd/com.claude.capability-registry.plist \
+          ~/Library/LaunchAgents/com.claude.capability-registry.plist
+       launchctl load -w ~/Library/LaunchAgents/com.claude.capability-registry.plist
+
+     Uninstall:
+       launchctl unload ~/Library/LaunchAgents/com.claude.capability-registry.plist
+       rm ~/Library/LaunchAgents/com.claude.capability-registry.plist
+
+     Manual dry-run:
+       DRYRUN=1 bash ~/docs_gh/llm/.claude/scripts/capability_registry_regen_cron.sh
+
+     Manual selftest (writes to /tmp only, no repo/db mutation):
+       SELFTEST=1 bash ~/docs_gh/llm/.claude/scripts/capability_registry_regen_cron.sh
+
+     Tracked in this PR (capability-registry-regen).
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.capability-registry</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/capability_registry_regen_cron.sh</string>
+    </array>
+
+    <!-- Daily at 07:05 local time (digest slot) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>7</integer>
+        <key>Minute</key>
+        <integer>5</integer>
+    </dict>
+
+    <!-- Do NOT run immediately on launchctl load -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- PATH must include nix stable profile so nix-shell resolves -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/johngavin/.nix-profile/bin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+        <key>NIX_SSL_CERT_FILE</key>
+        <string>/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/capability_registry_launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/capability_registry_launchd.log</string>
+
+    <!-- Retry once after 60 s if job exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+</dict>
+</plist>

--- a/.claude/reports/capability_registry_template.html
+++ b/.claude/reports/capability_registry_template.html
@@ -1,0 +1,379 @@
+<title>Capability Registry — Own Your Context</title>
+<style>
+  :root{
+    --ground:#EAEEF2; --surface:#FFFFFF; --surface-2:#F1F5F8;
+    --ink:#1A2028; --ink-2:#3C4650; --muted:#68737F; --line:#D8DFE6;
+    --accent:#B4501A; --accent-soft:#EBD9C9;
+    --h0:#98A4B0; --h1:#E1B268; --h2:#DA9A3E; --h3:#CB7A29; --h4:#AD4C17;
+    --ring:#AAB5C0;
+    --good:#4F7A52; --shadow:0 1px 2px rgba(20,30,42,.05), 0 14px 34px -18px rgba(20,30,42,.22);
+    --serif:Georgia,'Iowan Old Style','Palatino Linotype',Palatino,serif;
+    --mono:ui-monospace,'SF Mono','Cascadia Code','Roboto Mono',Menlo,Consolas,monospace;
+    --sans:system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',sans-serif;
+    --maxw:1120px;
+  }
+  @media (prefers-color-scheme:dark){
+    :root{
+      --ground:#0E1318; --surface:#161D25; --surface-2:#1B242E;
+      --ink:#E4E9EF; --ink-2:#C6CFD8; --muted:#AAB6C2; --line:#28323D;
+      --accent:#E8934A; --accent-soft:#3A2A1B;
+      --h0:#57646F; --h1:#C98F3D; --h2:#D69B43; --h3:#E5923D; --h4:#F2843C;
+      --ring:#5A6773;
+      --good:#79A97D; --shadow:0 1px 2px rgba(0,0,0,.3), 0 16px 40px -20px rgba(0,0,0,.6);
+    }
+  }
+  :root[data-theme="light"]{
+    --ground:#EAEEF2; --surface:#FFFFFF; --surface-2:#F1F5F8;
+    --ink:#1A2028; --ink-2:#3C4650; --muted:#68737F; --line:#D8DFE6;
+    --accent:#B4501A; --accent-soft:#EBD9C9;
+    --h0:#98A4B0; --h1:#E1B268; --h2:#DA9A3E; --h3:#CB7A29; --h4:#AD4C17; --ring:#AAB5C0;
+    --good:#4F7A52; --shadow:0 1px 2px rgba(20,30,42,.05), 0 14px 34px -18px rgba(20,30,42,.22);
+  }
+  :root[data-theme="dark"]{
+    --ground:#0E1318; --surface:#161D25; --surface-2:#1B242E;
+    --ink:#E4E9EF; --ink-2:#C6CFD8; --muted:#AAB6C2; --line:#28323D;
+    --accent:#E8934A; --accent-soft:#3A2A1B;
+    --h0:#57646F; --h1:#C98F3D; --h2:#D69B43; --h3:#E5923D; --h4:#F2843C; --ring:#5A6773;
+    --good:#79A97D; --shadow:0 1px 2px rgba(0,0,0,.3), 0 16px 40px -20px rgba(0,0,0,.6);
+  }
+
+  *{box-sizing:border-box;}
+  body{margin:0;}
+  .page{
+    background:var(--ground); color:var(--ink); font-family:var(--sans);
+    font-size:15.5px; line-height:1.55; -webkit-font-smoothing:antialiased;
+    min-height:100vh; padding:clamp(20px,4vw,56px) clamp(16px,4vw,40px) 80px;
+  }
+  .wrap{max-width:var(--maxw); margin:0 auto;}
+
+  /* masthead */
+  .eyebrow{font-family:var(--mono); font-size:11.5px; letter-spacing:.18em; text-transform:uppercase; color:var(--accent); font-weight:600;}
+  .thesis{font-family:var(--serif); font-weight:600; letter-spacing:-.01em; text-wrap:balance;
+    font-size:clamp(30px,5.4vw,52px); line-height:1.04; margin:.34em 0 .28em;}
+  .dek{max-width:64ch; color:var(--ink-2); font-size:clamp(15px,1.6vw,17px); margin:0;}
+  .dek b{color:var(--ink); font-weight:600;}
+
+  .rule{height:1px; background:var(--line); border:0; margin:clamp(26px,4vw,40px) 0;}
+
+  /* stat band */
+  .stats{display:grid; grid-template-columns:repeat(4,1fr); gap:14px; margin-top:clamp(24px,4vw,38px);}
+  @media (max-width:760px){ .stats{grid-template-columns:repeat(2,1fr);} }
+  @media (max-width:420px){ .stats{grid-template-columns:1fr;} }
+  .tile{background:var(--surface); border:1px solid var(--line); border-radius:12px; padding:18px 18px 16px; box-shadow:var(--shadow); position:relative; overflow:hidden;}
+  .tile .big{font-family:var(--mono); font-variant-numeric:tabular-nums; font-weight:600; font-size:clamp(26px,3.4vw,34px); line-height:1; color:var(--ink); letter-spacing:-.02em;}
+  .tile .big .unit{font-size:.5em; color:var(--muted); font-weight:500; letter-spacing:0;}
+  .tile .lab{margin-top:9px; font-size:13px; color:var(--ink-2); font-weight:550;}
+  .tile .note{margin-top:3px; font-size:11.5px; color:var(--ink-2); font-family:var(--mono); letter-spacing:.01em;}
+  .tile.hot .big{color:var(--accent);}
+
+  .sec-label{font-family:var(--mono); font-size:12px; letter-spacing:.14em; text-transform:uppercase; color:var(--muted); font-weight:600; margin:0 0 14px;}
+
+  /* gauges */
+  .gauges{display:grid; gap:16px;}
+  .gauge{background:var(--surface); border:1px solid var(--line); border-radius:12px; padding:15px 17px; box-shadow:var(--shadow);}
+  .gauge .top{display:flex; justify-content:space-between; align-items:baseline; gap:12px; margin-bottom:10px;}
+  .gauge .name{font-weight:600; font-size:14.5px;}
+  .gauge .name span{font-family:var(--mono); color:var(--muted); font-weight:500; font-size:12px; margin-left:8px; letter-spacing:.02em;}
+  .gauge .frac{font-family:var(--mono); font-variant-numeric:tabular-nums; font-size:13px; color:var(--ink-2); white-space:nowrap;}
+  .gauge .frac b{color:var(--accent);}
+  .segbar{display:flex; flex-wrap:wrap; gap:3px;}
+  .seg{width:14px; height:14px; border-radius:3px; background:var(--h0); flex:0 0 auto;}
+  .seg.lit{background:var(--h3);}
+  .seg.lit.hot{background:var(--h4);}
+  .seg.idle{background:transparent; border:1.5px solid var(--h0);}
+  .seg.unmeasured{background:transparent; border:1.5px dashed var(--ring);}
+  .seg.always{background:var(--surface-2); border:1.5px solid var(--line);}
+  .gauge .cap{margin-top:9px; font-size:12px; color:var(--muted);}
+
+  /* honesty */
+  .honesty-grid{display:grid; grid-template-columns:repeat(3,1fr); gap:14px;}
+  @media (max-width:820px){ .honesty-grid{grid-template-columns:1fr;} }
+  .hcard{background:var(--surface); border:1px solid var(--line); border-left:3px solid var(--edge,var(--line)); border-radius:12px; padding:15px 17px; box-shadow:var(--shadow);}
+  .hcard.measured{--edge:var(--good);}
+  .hcard.partial{--edge:var(--h2);}
+  .hcard.na{--edge:var(--muted);}
+  .hcard h3{margin:0 0 3px; font-size:14.5px; display:flex; align-items:center; gap:8px;}
+  .hcard .tag{font-family:var(--mono); font-size:10.5px; letter-spacing:.08em; text-transform:uppercase; padding:2px 7px; border-radius:100px; background:var(--surface-2); color:var(--ink-2); border:1px solid var(--line);}
+  .hcard.measured .tag{color:var(--good);}
+  .hcard.partial .tag{color:var(--h3);}
+  .hcard p{margin:6px 0 0; font-size:13px; color:var(--ink-2); line-height:1.5;}
+  .hcard b{color:var(--ink); font-weight:600;}
+  .cmd-row{display:flex; flex-wrap:wrap; gap:10px;}
+  .cmd{font-family:var(--mono); font-size:13px; color:var(--ink-2); background:var(--surface); border:1px solid var(--line); border-radius:100px; padding:7px 14px; box-shadow:var(--shadow); font-variant-numeric:tabular-nums;}
+  .cmd b{color:var(--accent); font-weight:600;}
+
+  /* controls */
+  .controls{display:flex; flex-wrap:wrap; gap:10px 12px; align-items:center; margin-bottom:14px;}
+  .search{flex:1 1 240px; position:relative; min-width:200px;}
+  .search input{width:100%; font-family:var(--sans); font-size:14px; color:var(--ink); background:var(--surface); border:1px solid var(--line); border-radius:9px; padding:9px 12px 9px 34px; box-shadow:var(--shadow);}
+  .search input::placeholder{color:var(--muted);}
+  .search svg{position:absolute; left:11px; top:50%; transform:translateY(-50%); width:15px; height:15px; color:var(--muted);}
+  .chips{display:flex; gap:6px; flex-wrap:wrap;}
+  .chip{font-family:var(--mono); font-size:12px; letter-spacing:.02em; padding:7px 12px; border-radius:100px; border:1px solid var(--line); background:var(--surface); color:var(--ink-2); cursor:pointer;}
+  .chip[aria-pressed="true"]{background:var(--accent); border-color:var(--accent); color:#fff;}
+  :root[data-theme="dark"] .chip[aria-pressed="true"]{color:#12161b;}
+  @media (prefers-color-scheme:dark){ :root:not([data-theme="light"]) .chip[aria-pressed="true"]{color:#12161b;} }
+  .toggle{display:inline-flex; align-items:center; gap:7px; font-size:13px; color:var(--ink-2); cursor:pointer; user-select:none;}
+  .toggle input{accent-color:var(--accent); width:15px; height:15px;}
+  select#sort{font-family:var(--mono); font-size:12.5px; color:var(--ink-2); background:var(--surface); border:1px solid var(--line); border-radius:9px; padding:8px 10px; cursor:pointer;}
+
+  /* legend */
+  .legend{display:flex; flex-wrap:wrap; gap:14px; align-items:center; font-size:11.5px; color:var(--muted); font-family:var(--mono); margin-bottom:10px;}
+  .legend .item{display:inline-flex; align-items:center; gap:6px;}
+  .dot{width:11px; height:11px; border-radius:50%; flex:0 0 auto; display:inline-block;}
+  .dot.h1{background:var(--h1);} .dot.h2{background:var(--h2);} .dot.h3{background:var(--h3);} .dot.h4{background:var(--h4);}
+  .dot.dm{background:var(--h0);}
+  .dot.du{background:transparent; border:1.5px dashed var(--ring);}
+  .mark-rule{width:11px; height:2px; border-radius:2px; background:var(--muted); display:inline-block; flex:0 0 auto;}
+
+  /* registry list */
+  .reg-head, .row{display:grid; grid-template-columns:22px minmax(150px,1.1fr) minmax(0,2fr) 96px; gap:14px; align-items:center;}
+  .reg-head{padding:0 14px 8px; font-family:var(--mono); font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:var(--muted);}
+  .reg-head .r{text-align:right;}
+  .list{background:var(--surface); border:1px solid var(--line); border-radius:12px; box-shadow:var(--shadow); overflow:hidden;}
+  .row{padding:11px 14px; border-top:1px solid var(--line);}
+  .row:first-child{border-top:0;}
+  .row .marker{display:flex; justify-content:center;}
+  .row .idcell{min-width:0;}
+  .row .cap-name{font-family:var(--mono); font-size:13.5px; font-weight:600; color:var(--ink); word-break:break-word;}
+  .row .kind{display:inline-block; margin-top:3px; font-family:var(--mono); font-size:10px; letter-spacing:.08em; text-transform:uppercase; color:var(--muted); background:var(--surface-2); border:1px solid var(--line); border-radius:5px; padding:1px 6px;}
+  .row .kind.skill{color:var(--h3);} .row .kind.agent{color:var(--accent);}
+  .row .desc{font-size:12.5px; color:var(--ink-2); line-height:1.45; min-width:0;}
+  .row .desc.empty{color:var(--muted); font-style:italic;}
+  .row .metric{text-align:right; font-family:var(--mono); font-variant-numeric:tabular-nums;}
+  .row .metric .n{font-size:15px; font-weight:600; color:var(--ink);}
+  .row .metric .n.zero{color:var(--muted); font-weight:500;}
+  .row .metric .n.on{font-size:11px; color:var(--good); letter-spacing:.04em;}
+  .row .metric .when{display:block; font-size:10.5px; color:var(--muted); margin-top:2px;}
+  @media (max-width:680px){
+    .reg-head{display:none;}
+    .row{grid-template-columns:20px 1fr auto; grid-template-areas:"m id metric" "m desc metric"; row-gap:4px;}
+    .row .marker{grid-area:m; align-self:start; margin-top:4px;}
+    .row .idcell{grid-area:id;} .row .desc{grid-area:desc;} .row .metric{grid-area:metric; align-self:start;}
+  }
+  .empty-state{padding:26px; text-align:center; color:var(--muted); font-family:var(--mono); font-size:13px;}
+
+  .count{font-family:var(--mono); color:var(--muted); font-size:12px; margin:10px 2px 0; text-align:right;}
+
+  /* build info */
+  .build{margin-top:clamp(30px,5vw,46px); padding-top:18px; border-top:1px solid var(--line); display:flex; flex-wrap:wrap; gap:6px 20px; font-family:var(--mono); font-size:11.5px; color:var(--muted);}
+  .build b{color:var(--ink-2); font-weight:600;}
+  .build .flag{color:var(--h3);}
+
+  a{color:var(--accent); text-underline-offset:2px;}
+  :focus-visible{outline:2px solid var(--accent); outline-offset:2px; border-radius:4px;}
+  @media (prefers-reduced-motion:no-preference){
+    .reveal{opacity:0; transform:translateY(6px); animation:rise .5s cubic-bezier(.2,.7,.2,1) forwards;}
+    @keyframes rise{to{opacity:1; transform:none;}}
+  }
+</style>
+
+<div class="page"><div class="wrap">
+  <header>
+    <div class="eyebrow">Own-your-context · Phase&nbsp;2 preview</div>
+    <h1 class="thesis">Which of these actually fire?</h1>
+    <p class="dek"><b>159 capabilities</b> are engineered into this environment — 72 skills, 12 agents, 75 rules. This page is the receipt: what's been exercised, what's dormant, and — the honest part — <b>how confidently we can even tell yet</b>.</p>
+  </header>
+
+  <section class="stats" id="stats" aria-label="Headline figures"></section>
+
+  <hr class="rule">
+
+  <section aria-label="Engineered versus exercised">
+    <h2 class="sec-label">Engineered vs exercised</h2>
+    <div class="gauges" id="gauges"></div>
+  </section>
+
+  <hr class="rule">
+
+  <section aria-label="Confidence of the record">
+    <h2 class="sec-label">Two very different confidences</h2>
+    <div class="honesty-grid">
+      <div class="hcard measured">
+        <h3>Agents <span class="tag">Complete record</span></h3>
+        <p>Every dispatch is logged. <b>8 of 12</b> agents have fired; the four idle ones are <b>genuinely idle</b>, not unmeasured. And <b>84%</b> of all agent work ran through a single agent — <b>fixer</b> — a real signal about how the fleet is actually used.</p>
+      </div>
+      <div class="hcard partial">
+        <h3>Skills <span class="tag">Genuinely sparse</span></h3>
+        <p><b>Phase 1b (merged)</b> backfilled the full transcript archive and found only <b>~10</b> Skill-tool invocations total — so the low count is <b>real, not under-capture</b>. The actual usage signal lives in <b>slash-commands</b> (logged as bare tool names, not skills), being instrumented in <b>#745</b>.</p>
+      </div>
+      <div class="hcard na">
+        <h3>Rules <span class="tag">Always-on</span></h3>
+        <p>The 75 rules don't "fire" on demand — they're always-on or path-scoped, injected when matching files are touched. No invocation count applies; they're shown here for completeness of the corpus.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="rule">
+
+  <section aria-label="Slash-commands now captured">
+    <h2 class="sec-label">Slash-commands — now captured (Card 1e, merged)</h2>
+    <p class="dek" style="margin-bottom:14px">Backfilled live on 2026-07-07: <b>11</b> historical slash-command invocations now sit in <b>command_usage</b> — the usage signal that skills-via-Skill-tool were missing. This is where "what I actually do" really shows up.</p>
+    <div class="cmd-row">
+      <span class="cmd"><b>/bye</b> ×7</span>
+      <span class="cmd"><b>/issue-triage</b> ×3</span>
+      <span class="cmd"><b>/cleanup-worktrees</b> ×1</span>
+    </div>
+  </section>
+
+  <hr class="rule">
+
+  <section aria-label="Capability registry">
+    <h2 class="sec-label">The registry — all 159, sorted by heat</h2>
+    <div class="controls">
+      <div class="search">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="7"></circle><path d="M21 21l-4.3-4.3"></path></svg>
+        <input id="q" type="search" placeholder="Search names and descriptions…" aria-label="Search capabilities">
+      </div>
+      <div class="chips" id="chips" role="group" aria-label="Filter by kind"></div>
+      <label class="toggle"><input type="checkbox" id="dormant"> Dormant only</label>
+      <select id="sort" aria-label="Sort order">
+        <option value="heat">Sort: heat</option>
+        <option value="name">Sort: name A–Z</option>
+        <option value="recent">Sort: recently fired</option>
+      </select>
+    </div>
+    <div class="legend" aria-hidden="true">
+      <span class="item"><span class="dot h4"></span>heavily used</span>
+      <span class="item"><span class="dot h2"></span>used</span>
+      <span class="item"><span class="dot dm"></span>idle (measured)</span>
+      <span class="item"><span class="dot du"></span>skill, unrecorded</span>
+      <span class="item"><span class="mark-rule"></span>always-on rule</span>
+    </div>
+    <div class="reg-head"><span></span><span>Capability</span><span>What it does</span><span class="r">Invocations</span></div>
+    <div class="list" id="list"></div>
+    <div class="count" id="count"></div>
+  </section>
+
+  <footer class="build">
+    <span><b>Source</b> ~/.claude/logs/unified.duckdb</span>
+    <span><b>Generated</b> __CAPABILITY_REGISTRY_GENERATED__</span>
+    <span class="flag">Prototype · Phase 1b+1e merged · backfilled live 2026-07-07 — skill_usage 39, command_usage 11</span>
+  </footer>
+</div></div>
+
+<script>(function(){
+const DATA = __CAPABILITY_REGISTRY_DATA_JSON__;
+const RM = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+const items = (DATA.items||[]).map(function(d){
+  return {kind:d.kind, name:d.name||'', desc:cleanDesc(d.desc||d.description||''),
+          inv:(d.inv!=null?d.inv:(d.invocations!=null?d.invocations:null)),
+          last:d.last_used||null};
+});
+function cleanDesc(d){ if(!d) return ''; var t=String(d).trim();
+  if(t==='' || t==='>.' || t==='>' || /^>?\s*\.?$/.test(t)) return '';
+  return t.replace(/\.\.$/,'.'); }
+function bucket(n){ if(n==null||n<=0) return 0; if(n>=21) return 4; if(n>=6) return 3; if(n>=3) return 2; return 1; }
+function fmtDate(s){ if(!s) return ''; return String(s).slice(0,10); }
+
+// ---- derived stats ----
+var skills=items.filter(function(i){return i.kind==='skill';});
+var agents=items.filter(function(i){return i.kind==='agent';});
+var rules=items.filter(function(i){return i.kind==='rule';});
+var firable=skills.concat(agents);
+var fired=firable.filter(function(i){return (i.inv||0)>0;}).length;
+var darkPct=Math.round((1-fired/firable.length)*100);
+var agentInv=agents.reduce(function(a,i){return a+(i.inv||0);},0);
+var topAgent=agents.slice().sort(function(a,b){return (b.inv||0)-(a.inv||0);})[0]||{name:'—',inv:0};
+var topShare=agentInv?Math.round((topAgent.inv/agentInv)*100):0;
+var skillsFired=skills.filter(function(i){return (i.inv||0)>0;}).length;
+var agentsFired=agents.filter(function(i){return (i.inv||0)>0;}).length;
+
+// ---- stat tiles ----
+var tiles=[
+  {big:items.length, unit:'', lab:'Capabilities engineered', note:skills.length+' skills · '+agents.length+' agents · '+rules.length+' rules'},
+  {big:fired, unit:'/ '+firable.length, lab:'Have a recorded invocation', note:agentsFired+' of 12 agents · '+skillsFired+' of 72 skills'},
+  {big:darkPct, unit:'%', lab:'Dark inventory', note:'no capture yet — see caveat', hot:true},
+  {big:topShare, unit:'%', lab:'Agent work via one agent', note:'through '+topAgent.name+' ('+topAgent.inv+' runs)', hot:true}
+];
+var stats=document.getElementById('stats');
+stats.innerHTML=tiles.map(function(t,i){
+  return '<div class="tile'+(t.hot?' hot':'')+(RM?'':' reveal')+'" style="'+(RM?'':'animation-delay:'+(i*70)+'ms')+'">'+
+    '<div class="big"><span class="cv" data-to="'+t.big+'">'+(RM?t.big:0)+'</span>'+(t.unit?' <span class="unit">'+t.unit+'</span>':'')+'</div>'+
+    '<div class="lab">'+t.lab+'</div><div class="note">'+t.note+'</div></div>';
+}).join('');
+if(!RM){ document.querySelectorAll('.cv').forEach(function(el){
+  var to=+el.getAttribute('data-to'), start=null, dur=850;
+  function step(ts){ if(!start)start=ts; var p=Math.min(1,(ts-start)/dur);
+    el.textContent=Math.round(to*(1-Math.pow(1-p,3))); if(p<1)requestAnimationFrame(step); }
+  requestAnimationFrame(step); }); }
+
+// ---- gauges ----
+function segs(arr, litClass, restClass, hotAt){
+  return arr.slice().sort(function(a,b){return (b.inv||0)-(a.inv||0);}).map(function(i){
+    var n=i.inv||0;
+    if(n>0){ var hot=(hotAt!=null && n>=hotAt); return '<i class="seg lit'+(hot?' hot':'')+'" title="'+i.name+': '+n+'"></i>'; }
+    return '<i class="seg '+restClass+'" title="'+i.name+': not fired"></i>';
+  }).join('');
+}
+document.getElementById('gauges').innerHTML=[
+  {cls:'', name:'Agents', sub:'complete record',
+   frac:'<b>'+agentsFired+'</b> / 12 fired',
+   bar:segs(agents,'lit','idle',21),
+   cap:'Every dispatch logged. The 4 empty squares are genuinely idle agents.'},
+  {cls:'', name:'Skills', sub:'instrumentation partial',
+   frac:'<b>'+skillsFired+'</b> / 72 recorded',
+   bar:segs(skills,'lit','unmeasured',21),
+   cap:'Dashed squares are "not yet measured", not "never used" — a floor that Phase 1b will raise.'},
+  {cls:'', name:'Rules', sub:'always-on / path-scoped',
+   frac:'<b>'+rules.length+'</b> active',
+   bar:rules.map(function(){return '<i class="seg always"></i>';}).join(''),
+   cap:'Injected automatically when matching files are touched — no on-demand firing.'}
+].map(function(g){
+  return '<div class="gauge'+(RM?'':' reveal')+'"><div class="top"><div class="name">'+g.name+
+    '<span>'+g.sub+'</span></div><div class="frac">'+g.frac+'</div></div>'+
+    '<div class="segbar">'+g.bar+'</div><div class="cap">'+g.cap+'</div></div>';
+}).join('');
+
+// ---- registry ----
+var chipsEl=document.getElementById('chips');
+var KINDS=[['all','All'],['skill','Skills'],['agent','Agents'],['rule','Rules']];
+var state={kind:'all', q:'', dormant:false, sort:'heat'};
+chipsEl.innerHTML=KINDS.map(function(k){ return '<button class="chip" data-k="'+k[0]+'" aria-pressed="'+(k[0]==='all')+'">'+k[1]+'</button>'; }).join('');
+chipsEl.addEventListener('click', function(e){ var b=e.target.closest('.chip'); if(!b)return;
+  state.kind=b.getAttribute('data-k');
+  chipsEl.querySelectorAll('.chip').forEach(function(c){ c.setAttribute('aria-pressed', c===b); });
+  render(); });
+document.getElementById('q').addEventListener('input', function(e){ state.q=e.target.value.toLowerCase().trim(); render(); });
+document.getElementById('dormant').addEventListener('change', function(e){ state.dormant=e.target.checked; render(); });
+document.getElementById('sort').addEventListener('change', function(e){ state.sort=e.target.value; render(); });
+
+var listEl=document.getElementById('list'), countEl=document.getElementById('count');
+function marker(i){
+  if(i.kind==='rule') return '<span class="mark-rule" title="always-on"></span>';
+  var n=i.inv||0;
+  if(n>0) return '<span class="dot h'+bucket(n)+'" title="'+n+' invocations"></span>';
+  return i.kind==='skill' ? '<span class="dot du" title="not yet measured"></span>'
+                          : '<span class="dot dm" title="idle"></span>';
+}
+function metric(i){
+  if(i.kind==='rule') return '<span class="n on">always-on</span>';
+  var n=i.inv||0;
+  var when=n>0 && i.last ? '<span class="when">'+fmtDate(i.last)+'</span>' : '';
+  return '<span class="n'+(n>0?'':' zero')+'">'+n+'</span>'+when;
+}
+function render(){
+  var rows=items.filter(function(i){
+    if(state.kind!=='all' && i.kind!==state.kind) return false;
+    if(state.dormant && (i.kind==='rule' || (i.inv||0)>0)) return false;
+    if(state.q){ var hay=(i.name+' '+i.desc+' '+i.kind).toLowerCase(); if(hay.indexOf(state.q)<0) return false; }
+    return true;
+  });
+  rows.sort(function(a,b){
+    if(state.sort==='name') return a.name.localeCompare(b.name);
+    if(state.sort==='recent') return (b.last||'').localeCompare(a.last||'');
+    var d=(b.inv||0)-(a.inv||0); if(d) return d; return a.name.localeCompare(b.name);
+  });
+  if(!rows.length){ listEl.innerHTML='<div class="empty-state">No capabilities match that filter.</div>'; countEl.textContent=''; return; }
+  listEl.innerHTML=rows.map(function(i){
+    var d=i.desc ? '<div class="desc">'+esc(i.desc)+'</div>' : '<div class="desc empty">no description captured</div>';
+    return '<div class="row"><div class="marker">'+marker(i)+'</div>'+
+      '<div class="idcell"><div class="cap-name">'+esc(i.name)+'</div>'+
+      '<span class="kind '+i.kind+'">'+i.kind+'</span></div>'+
+      d+'<div class="metric">'+metric(i)+'</div></div>';
+  }).join('');
+  countEl.textContent=rows.length+' of '+items.length+' shown';
+}
+function esc(s){ return String(s).replace(/[&<>"]/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];}); }
+render();
+})();</script>

--- a/.claude/scripts/capability_registry_regen.R
+++ b/.claude/scripts/capability_registry_regen.R
@@ -1,0 +1,377 @@
+#!/usr/bin/env Rscript
+# capability_registry_regen.R — Regenerate the "Capability Registry — Own Your
+# Context" self-contained HTML file from the current skill/agent/rule
+# inventory and unified.duckdb usage counters.
+#
+# IMPORTANT — republish boundary:
+#   Republishing to the LIVE claude.ai artifact URL is a session-only step
+#   (the Artifact tool, which requires a Claude Code session + claude.ai
+#   auth). A launchd cron CANNOT do that. This script only regenerates the
+#   self-contained HTML FILE on disk at .claude/reports/capability-registry.html.
+#   To push a fresh render live, a session must: open this file, call the
+#   Artifact tool with the SAME artifact URL used previously (see the `url`
+#   parameter of the Artifact tool), which redeploys to the existing page.
+#
+# Usage:
+#   Rscript .claude/scripts/capability_registry_regen.R \
+#     [--out PATH] [--db PATH] [--template PATH] [--dry-run]
+#
+# Defaults:
+#   --out       .claude/reports/capability-registry.html (repo-relative)
+#   --db        ~/.claude/logs/unified.duckdb
+#   --template  .claude/reports/capability_registry_template.html (repo-relative)
+#   --dry-run   print summary counts to stdout only, still writes --out
+#
+# SELFTEST=1 env var: runs against the real duckdb (read-only) into a /tmp
+# output path and validates the result is non-empty + well-formed, then exits.
+#
+# Data sources:
+#   Filesystem inventory: .claude/skills/*/SKILL.md (excluding .system,
+#     generated), .claude/agents/*.md, .claude/rules/*.md (top-level only,
+#     excludes _companions/).
+#   Usage counters: skill_usage, agent_runs tables in unified.duckdb.
+#     Rules have no usage table (they are always-on / path-scoped, not
+#     invoked on demand) — invocations/last_used are emitted as null,
+#     matching the template's "always-on" rendering path.
+#
+# Tables written: housekeeping_runs (heartbeat only; no dedicated events
+# table — this task has no per-item event stream, just a full-inventory
+# regeneration each run).
+#
+# See: housekeeping-framework rule, cron-auto-pull-discipline rule.
+
+suppressPackageStartupMessages({
+  library(jsonlite)
+})
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+args <- commandArgs(trailingOnly = TRUE)
+
+parse_args <- function(args) {
+  out <- list(
+    out      = NULL,
+    db       = Sys.getenv("UNIFIED_DB_PATH", file.path(Sys.getenv("HOME"), ".claude/logs/unified.duckdb")),
+    template = NULL,
+    dry_run  = FALSE
+  )
+  i <- 1L
+  while (i <= length(args)) {
+    if (args[i] == "--out" && i + 1L <= length(args)) {
+      out$out <- args[i + 1L]; i <- i + 2L
+    } else if (args[i] == "--db" && i + 1L <= length(args)) {
+      out$db <- args[i + 1L]; i <- i + 2L
+    } else if (args[i] == "--template" && i + 1L <= length(args)) {
+      out$template <- args[i + 1L]; i <- i + 2L
+    } else if (args[i] == "--dry-run") {
+      out$dry_run <- TRUE; i <- i + 1L
+    } else {
+      i <- i + 1L
+    }
+  }
+  out
+}
+
+cfg <- parse_args(args)
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+
+find_repo_root <- function() {
+  env_root <- Sys.getenv("LLM_REPO_ROOT", unset = "")
+  if (nzchar(env_root) && file.exists(file.path(env_root, ".git"))) {
+    return(normalizePath(env_root))
+  }
+  start <- tryCatch(
+    dirname(normalizePath(sys.frame(0)$ofile, mustWork = FALSE)),
+    error = function(e) getwd()
+  )
+  path <- start
+  for (i in seq_len(10L)) {
+    if (file.exists(file.path(path, ".git"))) return(path)
+    parent <- dirname(path)
+    if (parent == path) break
+    path <- parent
+  }
+  getwd()
+}
+
+REPO_ROOT <- find_repo_root()
+
+if (is.null(cfg$out)) {
+  cfg$out <- file.path(REPO_ROOT, ".claude/reports/capability-registry.html")
+}
+if (is.null(cfg$template)) {
+  cfg$template <- file.path(REPO_ROOT, ".claude/reports/capability_registry_template.html")
+}
+
+# ── SELFTEST override ─────────────────────────────────────────────────────────
+
+SELFTEST <- identical(Sys.getenv("SELFTEST"), "1")
+if (SELFTEST) {
+  cfg$out <- file.path(tempdir(), sprintf("capability_registry_selftest_%s.html", format(Sys.time(), "%Y%m%d%H%M%S")))
+  message(sprintf("capability_registry_regen.R: SELFTEST=1 -- writing to %s", cfg$out))
+}
+
+# ── duckdb-absent guard ───────────────────────────────────────────────────────
+
+duckdb_ok <- nzchar(Sys.which("duckdb")) && file.exists(cfg$db)
+if (!duckdb_ok) {
+  message(sprintf(
+    "capability_registry_regen.R: duckdb not available (binary on PATH: %s, db exists: %s) -- exiting cleanly, no file written",
+    nzchar(Sys.which("duckdb")), file.exists(cfg$db)
+  ))
+  quit(status = 0L)
+}
+
+if (!file.exists(cfg$template)) {
+  message(sprintf("capability_registry_regen.R: ERROR template not found at %s", cfg$template))
+  quit(status = 1L)
+}
+
+# ── duckdb query helper (read-only, JSON output) ──────────────────────────────
+
+query_duckdb <- function(sql, db_path) {
+  # system2() with stdout=TRUE builds and runs the command through a shell
+  # (see ?system2), so arguments containing shell metacharacters (SQL has
+  # parens/quotes) MUST be shQuote()'d -- unlike a raw execve() call.
+  result <- tryCatch(
+    system2("duckdb", args = c(shQuote(db_path), "-readonly", "-json", "-c", shQuote(sql)),
+            stdout = TRUE, stderr = FALSE),
+    error = function(e) character(0)
+  )
+  # duckdb CLI emits "loaded <ext> ;" / "unified: ..." status lines on stdout
+  # ahead of the JSON payload when extensions autoload; keep only the JSON
+  # array, which starts with '[' (or is empty '[]\n' for zero rows).
+  json_lines <- result[grepl("^\\s*[\\[\\{]", result) | grepl("^\\s*[\\]\\},\"]", result)]
+  json_text <- paste(json_lines, collapse = "\n")
+  if (!nzchar(trimws(json_text))) return(list())
+  tryCatch(jsonlite::fromJSON(json_text, simplifyVector = FALSE), error = function(e) list())
+}
+
+# ── Filesystem inventory ──────────────────────────────────────────────────────
+
+# YAML frontmatter `description:` extractor. Handles quoted and unquoted
+# single-line values; multi-line/folded YAML descriptions are truncated to
+# their first line (adequate for a registry blurb).
+extract_frontmatter_description <- function(path) {
+  lines <- tryCatch(readLines(path, warn = FALSE, n = 40L), error = function(e) character(0))
+  if (length(lines) == 0L || !identical(trimws(lines[1L]), "---")) return("")
+  end_idx <- which(trimws(lines[-1L]) == "---")
+  if (length(end_idx) == 0L) return("")
+  fm <- lines[2L:end_idx[1L]]
+  desc_line <- grep("^description:\\s*", fm, value = TRUE)
+  if (length(desc_line) == 0L) return("")
+  val <- sub("^description:\\s*", "", desc_line[1L])
+  val <- trimws(val)
+  val <- gsub('^"(.*)"$', "\\1", val)
+  val <- gsub("^'(.*)'$", "\\1", val)
+  val
+}
+
+collect_skills <- function(repo_root) {
+  skills_dir <- file.path(repo_root, ".claude/skills")
+  if (!dir.exists(skills_dir)) return(list())
+  subdirs <- list.dirs(skills_dir, recursive = FALSE, full.names = FALSE)
+  subdirs <- setdiff(subdirs, c(".system", "generated"))
+  out <- list()
+  for (nm in subdirs) {
+    skill_md <- file.path(skills_dir, nm, "SKILL.md")
+    if (!file.exists(skill_md)) next
+    out[[length(out) + 1L]] <- list(
+      kind = "skill",
+      name = nm,
+      description = extract_frontmatter_description(skill_md)
+    )
+  }
+  out
+}
+
+collect_agents <- function(repo_root) {
+  agents_dir <- file.path(repo_root, ".claude/agents")
+  if (!dir.exists(agents_dir)) return(list())
+  files <- list.files(agents_dir, pattern = "\\.md$", full.names = FALSE)
+  out <- list()
+  for (f in files) {
+    nm <- sub("\\.md$", "", f)
+    out[[length(out) + 1L]] <- list(
+      kind = "agent",
+      name = nm,
+      description = extract_frontmatter_description(file.path(agents_dir, f))
+    )
+  }
+  out
+}
+
+collect_rules <- function(repo_root) {
+  rules_dir <- file.path(repo_root, ".claude/rules")
+  if (!dir.exists(rules_dir)) return(list())
+  # Top-level only: excludes _companions/ (cross-referenced, not independently loaded)
+  files <- list.files(rules_dir, pattern = "\\.md$", full.names = FALSE, recursive = FALSE)
+  out <- list()
+  for (f in files) {
+    nm <- sub("\\.md$", "", f)
+    out[[length(out) + 1L]] <- list(
+      kind = "rule",
+      name = nm,
+      description = extract_frontmatter_description(file.path(rules_dir, f))
+    )
+  }
+  out
+}
+
+# ── Usage counters from unified.duckdb ────────────────────────────────────────
+
+fetch_skill_usage <- function(db_path) {
+  rows <- query_duckdb(
+    "SELECT skill_name, SUM(invocations) AS inv, MAX(ts) AS last_used
+     FROM skill_usage GROUP BY skill_name",
+    db_path
+  )
+  # named list keyed by skill_name -> list(inv=, last_used=)
+  out <- list()
+  for (r in rows) {
+    if (is.null(r$skill_name)) next
+    out[[r$skill_name]] <- list(inv = as.integer(r$inv %||% 0L), last_used = r$last_used)
+  }
+  out
+}
+
+fetch_agent_usage <- function(db_path) {
+  rows <- query_duckdb(
+    "SELECT agent_type, COUNT(*) AS inv, MAX(started_at) AS last_used
+     FROM agent_runs GROUP BY agent_type",
+    db_path
+  )
+  out <- list()
+  for (r in rows) {
+    if (is.null(r$agent_type)) next
+    out[[r$agent_type]] <- list(inv = as.integer(r$inv %||% 0L), last_used = r$last_used)
+  }
+  out
+}
+
+`%||%` <- function(a, b) if (is.null(a)) b else a
+
+# ── Build DATA object ─────────────────────────────────────────────────────────
+
+skills <- collect_skills(REPO_ROOT)
+agents <- collect_agents(REPO_ROOT)
+rules  <- collect_rules(REPO_ROOT)
+
+skill_usage <- fetch_skill_usage(cfg$db)
+agent_usage <- fetch_agent_usage(cfg$db)
+
+annotate <- function(item, usage_map) {
+  u <- usage_map[[item$name]]
+  item$invocations <- if (is.null(u)) 0L else u$inv
+  item$last_used    <- if (is.null(u)) NULL else u$last_used
+  item
+}
+
+skills <- lapply(skills, annotate, usage_map = skill_usage)
+agents <- lapply(agents, annotate, usage_map = agent_usage)
+rules  <- lapply(rules, function(item) {
+  item$invocations <- NA  # NA -> null in JSON; matches template's "always-on" path
+  item$last_used <- NULL
+  item
+})
+
+all_items <- c(skills, agents, rules)
+
+skills_with_usage <- sum(vapply(skills, function(x) (x$invocations %||% 0L) > 0L, logical(1)))
+agents_with_usage <- sum(vapply(agents, function(x) (x$invocations %||% 0L) > 0L, logical(1)))
+
+firable <- c(skills, agents)
+inv_vals <- vapply(firable, function(x) as.integer(x$invocations %||% 0L), integer(1))
+ord <- order(inv_vals, decreasing = TRUE)
+top5 <- firable[ord][seq_len(min(5L, length(firable)))]
+top5_out <- lapply(top5, function(x) list(name = x$name, kind = x$kind, invocations = as.integer(x$invocations %||% 0L)))
+
+items_out <- lapply(all_items, function(x) {
+  list(
+    kind = x$kind,
+    name = x$name,
+    description = x$description,
+    invocations = if (is.na(x$invocations %||% NA)) NULL else as.integer(x$invocations),
+    last_used = x$last_used
+  )
+})
+
+DATA <- list(
+  generated_note = "usage from unified.duckdb (skill_usage, agent_runs); rules are always-on/path-scoped and carry no invocation count",
+  counts = list(
+    skills = length(skills),
+    agents = length(agents),
+    rules  = length(rules),
+    total  = length(all_items)
+  ),
+  usage_coverage = list(
+    skills_with_any_usage = skills_with_usage,
+    agents_with_any_usage = agents_with_usage
+  ),
+  top_5_by_invocations = top5_out,
+  items = items_out
+)
+
+data_json <- jsonlite::toJSON(DATA, auto_unbox = TRUE, null = "null", na = "null", pretty = TRUE)
+
+# ── Render template ────────────────────────────────────────────────────────────
+
+template_text <- paste(readLines(cfg$template, warn = FALSE), collapse = "\n")
+
+generated_date <- format(Sys.Date(), "%Y-%m-%d")
+
+html_out <- template_text
+html_out <- sub("__CAPABILITY_REGISTRY_DATA_JSON__", data_json, html_out, fixed = TRUE)
+html_out <- sub("__CAPABILITY_REGISTRY_GENERATED__", generated_date, html_out, fixed = TRUE)
+
+dir.create(dirname(cfg$out), showWarnings = FALSE, recursive = TRUE)
+writeLines(html_out, cfg$out)
+
+summary_msg <- sprintf(
+  "capability_registry_regen.R: wrote %s | skills=%d agents=%d rules=%d total=%d | skills_with_usage=%d agents_with_usage=%d",
+  cfg$out, length(skills), length(agents), length(rules), length(all_items),
+  skills_with_usage, agents_with_usage
+)
+message(summary_msg)
+
+if (cfg$dry_run) {
+  message("capability_registry_regen.R: --dry-run (file still written; no downstream publish step exists for this script)")
+}
+
+if (SELFTEST) {
+  ok <- TRUE
+  if (!file.exists(cfg$out) || file.info(cfg$out)$size == 0L) {
+    message("SELFTEST FAIL: output file missing or empty")
+    ok <- FALSE
+  }
+  written <- paste(readLines(cfg$out, warn = FALSE), collapse = "\n")
+  if (!grepl("const DATA = ", written, fixed = TRUE)) {
+    message("SELFTEST FAIL: DATA blob placeholder was not substituted")
+    ok <- FALSE
+  }
+  if (grepl("__CAPABILITY_REGISTRY_", written, fixed = TRUE)) {
+    message("SELFTEST FAIL: unsubstituted placeholder(s) remain")
+    ok <- FALSE
+  }
+  parsed <- tryCatch({
+    m <- regmatches(written, regexpr("(?s)const DATA = (\\{.*?\\});", written, perl = TRUE))
+    json_only <- sub("^const DATA = ", "", sub(";$", "", m))
+    jsonlite::fromJSON(json_only, simplifyVector = FALSE)
+  }, error = function(e) NULL)
+  if (is.null(parsed)) {
+    message("SELFTEST FAIL: embedded DATA JSON did not parse")
+    ok <- FALSE
+  } else if (is.null(parsed$counts) || is.null(parsed$items)) {
+    message("SELFTEST FAIL: parsed DATA missing counts/items")
+    ok <- FALSE
+  }
+  if (ok) {
+    message(sprintf("SELFTEST PASS: %s is well-formed (counts: skills=%s agents=%s rules=%s total=%s)",
+                     cfg$out, parsed$counts$skills, parsed$counts$agents, parsed$counts$rules, parsed$counts$total))
+  } else {
+    quit(status = 1L)
+  }
+}
+
+invisible(cfg$out)

--- a/.claude/scripts/capability_registry_regen_cron.sh
+++ b/.claude/scripts/capability_registry_regen_cron.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+# capability_registry_regen_cron.sh — Wrapper for daily regeneration of the
+# "Capability Registry — Own Your Context" self-contained HTML file.
+#
+# IMPORTANT — republish boundary:
+#   Republishing to the LIVE claude.ai artifact URL is a session-only step
+#   (the Artifact tool, which needs a Claude Code session + claude.ai auth).
+#   This cron CANNOT do that. It only regenerates the file on disk at
+#   .claude/reports/capability-registry.html. A session republishes by
+#   opening the file and calling the Artifact tool with the SAME artifact
+#   URL used previously (Artifact tool `url` parameter redeploys in place).
+#
+# Steps:
+#   0. Write housekeeping_runs start row (if duckdb available)
+#   1. Run capability_registry_regen.R to write the HTML file
+#   2. Update housekeeping_runs end row
+#
+# unified.duckdb writes: gracefully skipped when duckdb is absent.
+# Tables written: housekeeping_runs (heartbeat only -- this task has no
+#   per-item event stream, just a full-inventory regeneration each run).
+# See: housekeeping-framework rule, cron-auto-pull-discipline rule, llm#(this PR).
+#
+# All R calls are wrapped in nix-shell per the nix-agent-shell-protocol rule.
+#
+# Manual run (dry):
+#   DRYRUN=1 bash .claude/scripts/capability_registry_regen_cron.sh
+#
+# Manual selftest (writes to /tmp, validates output, no repo write):
+#   SELFTEST=1 bash .claude/scripts/capability_registry_regen_cron.sh
+#
+# Install plist:
+#   cp .claude/launchd/com.claude.capability-registry.plist \
+#      ~/Library/LaunchAgents/com.claude.capability-registry.plist
+#   launchctl load -w ~/Library/LaunchAgents/com.claude.capability-registry.plist
+#
+# Log: ~/.claude/logs/capability_registry.log
+
+set -uo pipefail
+
+# ── PATH (launchd runs with a bare PATH; must resolve nix-shell, Rscript) ─────
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# ── Recursion / fork-bomb guard ────────────────────────────────────────────────
+: "${CAPREG_CRON_DEPTH:=0}"
+if (( CAPREG_CRON_DEPTH > 0 )); then
+  echo "[capability_registry_regen_cron] ERROR: recursion detected (depth=${CAPREG_CRON_DEPTH}). Abort." >&2
+  exit 1
+fi
+export CAPREG_CRON_DEPTH=$(( CAPREG_CRON_DEPTH + 1 ))
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && cd .. && pwd)"
+LLM_NIX="${REPO_ROOT}/default.nix"
+LOG_FILE="${HOME}/.claude/logs/capability_registry.log"
+LOCK_FILE="/tmp/capability_registry_regen_cron.lock"
+UNIFIED_DB="${UNIFIED_DB_PATH:-${HOME}/.claude/logs/unified.duckdb}"
+REGEN_R="${REPO_ROOT}/.claude/scripts/capability_registry_regen.R"
+OUT_HTML="${REPO_ROOT}/.claude/reports/capability-registry.html"
+
+DRYRUN="${DRYRUN:-0}"
+SELFTEST="${SELFTEST:-0}"
+export LLM_REPO_ROOT="${REPO_ROOT}"
+
+# ── Logging ────────────────────────────────────────────────────────────────────
+mkdir -p "$(dirname "${LOG_FILE}")"
+
+log() {
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  printf '%s: %s\n' "${ts}" "$1" | tee -a "${LOG_FILE}"
+}
+
+log "=== capability_registry_regen_cron.sh starting (DRYRUN=${DRYRUN} SELFTEST=${SELFTEST}) ==="
+
+# ── Lock (prevent concurrent runs) ────────────────────────────────────────────
+if [ -f "${LOCK_FILE}" ]; then
+  existing_pid="$(cat "${LOCK_FILE}" 2>/dev/null || true)"
+  if [ -n "${existing_pid}" ] && kill -0 "${existing_pid}" 2>/dev/null; then
+    log "SKIP: another instance running (PID ${existing_pid})"
+    exit 0
+  fi
+fi
+printf '%d' "$$" > "${LOCK_FILE}"
+trap 'rm -f "${LOCK_FILE}"' EXIT
+
+# ── SELFTEST short-circuit (no repo pull, no housekeeping_runs write) ─────────
+if [ "${SELFTEST}" = "1" ]; then
+  log "SELFTEST=1: delegating to capability_registry_regen.R self-check (writes to /tmp only)"
+  if [ ! -f "${LLM_NIX}" ]; then
+    log "ERROR: nix file not found at ${LLM_NIX}"
+    exit 1
+  fi
+  SELFTEST=1 nix-shell "${LLM_NIX}" --run "Rscript '${REGEN_R}'" 2>&1 | tee -a "${LOG_FILE}"
+  exit "${PIPESTATUS[0]}"
+fi
+
+# ── Deploy: pull latest main before running (llm#510) ─────────────────────────
+# Cron wrappers run against ${REPO_ROOT}; without this step every gh pr merge
+# ships nothing -- the cron uses whatever was last manually pulled to the main
+# checkout. The fast-forward is silent on success and never overwrites local
+# work because of --ff-only.
+if [ -z "${SKIP_CRON_PULL:-}" ]; then
+    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
+    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
+        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+    else
+        log "deploy WARN: ff-only failed — running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+    fi
+fi
+log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
+
+# ── Verify nix shell is accessible ────────────────────────────────────────────
+if [ ! -f "${LLM_NIX}" ]; then
+  log "ERROR: nix file not found at ${LLM_NIX}"
+  exit 1
+fi
+
+if ! command -v nix-shell > /dev/null 2>&1; then
+  log "ERROR: nix-shell not on PATH (${PATH})"
+  exit 1
+fi
+
+# ── Resolve nix target: GC-rooted drv preferred (llm#596) ─────────────────────
+# Evaluating ${LLM_NIX} re-fetches the unhashed nixpkgs tarball once the
+# tarball TTL lapses; the launchd environment cannot resolve github.com, so
+# the job dies before doing any work. `nix-shell <drv>` skips evaluation
+# entirely -- no network at runtime. The drv root is maintained by
+# .claude/scripts/nix_gcroot_refresh.sh (best-effort refresh below; a stale
+# root still runs the previously-pinned shell, which beats dying).
+GCROOT_DRV="${HOME}/.claude/nix-gcroots/llm-shell.drv"
+GCROOT_STAMP="${GCROOT_DRV}.stamp"
+if [ ! -e "${GCROOT_DRV}" ] || [ ! -e "${GCROOT_STAMP}" ] || [ "${LLM_NIX}" -nt "${GCROOT_STAMP}" ]; then
+  "${REPO_ROOT}/.claude/scripts/nix_gcroot_refresh.sh" "${LLM_NIX}" >> "${LOG_FILE}" 2>&1 || true
+fi
+if [ -e "${GCROOT_DRV}" ]; then
+  NIX_TARGET="${GCROOT_DRV}"
+  if [ -e "${GCROOT_STAMP}" ] && [ "${LLM_NIX}" -nt "${GCROOT_STAMP}" ]; then
+    log "nix WARN: gcroot stale — running stale-but-cached shell (llm#596)"
+  else
+    log "nix: using GC-rooted drv (no network needed)"
+  fi
+else
+  NIX_TARGET="${LLM_NIX}"
+  log "nix WARN: no gcroot — falling back to nix-shell evaluation (needs network, llm#596)"
+fi
+
+# ── DuckDB availability check ──────────────────────────────────────────────────
+# Gracefully skip all DB writes when duckdb binary or unified.duckdb is absent.
+# Same defensive pattern as kb_digest_daily_cron.sh / config_digest_cron.sh.
+_duckdb_ok=0
+if command -v duckdb >/dev/null 2>&1 && [ -f "${UNIFIED_DB}" ]; then
+  _duckdb_ok=1
+  log "duckdb: available at ${UNIFIED_DB}"
+else
+  log "duckdb: not available — skipping DB writes (capability_registry_regen.R will also skip HTML write)"
+fi
+
+# Run ID for this invocation (bash native — no python3 per llm#569 compliance)
+_run_id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+_run_started="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+# ── Step 0: Write housekeeping_runs start row ─────────────────────────────────
+if [ "${_duckdb_ok}" = "1" ]; then
+  _script_abs="${SCRIPT_DIR}/capability_registry_regen_cron.sh"
+  duckdb "${UNIFIED_DB}" "
+    INSERT OR IGNORE INTO housekeeping_runs
+      (id, task, source_script, started_at, status, rows_written)
+    VALUES (
+      '${_run_id}',
+      'capability_registry_regen',
+      '${_script_abs}',
+      TIMESTAMPTZ '${_run_started}',
+      'ok',
+      0
+    );
+  " 2>/dev/null || log "duckdb WARN: housekeeping_runs INSERT failed (non-fatal)"
+fi
+
+# ── Step 1: Regenerate the HTML file ──────────────────────────────────────────
+log "Step 1: regenerating capability registry HTML..."
+
+if [ ! -f "${REGEN_R}" ]; then
+  log "ERROR: capability_registry_regen.R not found at ${REGEN_R}"
+  if [ "${_duckdb_ok}" = "1" ]; then
+    _run_ended="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    duckdb "${UNIFIED_DB}" "
+      UPDATE housekeeping_runs
+      SET ended_at = TIMESTAMPTZ '${_run_ended}', status = 'failed', rows_written = 0
+      WHERE id = '${_run_id}';
+    " 2>/dev/null || true
+  fi
+  exit 1
+fi
+
+if [ "${DRYRUN}" = "1" ]; then
+  log "  DRYRUN: would run nix-shell ${NIX_TARGET} --run 'Rscript ${REGEN_R} --dry-run'"
+  STEP1_EXIT=0
+  _rows_written=0
+else
+  UNIFIED_DB_PATH="${UNIFIED_DB}" LLM_REPO_ROOT="${REPO_ROOT}" \
+    nix-shell "${NIX_TARGET}" --run "Rscript '${REGEN_R}'" >> "${LOG_FILE}" 2>&1
+  STEP1_EXIT=$?
+  _rows_written=1
+fi
+
+if [ "${STEP1_EXIT}" -ne 0 ]; then
+  log "ERROR: capability_registry_regen.R exited ${STEP1_EXIT} — aborting"
+  if [ "${_duckdb_ok}" = "1" ]; then
+    _run_ended="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    duckdb "${UNIFIED_DB}" "
+      UPDATE housekeeping_runs
+      SET ended_at = TIMESTAMPTZ '${_run_ended}', status = 'failed', rows_written = 0
+      WHERE id = '${_run_id}';
+    " 2>/dev/null || true
+  fi
+  exit "${STEP1_EXIT}"
+fi
+
+if [ -f "${OUT_HTML}" ]; then
+  byte_count=$(wc -c < "${OUT_HTML}")
+  log "  Output: ${OUT_HTML} (${byte_count} bytes)"
+fi
+
+log "Step 1 done (exit=${STEP1_EXIT})"
+
+# ── Step 2: Update housekeeping_runs end row ──────────────────────────────────
+if [ "${_duckdb_ok}" = "1" ]; then
+  _run_ended="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  duckdb "${UNIFIED_DB}" "
+    UPDATE housekeeping_runs
+    SET ended_at = TIMESTAMPTZ '${_run_ended}',
+        rows_written = ${_rows_written}
+    WHERE id = '${_run_id}';
+  " 2>/dev/null || log "duckdb WARN: housekeeping_runs UPDATE failed (non-fatal)"
+  log "Step 2: housekeeping_runs updated (rows_written=${_rows_written})"
+fi
+
+# Stamp for cron_catchup.sh catch-up detection
+mkdir -p "${HOME}/.claude/logs/stamps"
+date -u +%Y-%m-%dT%H:%M:%SZ > "${HOME}/.claude/logs/stamps/capability-registry.stamp"
+
+log "=== capability_registry_regen_cron.sh done ==="
+log "REMINDER: this only regenerated the on-disk file. Republishing to the"
+log "  live claude.ai artifact URL requires a session: open ${OUT_HTML}"
+log "  and call the Artifact tool with the existing artifact's URL."

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ explorations/*
 # Credential tier file (real one lives at ~/.claude/credential_tiers.toml — JohnGavin/llm#376)
 # The .example template is tracked; the real file with actual key names is not.
 .claude/credential_tiers.toml
+
+# Capability registry: the template is source-controlled, the regenerated
+# HTML output is not (rewritten daily by com.claude.capability-registry cron).
+.claude/reports/capability-registry.html


### PR DESCRIPTION
## Summary

- Adds the file-regeneration half of automating the "Capability Registry — Own Your Context" artifact's data, per the `housekeeping-framework` 5-point template.
- **Hard constraint, stated explicitly in both scripts' header comments**: a launchd cron **cannot** re-publish to the live claude.ai artifact URL — that requires the Artifact tool inside a Claude Code session (claude.ai auth). This PR only regenerates a self-contained HTML **file on disk** at `.claude/reports/capability-registry.html`. Republishing to the live URL stays a manual/session step: open the regenerated file and call the Artifact tool with the **same** artifact URL used previously (the `url` parameter redeploys in place).

## What's here

| File | Purpose |
|---|---|
| `.claude/scripts/capability_registry_regen.R` | Counts skills (`.claude/skills/*/SKILL.md`, excluding `.system`/`generated`), agents (`.claude/agents/*.md`), rules (`.claude/rules/*.md`, top-level only); joins invocation counts from `skill_usage` and `agent_runs` in `unified.duckdb`; fills the `DATA` JSON blob + `Generated` date into the template. `SELFTEST=1` runs against the real duckdb into a `/tmp` output and validates the HTML is non-empty, has no leftover placeholders, and the embedded `DATA` JSON parses. duckdb-absent guard exits cleanly. |
| `.claude/reports/capability_registry_template.html` | The artifact's HTML/CSS/JS shell, fetched once (via WebFetch) from the live artifact (`71d85c4a-ee55-4c64-91ec-aca5e3860bee`) and saved with the `const DATA = {…}` blob and the footer `Generated` date replaced by placeholder tokens. Fully self-contained (inline CSS/JS, no external requests). The *rendered output* (`capability-registry.html`) is gitignored — it's regenerated daily, not source. |
| `.claude/scripts/capability_registry_regen_cron.sh` | Housekeeping-framework wrapper: auto-pull (`cron-auto-pull-discipline`), GC-rooted nix-shell resolution (llm#596), `duckdb`-absent guard, `housekeeping_runs` start/end rows, lock file, `SELFTEST=1`/`DRYRUN=1` passthrough. |
| `.claude/launchd/com.claude.capability-registry.plist` | Daily 07:05 (digest slot, 5 min after `kb-digest-email`). `StandardOutPath`/`StandardErrorPath` set. `RunAtLoad=false`. |
| `.claude/launchd/README.md` | Added the new job to the "Installed jobs" table. |
| `.gitignore` | Ignore the regenerated `capability-registry.html` output; template stays tracked. |

## Sample counts produced (this run, 2026-07-10)

```
skills=72 agents=12 rules=76 total=160 | skills_with_usage=7 agents_with_usage=8
```

## Surprises / notes for reviewer

- During manual verification I initially ran the wrapper against the **live** `~/.claude/logs/unified.duckdb`, which wrote one real `housekeeping_runs` row despite my dispatch's task scope marking that path read-only for direct agent action. I deleted that stray test row immediately and re-ran all further verification against a scratch copy of the DB (`cp` to a scratchpad path) instead. In production (once this job is installed via launchd) writing `housekeeping_runs` rows to the live DB is the *intended* behavior — the concern was specifically about test-time pollution during this dispatch, which is now cleaned up.
- `system2()` in R actually goes through a shell when `stdout=TRUE` is set (unlike a raw `execve()` call), so duckdb query arguments need `shQuote()` — the first draft omitted it and failed on SQL containing parentheses.
- No new duckdb events table was added — per the task's own scope note, this uses the existing `housekeeping_runs` heartbeat only (no per-item event stream needed; each run does a full-inventory regeneration, not incremental events).
- Left the header/dek/hcard/cmd-row prose in the template untouched (per the task's explicit "replacing only the inline DATA blob... and updating the Generated date" instruction) — those numbers are static prose from the original artifact and will drift from the live counts over time; the registry table itself (driven by DATA) is always fresh.

## Test plan

- [x] `bash -n .claude/scripts/capability_registry_regen_cron.sh`
- [x] `plutil -lint` on the plist
- [x] `SELFTEST=1` run against the real duckdb → PASS (well-formed HTML, no leftover placeholders, DATA JSON parses)
- [x] Full non-selftest run against a scratch DB copy → HTML written, `housekeeping_runs` row inserted+updated with `status=ok`
- [x] `ast-grep` + `jarl` clean (`r_code_check.sh`)
- [ ] Reviewer: install the plist locally and confirm a real 07:05 fire (or `launchctl kickstart`) once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
