### PR TITLE
fix(dashboard): add range sliders to time-series charts

### DIFF
--- a/inst/shiny/dashboard/app.R
+++ b/inst/shiny/dashboard/app.R
@@ -93,14 +93,18 @@ empty_plot <- function(msg, type = "bar", mode = NULL) {
   plotly_dark_layout(p)
 }
 
-plotly_dark_layout <- function(p, title = NULL) {
+plotly_dark_layout <- function(p, title = NULL, rangeslider = FALSE) {
+  xaxis <- list(gridcolor = "#333", zerolinecolor = "#333", color = "#fff")
+  if (isTRUE(rangeslider)) {
+    xaxis$rangeslider <- list(visible = TRUE)
+  }
   plotly::layout(
     p,
     title         = if (!is.null(title)) list(text = title, font = list(color = "#fff")) else NULL,
     paper_bgcolor = "#000000",
     plot_bgcolor  = "#000000",
     font          = list(color = "#ffffff"),
-    xaxis         = list(gridcolor = "#333", zerolinecolor = "#333", color = "#fff"),
+    xaxis         = xaxis,
     yaxis         = list(gridcolor = "#333", zerolinecolor = "#333", color = "#fff"),
     legend        = list(
       orientation = "h", xanchor = "center", x = 0.5,
@@ -510,7 +514,7 @@ server <- function(input, output, session) {
       plotly::add_bars(y = ~sonnet_cost, name = "Sonnet", marker = list(color = "#3498db")) |>
       plotly::add_bars(y = ~haiku_cost,  name = "Haiku",  marker = list(color = "#2ecc71")) |>
       plotly::layout(barmode = "stack", yaxis = list(title = "USD"))
-    plotly_dark_layout(p)
+    plotly_dark_layout(p, rangeslider = TRUE)
   })
 
   # Daily sessions by project (stacked bar)
@@ -547,7 +551,7 @@ server <- function(input, output, session) {
       p <- plotly::add_bars(p, x = sub$date, y = sub$n_sessions, name = proj)
     }
     p <- plotly::layout(p, barmode = "stack", yaxis = list(title = "Sessions"))
-    plotly_dark_layout(p)
+    plotly_dark_layout(p, rangeslider = TRUE)
   })
 
   # ---- Costs tab -----------------------------------------------------------
@@ -588,7 +592,7 @@ server <- function(input, output, session) {
         line = list(color = "#e74c3c", dash = "dash", width = 1.5)
       ) |>
       plotly::layout(yaxis = list(title = "USD"))
-    plotly_dark_layout(p, "Cumulative cost vs $500 cap")
+    plotly_dark_layout(p, "Cumulative cost vs $500 cap", rangeslider = TRUE)
   })
 
   output$model_mix_area <- plotly::renderPlotly({
@@ -613,7 +617,7 @@ server <- function(input, output, session) {
         line = list(color = "#2ecc71")
       ) |>
       plotly::layout(yaxis = list(title = "%", range = c(0, 100)))
-    plotly_dark_layout(p, "Model mix (%)")
+    plotly_dark_layout(p, "Model mix (%)", rangeslider = TRUE)
   })
 
   output$costs_tbl <- DT::renderDataTable({
@@ -849,7 +853,7 @@ server <- function(input, output, session) {
       p <- plotly::add_bars(p, x = sub$date, y = sub$total_min, name = proj)
     }
     p <- plotly::layout(p, barmode = "stack", yaxis = list(title = "Minutes"))
-    plotly_dark_layout(p)
+    plotly_dark_layout(p, rangeslider = TRUE)
   })
 
   # Recent sessions table


### PR DESCRIPTION
## Summary

The `visualization-standards` project rule requires: "Time series plots MUST have a range slider and default to last 3 months view." `inst/shiny/dashboard/app.R` was out of compliance on the range-slider half (the date filter already defaults to `Sys.Date() - 90`, satisfying the second half).

This is an additive compliance fix — no refactor, no visual restyle, no dedup.

## Change

- `plotly_dark_layout(p, title = NULL, rangeslider = FALSE)` gained an opt-in `rangeslider` param. When `TRUE`, it merges `rangeslider = list(visible = TRUE)` into the existing `xaxis` list (does not clobber the existing `gridcolor`/`zerolinecolor`/`color` settings).
- Default stays `FALSE`, so `empty_plot()`'s "no data" placeholder charts are unaffected.

## Per-chart decision

All 5 `renderPlotly` outputs were read and confirmed to have a date/time x-axis (`x = ~date` or `x = sub$date`), so all 5 got `rangeslider = TRUE`:

| Chart | x-axis | Slider added? |
|---|---|---|
| `daily_cost_bar` | daily date (stacked bar) | Yes |
| `daily_sessions_project` | daily date (stacked bar) | Yes |
| `cumulative_cost_line` | daily date (line, cumulative) | Yes |
| `model_mix_area` | daily date (stacked area) | Yes |
| `daily_time_project` | daily date, last 10 days (stacked bar) | Yes |

`empty_plot()` (the shared "no data" placeholder) was left at the new default `rangeslider = FALSE` — placeholders don't need a slider.

## Verification

- Parse: `nix-shell default.nix --run "Rscript -e 'invisible(parse(\"inst/shiny/dashboard/app.R\"))'"` → `PARSE_OK`
- Build: `nix-shell default.nix --run "Rscript -e 'app <- shiny::shinyAppFile(\"inst/shiny/dashboard/app.R\"); cat(class(app))'"` → `shiny.appobj`
- `~/.claude/scripts/r_code_check.sh` (ast-grep + jarl): jarl passed clean; ast-grep found 1 error + 1 warning + 1 hardcoded-path note, all **pre-existing** and outside this diff (line 15 raw SQL in `query_db()`, line 121 hardcoded `cmonitor-rs` path, line 657 `suppressWarnings(as.numeric())`) — none introduced by this change.

## Test plan

- [ ] Run the app locally (`nix-shell default.nix --run "Rscript -e 'shiny::runApp(\"inst/shiny/dashboard\")'"`) and confirm each of the 5 charts renders a range slider below its x-axis
- [ ] Confirm dragging the slider filters the visible date range without errors
- [ ] Confirm the "no data" placeholder (e.g. by narrowing the sidebar date filter to an empty range) still renders without a slider

Additive/compliance-only change. **Not merged** — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)