### PR TITLE
feat(governance): press-release-first gate (#769) + CC BY 4.0 content licensing (#767)

### DIFF
--- a/.claude/RULES.md
+++ b/.claude/RULES.md
@@ -4,7 +4,7 @@ Companion to `AGENTS.md`. Holds only the categorised rule index; the mandatory-r
 
 | Group | Rules |
 |---|---|
-| **Core** | `auto-delegation`, `architecture-planning`, `orchestrator-protocol`, `systematic-debugging`, `verification-before-completion`, `pivot-signal`, `cross-cutting-rename`, `branch-harvest-on-fork`, `pr-shipping-discipline`, `skills-vs-mcp` |
+| **Core** | `auto-delegation`, `architecture-planning`, `orchestrator-protocol`, `systematic-debugging`, `verification-before-completion`, `pivot-signal`, `cross-cutting-rename`, `branch-harvest-on-fork`, `pr-shipping-discipline`, `skills-vs-mcp`, `press-release-first` |
 | **Nix** | `nix-agent-shell-protocol`, `nix-nested-shell-isolation` |
 | **MCP** | `btw-timeouts` |
 | **Bash** | `bash-safety` |
@@ -17,7 +17,7 @@ Companion to `AGENTS.md`. Holds only the categorised rule index; the mandatory-r
 | **Knowledge** | `wiki-conventions` |
 | **Quality** | `accessibility`, `analytical-review-checklist`, `analysis-rationale-mandatory`, `braindump-closed-loop` |
 | **Security** | `destructive-fs-guard`, `destructive-ops-guard`, `permission-discipline`, `backup-architecture` |
-| **Other** | `website-index-update`, `t-lang-r-package`, `huggingface-upload`, `gh-pages-nojekyll`, `namespace-discipline`, `portable-paths`, `project-charter`, `roborev-resolution`, `single-change-experiment`, `snapshot-tests-mandatory`, `search-all-pipeline-stages`, `audience-communication` |
+| **Other** | `website-index-update`, `t-lang-r-package`, `huggingface-upload`, `gh-pages-nojekyll`, `namespace-discipline`, `portable-paths`, `project-charter`, `roborev-resolution`, `single-change-experiment`, `snapshot-tests-mandatory`, `search-all-pipeline-stages`, `audience-communication`, `content-licensing` |
 
 ## Adding a new rule
 

--- a/.claude/rules/content-licensing.md
+++ b/.claude/rules/content-licensing.md
@@ -1,0 +1,69 @@
+---
+description: Public-project licensing policy — content (docs, vignettes, wiki, figures, data) under CC BY 4.0; code stays under its OSS licence (MIT/etc.). Never put source code under a CC licence.
+paths:
+  - "**/LICENSE*"
+  - "**/DESCRIPTION"
+  - "**/README.qmd"
+  - "**/README.md"
+  - "**/_quarto.yml"
+---
+
+# Rule: Public-Project Licensing Policy
+
+## Decision
+
+[#767](https://github.com/JohnGavin/llm/issues/767), decided 2026-07-11
+(**Option 3**): standardise public projects on a **content vs code** split.
+
+| Layer | Licence | Applies to |
+|---|---|---|
+| **Content** | **CC BY 4.0** (Attribution) | vignettes, docs, pkgdown/Quarto sites, wiki prose, diagrams, figures, datasets |
+| **Code** | existing **OSS licence** (MIT unless the repo already differs) | `R/`, `inst/`, scripts, `.github/`, anything that executes |
+
+CC BY 4.0 was chosen over BY-NC-SA to **maximise reach and compatibility**:
+attribution only, no NonCommercial ambiguity, ShareAlike dropped, Wikipedia/OER
+compatible. The trade-off accepted: no protection against commercial
+repackaging of our writing.
+
+## CRITICAL: Never put source code under a Creative Commons licence
+
+Creative Commons **explicitly recommends against CC licences for software** —
+they don't address source-vs-object code or patent grants and aren't
+OSI-approved. For R packages this also breaks CRAN-readiness (`DESCRIPTION`
+`License:` must be a recognised software licence). Code stays OSS; only content
+is CC.
+
+## Application
+
+- **`DESCRIPTION` `License:`** — set/keep the software (OSS) licence via the
+  standard SPDX id; CRAN does not validate content licences.
+- **Content licence** — add a `LICENSE.content.md` (or a `## Licence` README
+  section) stating "Documentation and other content in this repository are
+  licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/);
+  source code is licensed under <OSS licence>." Link the deed.
+- **README `## Licence` section** — state the split in one short paragraph so
+  reusers see it immediately.
+- **pkgdown/Quarto sites** — add a footer attribution + CC BY 4.0 link.
+
+## Scope and exemptions
+
+- Applies to **public** repos only.
+- The local-only `knowledge/` hub is **never published** — CC does not apply;
+  exclude it explicitly (it already carries a `PRIVATE` marker + pre-push block).
+- Private/PHI repos (e.g. `mycare`) are out of scope.
+- Rollout to existing public repos is phased and confirmed per repo — see #767;
+  dead scaffolds are not licensed (subtractive-first).
+
+## Forbidden patterns
+
+| Pattern | Why wrong | Fix |
+|---|---|---|
+| CC BY 4.0 in `DESCRIPTION` `License:` | Not a recognised software licence; breaks CRAN | OSS licence for code; CC for content only |
+| CC BY-NC / -SA re-introduced without a new decision | Reverses #767 (NC ambiguity, incompatibility) | Keep CC BY 4.0 unless #767 is superseded |
+| Content licence added to the `knowledge/` hub | Hub is local-only, never published | Exclude; it is not a public project |
+
+## Related
+
+- [#767](https://github.com/JohnGavin/llm/issues/767) — decision + full option analysis.
+- `knowledge-base-wiki` skill / `wiki-storage-policy` — the local-only hub is out of scope.
+- `press-release-first` — companion governance rule created in the same PR.

--- a/.claude/rules/press-release-first.md
+++ b/.claude/rules/press-release-first.md
@@ -1,0 +1,80 @@
+---
+description: Every new skill, rule, or command must open with a one-line when-to-use ("press release") and a Chesterton check naming what existing surface it does NOT duplicate, before it is authored
+paths:
+  - ".claude/skills/**"
+  - ".claude/rules/**"
+  - ".claude/commands/**"
+---
+
+# Rule: Press-Release-First for New Config Surface
+
+## Origin
+
+[#769](https://github.com/JohnGavin/llm/issues/769) — applying David Epstein's
+"Constraints, not Goals" (Tony Fadell's *"draw the box / write the press release
+first"*) to our own config. The talk's core warning: **abundance breeds
+sprawling, unoriginal solutions.** Our config *is* that abundance (76 rules,
+73 skills, 14 commands). The constraint therefore applies to the config itself.
+
+## When This Applies
+
+Authoring any NEW `.claude/skills/**`, `.claude/rules/**`, or
+`.claude/commands/**` file. Not for edits to existing surface (those go through
+the normal review path).
+
+## CRITICAL: State the outcome and the non-duplication BEFORE authoring
+
+A new skill/rule/command may only be created after its author (human or agent)
+can state, up front and in one or two lines each:
+
+1. **Press release** — the one-line *when-to-use*: the concrete trigger and the
+   user-facing outcome. If you cannot say in one line when this fires and what
+   it changes, the surface is not ready to exist.
+2. **Chesterton check** — name the *existing* rule/skill/command/hook/launchd
+   job that is closest to this, and state why it does **not** already cover the
+   need. "Nothing is close" is a valid answer only after you have searched
+   (`grep` the rules/skills index). A hook or pulse field often already does the
+   job (cf. #750, which pruned 7 commands whose deterministic core already ran
+   in hooks/launchd).
+
+If the Chesterton check finds an existing surface that covers ≥80% of the need,
+**extend that surface instead of adding a new one.** Subtraction and reuse beat
+addition (see `simplicity` principle in `CLAUDE.md`).
+
+## Required header block
+
+Every new file opens with the machinery it already needs, so the gate is
+self-documenting:
+
+- **Skills:** the `description:` frontmatter already IS the press release — it
+  must lead with the trigger ("Use when …") and be specific enough to match on.
+  Add a one-line `<!-- not: … -->` comment naming the nearest existing skill it
+  does not duplicate.
+- **Rules:** the `description:` frontmatter is the press release; a `## Origin`
+  or opening line states the nearest existing rule and why this is distinct.
+  (`paths:` scoping is separately mandatory — see the rule-loading enforcement
+  in `CLAUDE.md`; a non-mandatory rule without `paths:` is a defect.)
+- **Commands:** the command's first line states its trigger and what automated
+  hook/launchd twin it is NOT (the #750 failure mode: commands that duplicate an
+  already-automated path).
+
+## Forbidden patterns
+
+| Pattern | Why wrong | Fix |
+|---|---|---|
+| New rule/skill authored, justification written afterward | Accretion-first; the #769 anti-pattern | State press release + Chesterton check first |
+| New command duplicating a hook/launchd/skill twin | The #750 vestigial-command failure | Extend the automated path; don't add a command |
+| "Might be useful later" surface with no concrete trigger | Speculative abundance | No trigger → don't create it |
+| New rule with no `paths:` scoping | Loads into every session/subagent (~250 tok/KB) | Add a real path glob (mandatory rules are the only exception) |
+
+## Relationship to other rules
+
+- `auto-delegation` — new rule creation is an orchestrator bounded exception; this
+  rule gates *what* may be created, not *who* creates it.
+- `housekeeping-framework` — the census/pruning side; this rule is the intake
+  gate, housekeeping is the exit sweep. Together they bound the config surface.
+- `skills-vs-mcp` — companion authoring discipline for the skill-vs-MCP choice.
+- [#769](https://github.com/JohnGavin/llm/issues/769) — origin (Epstein,
+  "Constraints, not Goals"; Fadell "write the press release first").
+- [#750](https://github.com/JohnGavin/llm/pull/750) — the pruning that motivated
+  the intake gate.

--- a/LICENSE.content.md
+++ b/LICENSE.content.md
@@ -1,0 +1,17 @@
+# Content Licence
+
+The **documentation and other content** in this repository — including
+vignettes, the pkgdown/Quarto site, README prose, diagrams, figures, and
+datasets — is licensed under the
+[Creative Commons Attribution 4.0 International Licence (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
+
+You are free to share and adapt this content for any purpose, including
+commercially, provided you give appropriate credit.
+
+The **source code** in this repository (everything that executes — `R/`,
+`inst/`, scripts, workflows) is licensed separately under the **MIT Licence**
+(see `LICENSE` / `LICENSE.md`). Creative Commons licences are not used for
+source code.
+
+Policy: JohnGavin/llm#767. The local-only `knowledge/` hub is never published
+and is not covered by this or any public licence.


### PR DESCRIPTION
Implements two decisions from the "Constraints, not Goals" config review.

## #769 — Press-release-first gate (Option 1)
New rule `press-release-first`: any new skill/rule/command must open with a one-line *when-to-use* + a **Chesterton check** naming the nearest existing surface it does NOT duplicate, before it's authored. Directly attacks config accretion (our most-cited chronic issue: 76 rules, 73 skills). Path-scoped to `.claude/{skills,rules,commands}/**`. Pairs with `housekeeping-framework` (this = intake gate, that = exit sweep).

**Closes #769.**

## #767 — Content licensing policy (Option 3)
New rule `content-licensing` codifies: public projects split **content → CC BY 4.0** (attribution only, max reach, Wikipedia/OER-compatible) from **code → existing OSS licence** (never CC — CC advises against it for software; would break CRAN). Applied to this repo via `LICENSE.content.md` (content CC BY 4.0; code stays MIT per `DESCRIPTION`).

Rollout to other public repos is **phased and confirmed separately** (dead scaffolds excluded, per subtractive-first). The local-only `knowledge/` hub is out of scope. **Refs #767** (kept open for the rollout).

## Verification
Both rules carry `paths:` frontmatter (rule-loading enforcement); added to `.claude/RULES.md` index. Prose-only change — no code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)