### PR TITLE
fix(vignettes): draw grob/gtable targets so isolated pages don't leak #> NULL (#780)

### DIFF
--- a/_includes/_safe-tar-read.qmd
+++ b/_includes/_safe-tar-read.qmd
@@ -12,6 +12,21 @@
 ```{r safe-tar-read-setup}
 #| include: false
 
+render_or_return <- function(obj) {
+  # grob/gtable objects (e.g. plots exported via vignette targets) have no
+  # knit_print method of their own; printing the list raw leaks a
+  # `#> NULL`-laced dump into isolated per-page renders (#780). Draw them
+  # explicitly so the chunk emits a figure instead.
+  if (inherits(obj, "grob") || inherits(obj, "gtable")) {
+    # Mirrors ggplot2:::print.ggplot (grid.newpage() + grid.draw()), the
+    # standard way to draw a captured grob/gtable to the active device.
+    grid::grid.newpage()
+    grid::grid.draw(obj)
+    return(invisible(NULL))
+  }
+  obj
+}
+
 safe_tar_read <- function(name, wrap_df = FALSE) {
   store <- tryCatch({
     owd <- setwd(here::here())
@@ -21,7 +36,7 @@ safe_tar_read <- function(name, wrap_df = FALSE) {
 
   if (!is.null(store)) {
     obj <- tryCatch(targets::tar_read_raw(name, store = store), error = function(e) NULL)
-    if (!is.null(obj)) return(obj)
+    if (!is.null(obj)) return(render_or_return(obj))
   }
 
   for (d in c("../inst/extdata/vignettes", "inst/extdata/vignettes",
@@ -36,7 +51,7 @@ safe_tar_read <- function(name, wrap_df = FALSE) {
           options = list(pageLength = 15, scrollX = TRUE),
           caption = if (!is.null(cap)) htmltools::HTML(cap)))
       }
-      return(obj)
+      return(render_or_return(obj))
     }
   }
   invisible(NULL)


### PR DESCRIPTION
## Summary

Closes #780. CI publish was broken: `scan_html_for_errors("docs")` aborted on `docs/vignettes/telemetry/prediction-calibration.html` because of a `#> NULL`-laced raw list dump.

**Root cause:** the two plot targets on that page (`vig_pred_global_brier_plot`, `vig_pred_success_rate_plot`) are exported as `gtable`/`gTree`/`grob`/`gDesc` objects (grobified via `ggplotGrob()` before saving to `inst/extdata/vignettes/*.rds`). `safe_tar_read()` in `_includes/_safe-tar-read.qmd` simply returned the object for the chunk to print. A grob/gtable has no `knit_print` method, so on an isolated per-page render (post-#778 vignette split, each page renders standalone with only `_setup.qmd` loaded) the object printed as a raw list dump containing `#> NULL` lines, tripping the CI HTML-error scanner.

**Fix:** added `render_or_return()` in the shared `_includes/_safe-tar-read.qmd` helper. Grob/gtable objects are now drawn via `grid::grid.newpage()` + `grid::grid.draw()` — the same mechanism `ggplot2:::print.ggplot` uses — instead of being returned for printing. Applied at both the live-targets-store and RDS-fallback return sites, so every vignette page reading a plot target through `safe_tar_read()` is covered, not just this one page.

## Verification

- `readRDS()` confirmed both fixtures are `"gtable" "gTree" "grob" "gDesc"`.
- Package installed to a scratch library; `vignettes/telemetry` rendered in the foreground (Quarto).
- `docs/vignettes/telemetry/prediction-calibration.html` no longer contains any `#&gt;` output lines, and now emits `<img>` figure tags (`pred-rolling-brier-1.png`, `pred-success-rate-1.png`) for both plot chunks instead of the raw dump.
- The exact CI gate passes: `scan_html_for_errors("docs")` → "No HTML error messages in 9 pages".
- Swept all other rendered telemetry pages for the same `#&gt;.*NULL|NaN` pattern — none found.

## Known follow-up (separate from this fix, filed as observation not fixed here)

The two committed RDS fixtures (`vig_pred_global_brier_plot.rds`, `vig_pred_success_rate_plot.rds`) render as **blank white images** even with this fix applied — verified by calling `grid::grid.draw()` directly outside knitr. By contrast, a freshly created `ggplotGrob()` object (built and saved/reloaded in this same R 4.5.2 / ggplot2 4.0.1 / gtable 0.3.6 environment) draws correctly. This points to the two specific committed snapshots being stale or serialization-incompatible with the current package versions (they were captured by a one-off export in #50 and haven't been regenerated since). Regenerating them requires real prediction-log data from `~/.claude/logs/predictions/`, which isn't available in this sandboxed environment, so I did not attempt it here — this fix resolves the reported CI-blocking bug (`#> NULL` leak / render blocked), but the two plots will show blank until the fixtures are refreshed in a follow-up.

## Test plan

- [x] `scan_html_for_errors("docs")` passes (the exact CI gate)
- [x] `prediction-calibration.html` emits `<img>` tags for both plot chunks, no `#&gt;` leak
- [x] No other telemetry page shows the same leak pattern
- [ ] (follow-up, not in this PR) regenerate the two stale RDS fixtures with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)