### PR TITLE
refactor(vignettes): hoist drifted safe_tar_read into one shared definition

### DIFF
--- a/_includes/_safe-tar-read.qmd
+++ b/_includes/_safe-tar-read.qmd
@@ -1,0 +1,44 @@
+<!-- _includes/_safe-tar-read.qmd
+     Shared safe_tar_read() helper. Reads a target from the live targets
+     store when available, else falls back to a pre-computed RDS snapshot
+     under inst/extdata/vignettes/ (used for CRAN/pkgdown builds where no
+     _targets/ store exists).
+     Usage: {{< include /_includes/_safe-tar-read.qmd >}}
+     Set wrap_df = TRUE at call sites that need data.frame results
+     re-wrapped as a DT::datatable() on the RDS-fallback path (the store
+     path never wraps — the live object already carries its own class).
+-->
+
+```{r safe-tar-read-setup}
+#| include: false
+
+safe_tar_read <- function(name, wrap_df = FALSE) {
+  store <- tryCatch({
+    owd <- setwd(here::here())
+    on.exit(setwd(owd))
+    normalizePath(targets::tar_config_get("store"))
+  }, error = function(e) NULL)
+
+  if (!is.null(store)) {
+    obj <- tryCatch(targets::tar_read_raw(name, store = store), error = function(e) NULL)
+    if (!is.null(obj)) return(obj)
+  }
+
+  for (d in c("../inst/extdata/vignettes", "inst/extdata/vignettes",
+              file.path(here::here(), "inst/extdata/vignettes"))) {
+    rds <- file.path(d, paste0(name, ".rds"))
+    if (file.exists(rds)) {
+      obj <- readRDS(rds)
+      if (wrap_df && is.data.frame(obj) && requireNamespace("DT", quietly = TRUE)) {
+        # Re-wrap data.frames as DT widgets (RDS stripped Nix paths)
+        cap <- attr(obj, "dt_caption")
+        return(DT::datatable(obj, rownames = FALSE, filter = "top",
+          options = list(pageLength = 15, scrollX = TRUE),
+          caption = if (!is.null(cap)) htmltools::HTML(cap)))
+      }
+      return(obj)
+    }
+  }
+  invisible(NULL)
+}
+```

--- a/vignettes/articles/closeread-config.qmd
+++ b/vignettes/articles/closeread-config.qmd
@@ -15,6 +15,7 @@ execute:
 ---
 
 {{< include /_includes/hover-popups.qmd >}}
+{{< include /_includes/_safe-tar-read.qmd >}}
 
 <style>
 .cr-section.sidebar-left .cr-sidebar-col { flex: 0 0 55% !important; max-width: 55% !important; }
@@ -27,24 +28,6 @@ execute:
 
 ```{r setup}
 #| include: false
-safe_tar_read <- function(name) {
-  store <- tryCatch({
-    owd <- setwd(here::here())
-    on.exit(setwd(owd))
-    normalizePath(targets::tar_config_get("store"))
-  }, error = function(e) NULL)
-  if (!is.null(store)) {
-    obj <- tryCatch(targets::tar_read_raw(name, store = store), error = function(e) NULL)
-    if (!is.null(obj)) return(obj)
-  }
-  for (d in c("../inst/extdata/vignettes", "inst/extdata/vignettes",
-              file.path(here::here(), "inst/extdata/vignettes"))) {
-    rds <- file.path(d, paste0(name, ".rds"))
-    if (file.exists(rds)) return(readRDS(rds))
-  }
-  NULL
-}
-
 counts <- safe_tar_read("vig_cr_infra_counts")
 if (is.null(counts)) counts <- list(n_rules=61, n_skills=63, n_agents=12, n_hooks=7, n_commands=15, n_memory=14)
 ```

--- a/vignettes/articles/scrolly-config-evolution.qmd
+++ b/vignettes/articles/scrolly-config-evolution.qmd
@@ -13,29 +13,12 @@ execute:
 ---
 
 {{< include /_includes/hover-popups.qmd >}}
+{{< include /_includes/_safe-tar-read.qmd >}}
 
 ```{r setup}
 #| include: false
 library(ggplot2)
 library(dplyr)
-
-safe_tar_read <- function(name) {
-  store <- tryCatch({
-    owd <- setwd(here::here())
-    on.exit(setwd(owd))
-    normalizePath(targets::tar_config_get("store"))
-  }, error = function(e) NULL)
-  if (!is.null(store)) {
-    obj <- tryCatch(targets::tar_read_raw(name, store = store), error = function(e) NULL)
-    if (!is.null(obj)) return(obj)
-  }
-  for (d in c("../inst/extdata/vignettes", "inst/extdata/vignettes",
-              file.path(here::here(), "inst/extdata/vignettes"))) {
-    rds <- file.path(d, paste0(name, ".rds"))
-    if (file.exists(rds)) return(readRDS(rds))
-  }
-  NULL
-}
 
 cfg <- safe_tar_read("vig_scrolly_config")
 if (is.null(cfg)) {

--- a/vignettes/closeread-infrastructure.qmd
+++ b/vignettes/closeread-infrastructure.qmd
@@ -14,29 +14,10 @@ execute:
 ---
 
 {{< include /_includes/hover-popups.qmd >}}
+{{< include /_includes/_safe-tar-read.qmd >}}
 
 ```{r setup}
 #| include: false
-
-safe_tar_read <- function(name) {
-  store <- tryCatch({
-    owd <- setwd(here::here())
-    on.exit(setwd(owd))
-    normalizePath(targets::tar_config_get("store"))
-  }, error = function(e) NULL)
-
-  if (!is.null(store)) {
-    obj <- tryCatch(targets::tar_read_raw(name, store = store), error = function(e) NULL)
-    if (!is.null(obj)) return(obj)
-  }
-
-  for (d in c("../inst/extdata/vignettes", "inst/extdata/vignettes",
-              file.path(here::here(), "inst/extdata/vignettes"))) {
-    rds <- file.path(d, paste0(name, ".rds"))
-    if (file.exists(rds)) return(readRDS(rds))
-  }
-  NULL
-}
 
 # Resolve a Claude config subdirectory. Prefers the in-repo .claude/ copy
 # (which is what gets deployed to gh-pages), falling back to the user's local

--- a/vignettes/telemetry.qmd
+++ b/vignettes/telemetry.qmd
@@ -15,6 +15,7 @@ vignette: >
 ---
 
 {{< include /_includes/hover-popups.qmd >}}
+{{< include /_includes/_safe-tar-read.qmd >}}
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(
@@ -26,36 +27,6 @@ knitr::opts_chunk$set(
   fig.height = 6,
   echo = FALSE
 )
-
-safe_tar_read <- function(name) {
-  store <- tryCatch({
-    owd <- setwd(here::here())
-    on.exit(setwd(owd))
-    normalizePath(targets::tar_config_get("store"))
-  }, error = function(e) NULL)
-
-  if (!is.null(store)) {
-    obj <- tryCatch(targets::tar_read_raw(name, store = store), error = function(e) NULL)
-    if (!is.null(obj)) return(obj)
-  }
-
-  for (d in c("../inst/extdata/vignettes", "inst/extdata/vignettes",
-              file.path(here::here(), "inst/extdata/vignettes"))) {
-    rds <- file.path(d, paste0(name, ".rds"))
-    if (file.exists(rds)) {
-      obj <- readRDS(rds)
-      # Re-wrap data.frames as DT widgets (RDS stripped Nix paths)
-      if (is.data.frame(obj) && requireNamespace("DT", quietly = TRUE)) {
-        cap <- attr(obj, "dt_caption")
-        return(DT::datatable(obj, rownames = FALSE, filter = "top",
-          options = list(pageLength = 15, scrollX = TRUE),
-          caption = if (!is.null(cap)) htmltools::HTML(cap)))
-      }
-      return(obj)
-    }
-  }
-  invisible(NULL)
-}
 ```
 
 # LLM Usage & Costs {#llm-usage-costs}
@@ -63,7 +34,7 @@ safe_tar_read <- function(name) {
 This section tracks costs, token usage, and limits.
 
 ```{r dashboard-status}
-safe_tar_read("vig_usage_summary")
+safe_tar_read("vig_usage_summary", wrap_df = TRUE)
 ```
 
 ::: {.panel-tabset}
@@ -71,25 +42,25 @@ safe_tar_read("vig_usage_summary")
 ## Cost Trends
 
 ```{r cost-trend, fig.cap="Daily LLM costs over time with LOESS smoothing trend line."}
-safe_tar_read("vig_cost_trend_plot")
+safe_tar_read("vig_cost_trend_plot", wrap_df = TRUE)
 ```
 
 ## Cumulative Cost
 
 ```{r cumulative-cost, fig.cap="Cumulative LLM spending over time showing total expenditure trajectory."}
-safe_tar_read("vig_cumulative_cost_plot")
+safe_tar_read("vig_cumulative_cost_plot", wrap_df = TRUE)
 ```
 
 ## Breakdowns
 
 ```{r breakdowns-combined, fig.height=10, fig.cap="Top: Cost breakdown by model. Bottom: Token usage by type (input, output, cache)."}
-safe_tar_read("vig_breakdowns_plot")
+safe_tar_read("vig_breakdowns_plot", wrap_df = TRUE)
 ```
 
 ## Gemini Analytics
 
 ```{r gemini-analysis, fig.cap="Gemini daily costs from the Gemini usage database."}
-safe_tar_read("vig_gemini_plot")
+safe_tar_read("vig_gemini_plot", wrap_df = TRUE)
 ```
 
 :::
@@ -103,25 +74,25 @@ Analysis of session durations and cost efficiency, including Claude Max5 blocks.
 ## Duration Trends
 
 ```{r duration-trend, fig.cap="Average session duration over time, colored by recency period."}
-safe_tar_read("vig_duration_trend_plot")
+safe_tar_read("vig_duration_trend_plot", wrap_df = TRUE)
 ```
 
 ## Cost Efficiency
 
 ```{r cost-eff, fig.cap="Cost per minute over time showing session cost efficiency trends."}
-safe_tar_read("vig_cost_efficiency_plot")
+safe_tar_read("vig_cost_efficiency_plot", wrap_df = TRUE)
 ```
 
 ## Cost vs Duration
 
 ```{r cost-duration, fig.cap="Scatter plot of cost intensity vs session duration. Longer sessions tend to be more cost efficient."}
-safe_tar_read("vig_cost_duration_plot")
+safe_tar_read("vig_cost_duration_plot", wrap_df = TRUE)
 ```
 
 ## Model Breakdown
 
 ```{r model-breakdown, fig.height=8, fig.cap="Cost efficiency faceted by Claude model variant."}
-safe_tar_read("vig_model_session_plot")
+safe_tar_read("vig_model_session_plot", wrap_df = TRUE)
 ```
 
 ## Max5 Block History {#max5-block-history}
@@ -133,7 +104,7 @@ Recent history of usage blocks. "Max5" refers to the **Claude 5-hour usage limit
 </div>
 
 ```{r max5-table}
-safe_tar_read("vig_max5_table")
+safe_tar_read("vig_max5_table", wrap_df = TRUE)
 ```
 
 :::
@@ -147,19 +118,19 @@ Targets pipeline composition: plans, target counts, heaviest targets by size and
 ## Plans & Targets
 
 ```{r pipeline-plans}
-safe_tar_read("vig_pipeline_plans_table")
+safe_tar_read("vig_pipeline_plans_table", wrap_df = TRUE)
 ```
 
 ## Top by Size
 
 ```{r pipeline-top-size}
-safe_tar_read("vig_pipeline_top_size_table")
+safe_tar_read("vig_pipeline_top_size_table", wrap_df = TRUE)
 ```
 
 ## Top by Compute Time
 
 ```{r pipeline-top-time}
-safe_tar_read("vig_pipeline_top_time_table")
+safe_tar_read("vig_pipeline_top_time_table", wrap_df = TRUE)
 ```
 
 :::
@@ -173,25 +144,25 @@ Repository timeline, commit velocity, issues, pull requests, and CI workflows.
 ## Commit Velocity
 
 ```{r commit-velocity}
-safe_tar_read("vig_commit_velocity_table")
+safe_tar_read("vig_commit_velocity_table", wrap_df = TRUE)
 ```
 
 ## Issues & PRs
 
 ```{r github-activity}
-safe_tar_read("vig_github_activity_table")
+safe_tar_read("vig_github_activity_table", wrap_df = TRUE)
 ```
 
 ## CI Workflow Runtimes
 
 ```{r ci-plot, fig.cap="Box plot of successful GitHub Actions workflow runtimes by workflow name."}
-safe_tar_read("vig_workflow_plot")
+safe_tar_read("vig_workflow_plot", wrap_df = TRUE)
 ```
 
 ## Git History
 
 ```{r git-hist, fig.cap="Daily commit frequency over the last 100 commits."}
-safe_tar_read("vig_git_history_plot")
+safe_tar_read("vig_git_history_plot", wrap_df = TRUE)
 ```
 
 :::
@@ -205,19 +176,19 @@ Codebase metrics, file organization, and repository health.
 ## Codebase
 
 ```{r codebase-metrics}
-safe_tar_read("vig_codebase_metrics")
+safe_tar_read("vig_codebase_metrics", wrap_df = TRUE)
 ```
 
 ## File Counts
 
 ```{r file-counts}
-safe_tar_read("vig_file_counts_table")
+safe_tar_read("vig_file_counts_table", wrap_df = TRUE)
 ```
 
 ## GitHub Stats
 
 ```{r github-stats}
-safe_tar_read("vig_github_stats_table")
+safe_tar_read("vig_github_stats_table", wrap_df = TRUE)
 ```
 
 :::
@@ -232,25 +203,25 @@ Brier score: 0 = perfect, 0.25 = uninformative baseline.
 ## By Project
 
 ```{r pred-by-project}
-safe_tar_read("vig_pred_by_project_table")
+safe_tar_read("vig_pred_by_project_table", wrap_df = TRUE)
 ```
 
 ## Calibration Buckets
 
 ```{r pred-calibration}
-safe_tar_read("vig_pred_global_calibration_table")
+safe_tar_read("vig_pred_global_calibration_table", wrap_df = TRUE)
 ```
 
 ## Rolling Brier Score
 
 ```{r pred-rolling-brier, fig.cap="Cumulative Brier score across all projects over time. Lower is better; 0.25 is the uninformative baseline."}
-safe_tar_read("vig_pred_global_brier_plot")
+safe_tar_read("vig_pred_global_brier_plot", wrap_df = TRUE)
 ```
 
 ## Predicted vs Actual
 
 ```{r pred-success-rate, fig.cap="Comparison of mean predicted probability vs actual success rate by project."}
-safe_tar_read("vig_pred_success_rate_plot")
+safe_tar_read("vig_pred_success_rate_plot", wrap_df = TRUE)
 ```
 
 :::


### PR DESCRIPTION
## Summary

`safe_tar_read()` was defined inline — with divergent bodies — in 4 vignettes:

- `vignettes/telemetry.qmd` — RDS-fallback path re-wraps `data.frame` results as `DT::datatable(...)` (preserving a `dt_caption` attr). ~24 call sites.
- `vignettes/closeread-infrastructure.qmd` — bare object, no DT wrap.
- `vignettes/articles/scrolly-config-evolution.qmd` — identical to closeread-infrastructure's (bare).
- `vignettes/articles/closeread-config.qmd` — identical to closeread-infrastructure's (bare).

This is a silent-inconsistency risk: any future edit to one copy silently diverges from the other three. Consolidated into a single shared definition.

## Approach chosen: Quarto include (not a package function)

Added `_includes/_safe-tar-read.qmd`, a partial containing one R chunk (`#| include: false`) that defines `safe_tar_read(name, wrap_df = FALSE)`. Each vignette now does:

```
{{< include /_includes/hover-popups.qmd >}}
{{< include /_includes/_safe-tar-read.qmd >}}
```

This mirrors the existing `hover-popups.qmd` partial, which is already included with the same absolute-path (`/_includes/...`) syntax from both `vignettes/*.qmd` and `vignettes/articles/*.qmd` (different directory depths) — confirmed working via `grep` before starting, and re-confirmed by an actual `quarto render` of files at both depths (see Verification). No fallback to a package function was needed; the include worked cleanly.

## Preserving telemetry's DT-wrap behavior

The union of the 4 bodies is identical except for telemetry's DT-rewrap-on-RDS-fallback branch. The shared function takes `wrap_df = FALSE` by default (matching the 3 bare vignettes — their call sites needed **zero changes**). All **24** call sites in `telemetry.qmd` were updated to pass `wrap_df = TRUE`, reproducing telemetry's original always-wrap behavior exactly. The store-path (live `targets` store) branch never wraps in either mode, matching all 4 originals.

One minor, deliberate normalization: the bare-vignette originals fell through to plain `NULL` on total miss, while telemetry fell through to `invisible(NULL)`. The shared function now always returns `invisible(NULL)`. This is unobservable in all call sites — the 3 bare vignettes always assign the result to a variable (`counts <-`, `cfg <-`, etc.), so visibility has no effect on the value.

## Verification

- **Zero remaining inline definitions:** `grep -rn "safe_tar_read <- function" vignettes/` → no output.
- **Two-mode behavior check** (tempdir RDS fixture, no live targets store required):
  ```
  nix-shell default.nix --run "timeout 90 Rscript verify_safe_tar_read.R"
  ```
  Output: `bare is.data.frame: TRUE`, `bare identical to original df: TRUE`, `wrapped inherits datatables: TRUE`, `wrapped inherits htmlwidget: TRUE`, `missing target is NULL: TRUE`, `ALL CHECKS PASSED`.
- **purl + parse** on all 5 modified files (4 vignettes + the new include): all `OK`.
- **Real `quarto render`** of both `vignettes/closeread-infrastructure.qmd` (bare mode) and `vignettes/telemetry.qmd` (DT-wrap mode) in the project nix shell — both rendered fully (all chunks executed including `[safe-tar-read-setup]`), no R/pandoc errors. No live `_targets/` store exists in this worktree, so the RDS-fallback path was genuinely exercised; `docs/vignettes/telemetry.html` contains 12 `datatables html-widget` blocks, confirming `wrap_df = TRUE` correctly re-wrapped data.frame targets. The only non-zero exit was the known post-render cross-page link checker (`llm#715`), which always fails on a single-file render outside a full site build — unrelated to this change.
- `~/.claude/scripts/r_code_check.sh _includes/` — ast-grep: no violations; hardcoded-path check: clean; jarl: all checks passed; Quarto fence parity: OK (9 files, 0 violations).

## Test plan

- [x] `grep -rn "safe_tar_read <- function" vignettes/` returns nothing
- [x] Two-mode (`wrap_df` TRUE/FALSE) behavior check passes
- [x] `knitr::purl()` + `parse()` succeeds on all 5 modified files
- [x] `quarto render` succeeds (no R errors) for both a bare-mode and DT-wrap-mode vignette
- [x] `r_code_check.sh` (ast-grep + jarl + fence parity) passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)