### PR TITLE
chore(site): consolidate dashboards under one navbar menu

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -25,18 +25,19 @@ website:
     left:
       - href: index.qmd
         text: Home
-      - href: https://johngavin.github.io/llmtelemetry/
-        text: Telemetry
       - text: Dashboards
         menu:
           - href: vignettes/config-evolution.qmd
             text: Config Evolution
           - href: vignettes/knowledge-evolution.qmd
             text: Knowledge Base
-      - href: vignettes/closeread-infrastructure.qmd
-        text: Infrastructure
-      - href: vignettes/articles/closeread-config.qmd
-        text: Config Stack
+          - href: vignettes/closeread-infrastructure.qmd
+            text: Infrastructure
+          - href: vignettes/articles/closeread-config.qmd
+            text: Config Stack
+          - href: https://johngavin.github.io/llmtelemetry/
+            text: Telemetry
+            target: _blank
       - href: vignettes/articles/llm-assisted-tips.qmd
         text: LLM-assisted Tips
       - text: Roborev


### PR DESCRIPTION
## Summary

Consolidates all dashboard pages under one **Dashboards** navbar dropdown in `_quarto.yml`. Nav-only restructure — no page content or URL changes.

**Before:**
```
Home | Telemetry | Dashboards ▾ (Config Evolution, Knowledge Base) | Infrastructure | Config Stack | LLM-assisted Tips | Roborev ▾ (Architecture)
```

**After:**
```
Home | Dashboards ▾ (Config Evolution, Knowledge Base, Infrastructure, Config Stack, Telemetry ↗) | LLM-assisted Tips | Roborev ▾ (Architecture)
```

- `Home` and `LLM-assisted Tips` stay top-level.
- `Infrastructure`, `Config Stack`, and the external `Telemetry` link move into the `Dashboards` dropdown alongside `Config Evolution` and `Knowledge Base`.
- `Telemetry` (external link) carries `target: _blank` so it opens in a new tab from within the dropdown.
- `Roborev` dropdown is unchanged.

## Verification

- YAML parses cleanly: `yaml::read_yaml("_quarto.yml")` succeeds.
- Parsed navbar structure confirmed programmatically — Dashboards menu now lists exactly 5 entries: Config Evolution, Knowledge Base, Infrastructure, Config Stack, Telemetry (target=`_blank`).
- Single-page `quarto render index.qmd` was attempted for full-stack verification. Quarto **accepted `_quarto.yml`** (parsing succeeded, render proceeded into chunk execution) — no schema error from `target: _blank`. The render then failed for a reason **unrelated to this change**: `library(llm)` errors because the local package isn't installed in this Nix dev-shell R environment (the project's Nix rules forbid `install.packages()`/`devtools::install()` in Nix; the site's actual publish workflow, `.github/workflows/quarto-publish.yaml`, uses native R + `R CMD INSTALL .` before rendering, which this local single-page nix-shell check doesn't perform).

## Test plan

- [ ] CI (`Quarto Publish` workflow) renders the full site successfully with the new navbar
- [ ] Visually confirm the Dashboards dropdown shows all 5 entries and Telemetry opens in a new tab

Dispatch-Id: 4826e4f7-2118-47a2-a5f0-59d3c4b15daf

🤖 Generated with [Claude Code](https://claude.com/claude-code)