### PR TITLE
fix(#510): dirty-tolerant cron deploy pull + surface deploy staleness (attempt #3)

### DIFF
--- a/.claude/scripts/capability_registry_regen_cron.sh
+++ b/.claude/scripts/capability_registry_regen_cron.sh
@@ -95,19 +95,15 @@ if [ "${SELFTEST}" = "1" ]; then
   exit "${PIPESTATUS[0]}"
 fi
 
-# ── Deploy: pull latest main before running (llm#510) ─────────────────────────
+# ── Deploy: pull latest main before running (llm#510, attempt #3) ────────────
 # Cron wrappers run against ${REPO_ROOT}; without this step every gh pr merge
 # ships nothing -- the cron uses whatever was last manually pulled to the main
-# checkout. The fast-forward is silent on success and never overwrites local
-# work because of --ff-only.
-if [ -z "${SKIP_CRON_PULL:-}" ]; then
-    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
-    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
-        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    else
-        log "deploy WARN: ff-only failed — running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    fi
-fi
+# checkout. cron_deploy_pull is dirty-tolerant: it auto-stashes and retries
+# the ff-only merge instead of silently giving up when the tree is dirty
+# (the previous bug -- see cron_deploy_pull.sh header for full rationale).
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/.claude/scripts/cron_deploy_pull.sh"
+cron_deploy_pull "${REPO_ROOT}" log
 log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
 
 # ── Verify nix shell is accessible ────────────────────────────────────────────

--- a/.claude/scripts/cron_deploy_pull.sh
+++ b/.claude/scripts/cron_deploy_pull.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# cron_deploy_pull.sh — Shared dirty-tolerant "pull latest main" helper for
+# launchd cron wrappers (llm#510, attempt #3).
+#
+# Problem this fixes:
+#   `git merge --ff-only origin/main` aborts whenever the main checkout's
+#   working tree is dirty (very common — orchestrator sessions routinely
+#   leave uncommitted .claude/memory/*.md edits). The abort was previously
+#   swallowed by `2>/dev/null`, and every wrapper's `else` branch silently
+#   ran stale code for weeks with no visible signal (llm#510 recurrence,
+#   2026-07-11).
+#
+# What this helper does:
+#   1. Fetches origin/main.
+#   2. If already up to date (0 commits behind), logs and returns 0.
+#   3. If behind and the tree is clean, does a plain ff-only merge.
+#   4. If behind and the tree is DIRTY, auto-stashes (including untracked
+#      files), retries the ff-only merge, then pops the stash back.
+#      - If the stash pop conflicts, the fast-forward is KEPT (never
+#        rolled back) and the stash entry is left on the stack for manual
+#        resolution — local edits are never lost silently.
+#   5. Always writes a machine-readable JSON status file so downstream
+#      consumers (the daily email) can surface staleness to a human.
+#
+# Usage (source, then call — NOT executed directly):
+#   # shellcheck disable=SC1091
+#   source "${REPO_ROOT}/.claude/scripts/cron_deploy_pull.sh"
+#   cron_deploy_pull "${REPO_ROOT}" log
+#
+# Arguments:
+#   $1  Absolute path to the repo root to pull in.
+#   $2  Name of an already-defined shell function to use for logging
+#       (e.g. `log`). Invoked as `"$2" "message"`. Optional — if omitted
+#       or not a defined function, logging is silently skipped.
+#
+# Respects SKIP_CRON_PULL exactly like the block it replaces: any non-empty
+# value skips the pull entirely (used by manual/dry-run invocations).
+#
+# Env:
+#   DEPLOY_STATUS_FILE   Override path for the JSON status file.
+#                        Default: $HOME/.claude/logs/cron_deploy_status.json
+#
+# Return code: 0 on success (including "clean" and "autostashed" and
+# "pop-conflict" — the pull itself succeeded in all three cases) or when
+# skipped via SKIP_CRON_PULL. Non-zero ONLY when the ff-only merge itself
+# could not be made to succeed (reason=ff-failed) — a genuine deploy
+# failure, distinct from the informational pop-conflict case.
+#
+# Tracked in llm#510 (attempt #3).
+
+cron_deploy_pull() {
+  local repo="$1"
+  local log_fn="${2:-}"
+  local status_file="${DEPLOY_STATUS_FILE:-${HOME}/.claude/logs/cron_deploy_status.json}"
+
+  _cdp_log() {
+    if [ -n "${log_fn}" ] && declare -F "${log_fn}" >/dev/null 2>&1; then
+      "${log_fn}" "$1"
+    fi
+  }
+
+  _cdp_write_status() {
+    local ok="$1" behind="$2" head_sha="$3" reason="$4"
+    local ts
+    ts="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    mkdir -p "$(dirname "${status_file}")" 2>/dev/null || true
+    printf '{"ok":%s,"behind":%s,"head":"%s","reason":"%s","ts":"%s"}\n' \
+      "${ok}" "${behind}" "${head_sha}" "${reason}" "${ts}" \
+      > "${status_file}" 2>/dev/null || true
+  }
+
+  if [ -n "${SKIP_CRON_PULL:-}" ]; then
+    _cdp_log "deploy: SKIP_CRON_PULL set — not pulling"
+    return 0
+  fi
+
+  git -C "${repo}" fetch origin main 2>/dev/null || true
+
+  local behind head_sha
+  behind="$(git -C "${repo}" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)"
+  [ -z "${behind}" ] && behind=0
+  head_sha="$(git -C "${repo}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+  if [ "${behind}" = "0" ]; then
+    _cdp_log "deploy: up to date"
+    _cdp_write_status true 0 "${head_sha}" "clean"
+    return 0
+  fi
+
+  # Behind — try a straight ff-only merge first (clean-tree fast path).
+  if git -C "${repo}" merge --ff-only origin/main 2>/dev/null; then
+    head_sha="$(git -C "${repo}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    _cdp_log "deploy: ff to ${head_sha}"
+    _cdp_write_status true 0 "${head_sha}" "clean"
+    return 0
+  fi
+
+  _cdp_log "deploy: ff-only failed on first attempt (${behind} behind) — checking for dirty tree"
+
+  if git -C "${repo}" diff --quiet 2>/dev/null && git -C "${repo}" diff --cached --quiet 2>/dev/null; then
+    # Tree is clean but ff-only still failed — genuine divergence (local
+    # commits ahead / diverged history), not a dirty-tree issue. Do not
+    # stash; nothing to stash, and stashing would not fix divergence.
+    head_sha="$(git -C "${repo}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    _cdp_log "deploy WARN: ff-only failed — running against ${head_sha} (${behind} behind; tree clean, likely diverged history)"
+    _cdp_write_status false "${behind}" "${head_sha}" "ff-failed"
+    return 1
+  fi
+
+  # Tree is dirty — auto-stash (including untracked) and retry.
+  local stash_marker="cron-deploy-autostash-$$"
+  if ! git -C "${repo}" stash push --include-untracked -m "${stash_marker}" 2>/dev/null; then
+    head_sha="$(git -C "${repo}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    _cdp_log "deploy WARN: stash push failed — running against ${head_sha} (${behind} behind)"
+    _cdp_write_status false "${behind}" "${head_sha}" "ff-failed"
+    return 1
+  fi
+
+  if ! git -C "${repo}" merge --ff-only origin/main 2>/dev/null; then
+    # Should be rare (tree was just made clean by the stash), but restore
+    # the stash and bail without losing anything if it happens.
+    git -C "${repo}" stash pop 2>/dev/null || true
+    head_sha="$(git -C "${repo}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    _cdp_log "deploy WARN: ff-only failed even after autostash — running against ${head_sha} (${behind} behind)"
+    _cdp_write_status false "${behind}" "${head_sha}" "ff-failed"
+    return 1
+  fi
+
+  head_sha="$(git -C "${repo}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+  if git -C "${repo}" stash pop 2>/dev/null; then
+    _cdp_log "deploy: ff to ${head_sha} (autostashed + restored local edits)"
+    _cdp_write_status true 0 "${head_sha}" "autostashed"
+    return 0
+  fi
+
+  # Pop conflicted. The fast-forward already succeeded (HEAD is now
+  # ${head_sha}) — keep it. Do NOT attempt to undo the merge: there is no
+  # in-progress merge to abort once --ff-only has completed; the conflict
+  # is confined to applying the stash back onto the working tree. Leave
+  # the stash entry on the stack (visible via `git stash list`) so the
+  # user's edits are preserved for manual `git stash pop` resolution.
+  _cdp_log "deploy WARN: ff applied to ${head_sha} but stash pop CONFLICTED — local edits preserved in 'git stash list' (${stash_marker}); resolve manually with 'git stash pop'"
+  _cdp_write_status false "${behind}" "${head_sha}" "pop-conflict"
+  return 0
+}

--- a/.claude/scripts/roborev_bridge_to_unified.sh
+++ b/.claude/scripts/roborev_bridge_to_unified.sh
@@ -91,16 +91,14 @@ fi
 printf '%d' "$$" > "${LOCK_FILE}"
 trap 'rm -f "${LOCK_FILE}"' EXIT
 
-# -- Deploy: pull latest main (cron-auto-pull-discipline, llm#510) ------------
+# -- Deploy: pull latest main before running (llm#510, attempt #3) -----------
 # Without this step every gh pr merge ships nothing to the cron.
-if [ -z "${SKIP_CRON_PULL:-}" ]; then
-    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
-    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
-        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    else
-        log "deploy WARN: ff-only failed -- running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    fi
-fi
+# cron_deploy_pull is dirty-tolerant: it auto-stashes and retries the
+# ff-only merge instead of silently giving up when the tree is dirty (the
+# previous bug -- see cron_deploy_pull.sh header for full rationale).
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/.claude/scripts/cron_deploy_pull.sh"
+cron_deploy_pull "${REPO_ROOT}" log
 log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
 
 # -- DuckDB availability check ------------------------------------------------

--- a/.claude/scripts/send_overnight_self_review_email.R
+++ b/.claude/scripts/send_overnight_self_review_email.R
@@ -639,6 +639,33 @@ cron_health <- safe_query("
     plist_label
 ")
 
+# Freshness guard (llm#510 attempt #3): the ROW_NUMBER()-partitioned query
+# above answers "what is the latest known state per plist", which is only
+# trustworthy if the launchd_health_events table itself has been refreshed
+# recently. If the table's sole weekly writer (launchd_health_weekly_cron.sh)
+# has not fired in a while, every row below is stale — a "failed" state may
+# just be old news, not a current problem. Surfaced after the false-positive
+# "5 failed" report on 2026-07-11 (metrics-etl/self-review/weekly-rollup were
+# actually last-exit 0 per `launchctl print`; the table just hadn't refreshed).
+cron_freshness <- safe_query("SELECT MAX(fired_at) AS newest_fired_at FROM launchd_health_events")
+cron_stale_note <- ""
+if (nrow(cron_freshness) > 0L) {
+  .newest_fired_at <- cron_freshness$newest_fired_at[[1]]
+  if (!is.null(.newest_fired_at) && !is.na(.newest_fired_at)) {
+    .cron_age_hours <- as.numeric(difftime(Sys.time(),
+                                            as.POSIXct(.newest_fired_at, tz = "UTC"),
+                                            units = "hours"))
+    if (!is.na(.cron_age_hours) && .cron_age_hours > 48) {
+      cron_stale_note <- sprintf(
+        '<p style="color:#ff5252;font-size:%s;margin-bottom:8px;">
+  &#9888; launchd_health_events is stale (newest row %s, %.0fh old) — \'failed\'
+  states below may be historical, not current. Verify with <code>launchctl print</code>.</p>',
+        EMAIL_FONT_SUBTITLE, .newest_fired_at, .cron_age_hours
+      )
+    }
+  }
+}
+
 if (nrow(cron_health) > 0L) {
   n_fail  <- sum(cron_health$state %in% c("loaded_recent_fail", "unloaded", "missing"),
                  na.rm = TRUE)
@@ -671,7 +698,9 @@ if (nrow(cron_health) > 0L) {
     )
   }), collapse = "\n")
 
-  cron_table_html <- sprintf(
+  cron_table_html <- paste0(
+    cron_stale_note,
+    sprintf(
     '<table style="width:auto;border-collapse:collapse;color:%s;font-size:%s;">
 <thead>
 <tr style="background-color:%s;">
@@ -685,6 +714,7 @@ if (nrow(cron_health) > 0L) {
 <tbody>%s</tbody>
 </table>',
     DARK_TEXT, EMAIL_FONT_BODY, DARK_ROW_ALT, cron_rows_html
+    )
   )
   if (n_fail > 0L) {
     cron_table_html <- paste0(
@@ -701,9 +731,12 @@ if (nrow(cron_health) > 0L) {
     n_plists, n_ok, n_fail
   )
 } else {
-  cron_table_html <- sprintf(
-    '<p style="color:%s;font-size:%s;">No launchd_health_events recorded yet.</p>',
-    DARK_MUTED, EMAIL_FONT_BODY
+  cron_table_html <- paste0(
+    cron_stale_note,
+    sprintf(
+      '<p style="color:%s;font-size:%s;">No launchd_health_events recorded yet.</p>',
+      DARK_MUTED, EMAIL_FONT_BODY
+    )
   )
   sec3e_summary <- "no data yet"
 }

--- a/.claude/scripts/send_roborev_email.R
+++ b/.claude/scripts/send_roborev_email.R
@@ -264,6 +264,41 @@ if (.d1_has_reviews && .d1_no_throughput) {
   }
 }
 
+# ── Deploy staleness banner (llm#510 attempt #3) ──────────────────────────────
+# cron_deploy_pull.sh (sourced by bin/roborev_daily_cron.sh) writes a status
+# file every run recording whether the local main checkout was successfully
+# brought up to date with origin/main before this email was generated. If the
+# pull failed, or main is still behind, the metrics below were computed
+# against stale code — surface that prominently instead of silently.
+deploy_status_file <- Sys.getenv(
+  "DEPLOY_STATUS_FILE",
+  file.path(Sys.getenv("HOME"), ".claude", "logs", "cron_deploy_status.json")
+)
+deploy_stale_block <- ""
+if (file.exists(deploy_status_file)) {
+  deploy_status <- tryCatch(
+    jsonlite::fromJSON(deploy_status_file, simplifyVector = TRUE),
+    error = function(e) NULL
+  )
+  if (!is.null(deploy_status)) {
+    .ds_ok     <- isTRUE(deploy_status$ok)
+    .ds_behind <- suppressWarnings(as.integer(deploy_status$behind %||% 0L))
+    .ds_behind_positive <- isTRUE(!is.na(.ds_behind) && .ds_behind > 0L)
+    if (!.ds_ok || .ds_behind_positive) {
+      .ds_behind_str <- if (is.na(.ds_behind)) "an unknown number of" else as.character(.ds_behind)
+      deploy_stale_block <- sprintf(
+        '<div style="background-color:#5b1a1a; color:#fff5f5; border:2px solid #f08080;
+          border-radius:6px; padding:14px 18px; margin:16px 0; font-size:%s;">
+          <strong style="font-size:15px;">&#9888; DEPLOY STALE</strong><br>
+          <span>Local main is %s commit(s) behind origin/main (reason: %s) —
+          merged fixes are NOT live. See llm#510.</span>
+        </div>',
+        EMAIL_FONT_BODY, .ds_behind_str, deploy_status$reason %||% "unknown"
+      )
+    }
+  }
+}
+
 # Zero-action error block (prepended before dashboard CTA when fired — llm#484)
 zero_action_block <- if (zero_action_fired) {
   sprintf(
@@ -279,8 +314,11 @@ zero_action_block <- if (zero_action_fired) {
   )
 } else ""
 
-# Dashboard link CTA (llm#484: zero_action_block prepended when trap fires)
+# Dashboard link CTA (llm#484: zero_action_block prepended when trap fires;
+# llm#510: deploy_stale_block prepended ahead of that when the deploy pull
+# failed or main is still behind origin)
 dashboard_block <- paste0(
+  deploy_stale_block,
   zero_action_block,
   sprintf(
     '<div style="margin: 16px 0;">

--- a/bin/config_digest_cron.sh
+++ b/bin/config_digest_cron.sh
@@ -73,18 +73,14 @@ fi
 printf '%d' "$$" > "${LOCK_FILE}"
 trap 'rm -f "${LOCK_FILE}"' EXIT
 
-# ── Deploy: pull latest main before running (llm#510) ─────────────────────────
+# ── Deploy: pull latest main before running (llm#510, attempt #3) ────────────
 # Cron wrappers run against ${REPO_ROOT}; without this step every gh pr merge
-# ships nothing. The fast-forward is silent on success and never overwrites local
-# work because of --ff-only.
-if [ -z "${SKIP_CRON_PULL:-}" ]; then
-    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
-    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
-        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    else
-        log "deploy WARN: ff-only failed — running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    fi
-fi
+# ships nothing. cron_deploy_pull is dirty-tolerant: it auto-stashes and
+# retries the ff-only merge instead of silently giving up when the tree is
+# dirty (the previous bug — see cron_deploy_pull.sh header for rationale).
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/.claude/scripts/cron_deploy_pull.sh"
+cron_deploy_pull "${REPO_ROOT}" log
 log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
 
 # ── Load credentials ──────────────────────────────────────────────────────────

--- a/bin/kb_digest_daily_cron.sh
+++ b/bin/kb_digest_daily_cron.sh
@@ -89,19 +89,15 @@ fi
 printf '%d' "$$" > "${LOCK_FILE}"
 trap 'rm -f "${LOCK_FILE}"' EXIT
 
-# ── Deploy: pull latest main before running (llm#510) ─────────────────────────
+# ── Deploy: pull latest main before running (llm#510, attempt #3) ────────────
 # Cron wrappers run against ${REPO_ROOT}; without this step every gh pr merge
 # ships nothing — the cron uses whatever was last manually pulled to the main
-# checkout. The fast-forward is silent on success and never overwrites local
-# work because of --ff-only.
-if [ -z "${SKIP_CRON_PULL:-}" ]; then
-    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
-    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
-        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    else
-        log "deploy WARN: ff-only failed — running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    fi
-fi
+# checkout. cron_deploy_pull is dirty-tolerant: it auto-stashes and retries
+# the ff-only merge instead of silently giving up when the tree is dirty
+# (the previous bug — see cron_deploy_pull.sh header for full rationale).
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/.claude/scripts/cron_deploy_pull.sh"
+cron_deploy_pull "${REPO_ROOT}" log
 log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
 
 # ── Load credentials from env file ────────────────────────────────────────────

--- a/bin/launchd_health_weekly_cron.sh
+++ b/bin/launchd_health_weekly_cron.sh
@@ -91,19 +91,15 @@ if [[ -f "$EMAIL_ENV_FILE" ]]; then
   log "sourced email credentials from $EMAIL_ENV_FILE"
 fi
 
-# ── Deploy: pull latest main before running (llm#510) ─────────────────────────
+# ── Deploy: pull latest main before running (llm#510, attempt #3) ────────────
 # Cron wrappers run against ${REPO_ROOT}; without this step every gh pr merge
 # ships nothing — the cron uses whatever was last manually pulled to the main
-# checkout. The fast-forward is silent on success and never overwrites local
-# work because of --ff-only.
-if [ -z "${SKIP_CRON_PULL:-}" ]; then
-    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
-    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
-        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    else
-        log "deploy WARN: ff-only failed — running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    fi
-fi
+# checkout. cron_deploy_pull is dirty-tolerant: it auto-stashes and retries
+# the ff-only merge instead of silently giving up when the tree is dirty
+# (the previous bug — see cron_deploy_pull.sh header for full rationale).
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/.claude/scripts/cron_deploy_pull.sh"
+cron_deploy_pull "${REPO_ROOT}" log
 log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
 
 # ── Verify nix-shell is accessible (mirrors roborev_daily_cron.sh) ────────────

--- a/bin/overnight_self_review_email_cron.sh
+++ b/bin/overnight_self_review_email_cron.sh
@@ -73,15 +73,13 @@ fi
 printf '%d' "$$" > "${LOCK_FILE}"
 trap 'rm -f "${LOCK_FILE}"' EXIT
 
-# ── Deploy: pull latest main before running (cron-auto-pull-discipline) ───────
-if [ -z "${SKIP_CRON_PULL:-}" ]; then
-    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
-    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
-        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    else
-        log "deploy WARN: ff-only failed — running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    fi
-fi
+# ── Deploy: pull latest main before running (llm#510, attempt #3) ────────────
+# cron_deploy_pull is dirty-tolerant: it auto-stashes and retries the
+# ff-only merge instead of silently giving up when the tree is dirty (the
+# previous bug — see cron_deploy_pull.sh header for full rationale).
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/.claude/scripts/cron_deploy_pull.sh"
+cron_deploy_pull "${REPO_ROOT}" log
 log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
 
 # ── Load credentials (bws injection takes priority over flat file) ─────────────

--- a/bin/roborev_daily_cron.sh
+++ b/bin/roborev_daily_cron.sh
@@ -78,19 +78,15 @@ fi
 printf '%d' "$$" > "${LOCK_FILE}"
 trap 'rm -f "${LOCK_FILE}"' EXIT
 
-# ── Deploy: pull latest main before running (llm#510) ─────────────────────────
+# ── Deploy: pull latest main before running (llm#510, attempt #3) ────────────
 # Cron wrappers run against ${REPO_ROOT}; without this step every gh pr merge
 # ships nothing — the cron uses whatever was last manually pulled to the main
-# checkout. The fast-forward is silent on success and never overwrites local
-# work because of --ff-only.
-if [ -z "${SKIP_CRON_PULL:-}" ]; then
-    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
-    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
-        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    else
-        log "deploy WARN: ff-only failed — running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    fi
-fi
+# checkout. cron_deploy_pull is dirty-tolerant: it auto-stashes and retries
+# the ff-only merge instead of silently giving up when the tree is dirty
+# (the previous bug — see cron_deploy_pull.sh header for full rationale).
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/.claude/scripts/cron_deploy_pull.sh"
+cron_deploy_pull "${REPO_ROOT}" log
 log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
 
 # ── Load credentials from env file ────────────────────────────────────────────

--- a/bin/roborev_weekly_rollup_cron.sh
+++ b/bin/roborev_weekly_rollup_cron.sh
@@ -50,19 +50,15 @@ else
   export EMAIL_DRY_RUN
 fi
 
-# ── Deploy: pull latest main before running (llm#510) ─────────────────────────
+# ── Deploy: pull latest main before running (llm#510, attempt #3) ────────────
 # Cron wrappers run against ${REPO_DIR}; without this step every gh pr merge
 # ships nothing — the cron uses whatever was last manually pulled to the main
-# checkout. The fast-forward is silent on success and never overwrites local
-# work because of --ff-only.
-if [ -z "${SKIP_CRON_PULL:-}" ]; then
-    git -C "${REPO_DIR}" fetch origin main 2>/dev/null
-    if git -C "${REPO_DIR}" merge --ff-only origin/main 2>/dev/null; then
-        log "deploy: ff to $(git -C "${REPO_DIR}" rev-parse --short HEAD)"
-    else
-        log "deploy WARN: ff-only failed — running against $(git -C "${REPO_DIR}" rev-parse --short HEAD)"
-    fi
-fi
+# checkout. cron_deploy_pull is dirty-tolerant: it auto-stashes and retries
+# the ff-only merge instead of silently giving up when the tree is dirty
+# (the previous bug — see cron_deploy_pull.sh header for full rationale).
+# shellcheck disable=SC1091
+source "${REPO_DIR}/.claude/scripts/cron_deploy_pull.sh"
+cron_deploy_pull "${REPO_DIR}" log
 log "HEAD: $(git -C "${REPO_DIR}" rev-parse --short HEAD) $(git -C "${REPO_DIR}" log -1 --format='%s')"
 
 # ── Verify nix-shell is accessible (mirrors roborev_daily_cron.sh) ────────────

--- a/bin/stage1_findings_daily_cron.sh
+++ b/bin/stage1_findings_daily_cron.sh
@@ -72,19 +72,15 @@ fi
 printf '%d' "$$" > "${LOCK_FILE}"
 trap 'rm -f "${LOCK_FILE}"' EXIT
 
-# ── Deploy: pull latest main before running (llm#510) ─────────────────────────
+# ── Deploy: pull latest main before running (llm#510, attempt #3) ────────────
 # Cron wrappers run against ${REPO_ROOT}; without this step every gh pr merge
 # ships nothing — the cron uses whatever was last manually pulled to the main
-# checkout. The fast-forward is silent on success and never overwrites local
-# work because of --ff-only.
-if [ -z "${SKIP_CRON_PULL:-}" ]; then
-    git -C "${REPO_ROOT}" fetch origin main 2>/dev/null
-    if git -C "${REPO_ROOT}" merge --ff-only origin/main 2>/dev/null; then
-        log "deploy: ff to $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    else
-        log "deploy WARN: ff-only failed — running against $(git -C "${REPO_ROOT}" rev-parse --short HEAD)"
-    fi
-fi
+# checkout. cron_deploy_pull is dirty-tolerant: it auto-stashes and retries
+# the ff-only merge instead of silently giving up when the tree is dirty
+# (the previous bug — see cron_deploy_pull.sh header for full rationale).
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/.claude/scripts/cron_deploy_pull.sh"
+cron_deploy_pull "${REPO_ROOT}" log
 log "HEAD: $(git -C "${REPO_ROOT}" rev-parse --short HEAD) $(git -C "${REPO_ROOT}" log -1 --format='%s')"
 
 # ── Load credentials from env file ────────────────────────────────────────────


### PR DESCRIPTION
## Problem (issue #510, reopened 2026-07-11)

Every launchd cron self-updates the local main checkout via `git merge --ff-only origin/main` (added in #513). But `--ff-only` **aborts on a dirty tree** — and the main checkout is ~always dirty (orchestrator sessions leave uncommitted `.claude/memory/*.md` edits). The abort was swallowed by `2>/dev/null`, so wrappers silently ran **stale code for weeks**. On 2026-07-11 local main was 10 commits behind; the 07:00 roborev email ran pre-#765 code and showed `n/a` p50s. This is the structural reason the deploy gap recurs.

## Fix

- **New shared helper `.claude/scripts/cron_deploy_pull.sh`** — fetch → detect behind → clean-tree ff fast path → **dirty-tree path that auto-stashes (incl. untracked), retries `--ff-only`, then pops**. On pop-conflict the fast-forward is **kept** and the stash left on the stack, so local edits are never lost. Writes a machine-readable JSON status file each run.
- **All 9 cron wrappers** converted to `source` + call the helper (preserving `SKIP_CRON_PULL` and the trailing `HEAD:` log line).
- **`send_roborev_email.R`** — prepends a red **"DEPLOY STALE"** banner when the status file reports `ok=false` or `behind>0`, so a jam is visible next morning instead of silently producing stale metrics.
- **`send_overnight_self_review_email.R`** — flags the cron-health section when `launchd_health_events` is >48h stale. This addresses the **2026-07-11 false "5 failed cron jobs"** report (metrics-etl / self-review-stage1 / weekly-rollup actually have `last exit code 0` per `launchctl print`; the table's sole weekly writer had not refreshed since ~Jun 28).

## Verification

- `bash -n` passes on all 10 shell scripts.
- Both R files `parse()` cleanly.
- Helper sources, defines `cron_deploy_pull`, `SKIP_CRON_PULL` path exits 0; status JSON format valid.

## Provenance

Edits were produced by a `fixer` dispatch (Dispatch-Id `67ea011c`) that stalled at the verify stage; salvaged, re-verified, and finalized by the orchestrator. Not merged — for review.

Refs #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)