### PR TITLE
fix(vignettes): attach ggplot2 so grid.draw renders plot grobs (not blank) (#780)

### DIFF
--- a/_includes/_safe-tar-read.qmd
+++ b/_includes/_safe-tar-read.qmd
@@ -12,6 +12,19 @@
 ```{r safe-tar-read-setup}
 #| include: false
 
+# grid::grid.draw() on a ggplot2-produced gtable (e.g. via ggplotGrob())
+# dispatches S3/gTree draw methods defined by ggplot2 (grill gTree for panel
+# background/gridlines, etc.). Without ggplot2 attached, those methods never
+# register and grid.draw() silently no-ops -> blank figure, no error (#780).
+# Guarded so a missing package degrades to render_or_return()'s existing
+# grob/gtable branch rather than hard-erroring the render.
+if (requireNamespace("ggplot2", quietly = TRUE)) {
+  library(ggplot2)
+}
+if (requireNamespace("gtable", quietly = TRUE)) {
+  library(gtable)
+}
+
 render_or_return <- function(obj) {
   # grob/gtable objects (e.g. plots exported via vignette targets) have no
   # knit_print method of their own; printing the list raw leaks a


### PR DESCRIPTION
## Summary

Telemetry plot pages using `safe_tar_read()` were rendering blank images. PR #783 added `render_or_return()` in `_includes/_safe-tar-read.qmd`, which draws grob/gtable objects via `grid::grid.draw()`. The plot RDS fixtures are ggplot2-produced gtables (`ggplotGrob()` output).

**Root cause:** `ggplot2` was never `library()`-attached anywhere in the render chain (`_includes/_safe-tar-read.qmd` or `vignettes/telemetry/_setup.qmd`). Without ggplot2 attached, its custom gTree subclasses (e.g. the `grill` gTree for panel background/gridlines) don't get their draw methods dispatched, so `grid.draw()` silently no-ops -> blank canvas, no error.

This was verified with isolated tests: a from-scratch `ggplotGrob()` draws blank without `library(ggplot2)` and correctly with it; the existing committed RDS fixtures also draw correctly once ggplot2 is attached. **The RDS files were never stale** — the earlier "regenerate the RDS" theory was wrong and no RDS files were touched in this fix.

**Fix:** attach `ggplot2` (and `gtable` for safety) in the shared include's setup chunk, guarded with `requireNamespace()` so a missing package degrades gracefully instead of hard-erroring the render. Because this is the shared `_includes/_safe-tar-read.qmd`, the fix covers every vignette page that draws plot targets via `safe_tar_read()` — not just `prediction-calibration`.

## Verification

- Installed the package into a scratch library and rendered `vignettes/telemetry/` in the foreground.
- Confirmed figure PNGs are non-blank via pixel-level analysis (near-white-pixel fraction well below the ~100% a blank canvas would show):
  - `prediction-calibration_files/figure-html/pred-success-rate-1.png`: 53.8% near-white, 71KB
  - `prediction-calibration_files/figure-html/pred-rolling-brier-1.png`: 95.2% near-white, 119KB
  - `llm-usage-costs_files/figure-html/cost-trend-1.png`: 83.3% near-white, 107KB
  - `session-efficiency_files/figure-html/duration-trend-1.png`: 96.9% near-white, 99KB
- `scan_html_for_errors("docs")` QA gate: clean, no HTML error messages in 9 rendered pages.
- Note: the post-render internal-link checker reports broken links to sibling vignette folders (`config-evolution`, `knowledge-evolution`, etc.) — expected false positive from a partial single-folder render; not related to this fix.

## Test plan

- [x] `_includes/_safe-tar-read.qmd` change reviewed — minimal, guarded `library()` calls only
- [x] Rendered `vignettes/telemetry/` in foreground, confirmed non-blank plot PNGs
- [x] `scan_html_for_errors("docs")` QA gate passes
- [ ] Reviewer: spot-check a rendered plot page visually to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)
