### PR TITLE
fix(telemetry): robust agent_runs logging + retire errors tracking (#784)

### DIFF
--- a/.claude/hooks/log_agent_run.sh
+++ b/.claude/hooks/log_agent_run.sh
@@ -5,19 +5,85 @@
 #   PostToolUse -> agent_stop  (sets ended_at, duration, status done/failed)
 # Reads the hook payload as JSON on stdin (modern interface); falls back to
 # CLAUDE_TOOL_INPUT env (legacy). ALWAYS exits 0 — must never block dispatch.
+#
+# Session-id resolution (llm#784): the `.current_session` marker file this
+# hook used to depend on exclusively is owned by log_session.sh's
+# session_start/session_stop and has been observed absent during an active
+# session — every agent dispatch was then silently skipped while `sessions`
+# kept filling (agent_runs frozen 2026-07-14, sessions stayed live). Resolve
+# session_id in order, self-healing past a missing/stale marker:
+#   1. Top-level `session_id` field of the hook's own JSON payload — Claude
+#      Code documents this as a common field on every hook event, see
+#      https://code.claude.com/docs/en/hooks ("Common Fields").
+#   2. `.current_session` marker file (previous/legacy behaviour).
+#   3. Self-heal: newest open (no ended_at) row in `sessions`, else the
+#      newest row overall, queried directly from unified.duckdb.
+#   4. Give up — exit 0, but leave a breadcrumb in agent_hook_debug.log so the
+#      miss is visible instead of silent.
 set -uo pipefail   # deliberately NOT -e
 
 _log_script="$HOME/.claude/scripts/log_session.sh"
 [ -x "$_log_script" ] || exit 0
-[ -f "$HOME/.claude/logs/.current_session" ] || exit 0
-_sid=$(cat "$HOME/.claude/logs/.current_session" 2>/dev/null || echo "")
-[ -n "$_sid" ] || exit 0
 
 _input=$(cat 2>/dev/null || echo "")   # consume stdin once
 
 _jq() { echo "$_input" | jq -r "$1" 2>/dev/null || echo ""; }
 
-if [ -n "$_input" ] && command -v jq >/dev/null 2>&1; then
+_have_jq=0
+command -v jq >/dev/null 2>&1 && _have_jq=1
+
+# Portable bounded execution for the DB self-heal query (llm#716 pattern):
+# GNU timeout is absent on macOS/launchd PATH; fall back to perl's alarm(2).
+_TIMEOUT_CMD=$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)
+_bounded() {
+  local secs="$1"; shift
+  if [ -n "$_TIMEOUT_CMD" ]; then
+    "$_TIMEOUT_CMD" "$secs" "$@"
+  elif command -v perl >/dev/null 2>&1; then
+    perl -e 'my $t = shift; alarm $t; exec @ARGV or die "exec: $!"' "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
+# ── 1. session_id from the hook payload itself ──────────────────────────────
+_sid=""
+if [ -n "$_input" ] && [ "$_have_jq" -eq 1 ]; then
+  _sid=$(_jq '.session_id // empty')
+fi
+
+# ── 2. .current_session marker file (legacy / fallback) ────────────────────
+if [ -z "$_sid" ] && [ -f "$HOME/.claude/logs/.current_session" ]; then
+  _sid=$(cat "$HOME/.claude/logs/.current_session" 2>/dev/null || echo "")
+fi
+
+# ── 3. Self-heal: newest open session (else newest row) straight from the DB
+if [ -z "$_sid" ]; then
+  _db="$HOME/.claude/logs/unified.duckdb"
+  if [ -f "$_db" ]; then
+    _query="SELECT session_id FROM sessions ORDER BY (ended_at IS NULL) DESC, started_at DESC LIMIT 1;"
+    if command -v duckdb >/dev/null 2>&1; then
+      _sid=$(_bounded 5 duckdb -init /dev/null "$_db" -noheader -list -c "$_query" 2>/dev/null || echo "")
+    else
+      _hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+      _nix_default="$(cd "${_hook_dir}/../.." 2>/dev/null && pwd)/default.nix"
+      if command -v nix-shell >/dev/null 2>&1 && [ -f "$_nix_default" ]; then
+        _sid=$(_bounded 15 nix-shell "$_nix_default" --run \
+          "duckdb -init /dev/null '$_db' -noheader -list -c \"$_query\"" 2>/dev/null || echo "")
+      fi
+    fi
+    _sid=$(echo "$_sid" | tr -d '[:space:]')
+  fi
+fi
+
+# ── 4. Give up ───────────────────────────────────────────────────────────────
+if [ -z "$_sid" ]; then
+  echo "$(date '+%F %T') no-session-id payload=$(echo "$_input" | head -c 300)" \
+    >> "$HOME/.claude/logs/agent_hook_debug.log" 2>/dev/null || true
+  exit 0
+fi
+
+if [ -n "$_input" ] && [ "$_have_jq" -eq 1 ]; then
   _event=$(_jq '.hook_event_name // empty')
   _agent_type=$(_jq '.tool_input.subagent_type // empty')
   _model=$(_jq '.tool_input.model // empty')

--- a/.claude/scripts/etl_freshness_check.sh
+++ b/.claude/scripts/etl_freshness_check.sh
@@ -66,7 +66,7 @@ THRESH_RED=2592000        # 30 days
 TRACKED_TABLES=(
     # ── Core session infrastructure ────────────────────────────────────────
     "hook_events:fired_at:rate"
-    "errors:logged_at"
+    # errors: retired from tracking — no producer (llm#784); re-add when a producer is wired
     "agent_runs:started_at:rate"
     "sessions:started_at"
     "self_review_findings_stage1:detected_at"

--- a/.claude/scripts/send_overnight_self_review_email.R
+++ b/.claude/scripts/send_overnight_self_review_email.R
@@ -174,14 +174,16 @@ sec1_block <- collapsible_block(
 )
 
 # ── Section 2: Source table volume (last 24h) — ETL starvation detector ────────
-source_tables <- c("sessions", "agent_runs", "hook_events", "errors")
+# errors: retired from this DEAD/STALE flagging set — no producer (llm#784);
+# re-add when a producer is wired. Table still appears in Section 3 below
+# (cumulative totals only, no alarm).
+source_tables <- c("sessions", "agent_runs", "hook_events")
 
 sec2_rows <- lapply(source_tables, function(tbl) {
   ts_col <- switch(tbl,
     sessions   = "started_at",
     agent_runs = "started_at",
-    hook_events = "fired_at",
-    errors     = "logged_at"
+    hook_events = "fired_at"
   )
 
   info <- safe_query(sprintf("


### PR DESCRIPTION
## Summary

Implements the decided remediation from #784 for two dead `unified.duckdb` telemetry tables.

### Fix 1 — `agent_runs`: decouple from the `.current_session` file marker

`log_agent_run.sh` hard-exited whenever `~/.claude/logs/.current_session` was
absent. That marker is owned by `log_session.sh session_start`/`session_stop`
and was observed missing mid-session (2026-07-17), so every agent dispatch
was silently dropped while `sessions` kept filling normally — exactly the
split described in #784 (`agent_runs` frozen since 2026-07-14, `sessions`
live).

`log_agent_run.sh` now resolves `session_id` in four tiers, self-healing past
a missing/stale marker:

1. Top-level `session_id` field of the hook's own JSON stdin payload —
   confirmed via the [Claude Code hooks docs](https://code.claude.com/docs/en/hooks)
   ("Common Fields" on every hook event).
2. `.current_session` marker file (previous/legacy behaviour).
3. Self-heal: newest open (`ended_at IS NULL`) row in `sessions`, else the
   newest row overall, queried directly via `duckdb` (falling back to
   `nix-shell` if the CLI isn't on `PATH`), both time-bounded with the
   portable `timeout`/`gtimeout`/perl-`alarm` pattern used elsewhere in this
   repo.
4. Give up — still `exit 0` (never blocks dispatch), but leaves a breadcrumb
   in `agent_hook_debug.log` so the miss is visible instead of silent.

`log_session.sh` already accepted `session_id` as an explicit positional
arg, so no change was needed there — `log_agent_run.sh` just threads the
resolved id through as before.

### Fix 2 — `errors`: retire from freshness tracking (no producer)

No hook or script anywhere under `.claude/hooks/` or `.claude/scripts/`
invokes `log_session.sh error`, so `errors` was permanently stale and
falsely alarming. Removed `errors:logged_at` from `TRACKED_TABLES` in
`etl_freshness_check.sh`, and from the DEAD/STALE-flagging `source_tables`
set (Section 2, the ETL-starvation detector) in
`send_overnight_self_review_email.R`. Left `errors` in Section 3
(cumulative totals — informational only, no alarm) and left the table +
writer in place per the issue's decision, in case a producer is wired
later.

## Test plan

- [x] `etl_freshness_check.sh --selftest` — 12 PASS, 0 FAIL
- [x] `etl_freshness_check.sh --list-tables` — 9 tracked tables, `errors` gone
- [x] `bash -n` on all three edited files
- [x] Hook dry-run: `session_id` resolved from stdin payload (verified a
      real `agent_runs` row was written, then cleaned up)
- [x] Hook dry-run: marker-file fallback tier (payload without `session_id`,
      marker present) — verified row written with marker's id, cleaned up
- [x] Hook dry-run: full-fallback path (no payload `session_id`, no marker,
      no DB) — confirmed `exit 0` and a breadcrumb line in
      `agent_hook_debug.log`
- [x] Confirmed no `~/.claude/...` literal write paths were introduced
      (only `$HOME/.claude/...` runtime references, matching the
      pre-existing pattern in this file)

Follow-up (noted in #784, not addressed here): pin down the exact
`session_init.sh`-side regression that stopped the marker being present
mid-session — this PR makes agent logging robust regardless, but the
marker's absence may affect other consumers.

Closes #784 (partially — the `session_init.sh` marker root-cause is a
separate follow-up per the issue).

Dispatch-Id: bb6be4a7-3211-4974-a97f-e71c8b792918
Agent-Type: fixer
