### PR TITLE
fix(launchd): guard missing report file + export GMAIL creds in weekly health cron

### DIFF
--- a/bin/launchd_health_weekly_cron.sh
+++ b/bin/launchd_health_weekly_cron.sh
@@ -84,10 +84,21 @@ fi
 # (the same one the roborev email cron sources — bin/roborev_weekly_rollup_cron.sh).
 # Without this, send_launchd_health_email.R aborts with "GMAIL_USERNAME or
 # GMAIL_APP_PASSWORD not set" and the whole job exits 1 (#749 Part A).
+#
+# set -a / set +a: the #753 fix sourced this file WITHOUT auto-export, so
+# GMAIL_USERNAME/GMAIL_APP_PASSWORD were set as shell-local variables only —
+# invisible to the nix-shell subprocess that runs send_launchd_health_email.R
+# (Step 2), which reads them via Sys.getenv(). Every run since (2026-07-05,
+# 07-12, 07-19) logged "sourced email credentials..." yet Step 2 still failed
+# with "GMAIL_USERNAME or GMAIL_APP_PASSWORD not set". set -a/set +a matches
+# the already-working pattern in roborev_weekly_rollup_cron.sh and
+# roborev_daily_cron.sh.
 EMAIL_ENV_FILE="$HOME/.claude/env/roborev_email.env"
 if [[ -f "$EMAIL_ENV_FILE" ]]; then
   # shellcheck disable=SC1090
+  set -a
   source "$EMAIL_ENV_FILE"
+  set +a
   log "sourced email credentials from $EMAIL_ENV_FILE"
 fi
 
@@ -159,7 +170,17 @@ STEP1_EXIT=$?
 if [ "${STEP1_EXIT}" -ne 0 ]; then
   log "WARNING: launchd_health_report.R exited ${STEP1_EXIT} — continuing"
 fi
-log "Step 1 done (exit=${STEP1_EXIT}, $(wc -l < "${REPORT_OUT}" 2>/dev/null || echo '?') lines)"
+# Guard against ${REPORT_OUT} not existing (e.g. Step 1 failed before writing
+# output): a bare `wc -l < "${REPORT_OUT}"` fails the *shell's* input redirect
+# before the `2>/dev/null` on the same simple command takes effect, so the
+# "No such file or directory" leaks to real stderr (launchd_health_weekly.err)
+# instead of being swallowed. Observed for 2026-06-14/21/28 at then-line 151.
+if [ -f "${REPORT_OUT}" ]; then
+  _report_lines="$(wc -l < "${REPORT_OUT}" 2>/dev/null || echo '?')"
+else
+  _report_lines="?"
+fi
+log "Step 1 done (exit=${STEP1_EXIT}, ${_report_lines} lines)"
 
 # ── Step 1b: Write launchd_health_events rows (llm#554 Phase A) ──────────────
 # Enumerate every canonical plist (com.claude.*.plist, excluding .deprecated*).


### PR DESCRIPTION
## Summary

`com.claude.launchd-health-weekly` (Sunday 09:00) has been failing every
week. Two distinct root causes, both evidenced directly by
`~/.claude/logs/launchd_health_weekly.{log,err}`:

1. **Missing-file redirect leak** (dormant today, but still present in the
   code until this fix). `launchd_health_weekly.err` shows, verbatim, for
   the 2026-06-14/06-21/06-28 runs:
   ```
   bin/launchd_health_weekly_cron.sh: line 151: /Users/johngavin/.claude/logs/launchd_health_report_2026-06-14.md: No such file or directory
   ```
   Root cause: `wc -l < "${REPORT_OUT}" 2>/dev/null || echo '?'` — when
   `${REPORT_OUT}` doesn't exist, bash's *own* input-redirect open failure
   is printed to real stderr before the same command's `2>/dev/null` takes
   effect (classic bash redirect-order gotcha), so the error escapes
   instead of being swallowed. Reproduced standalone (see commit message)
   and confirmed the fix silences it.
   Fix: `[ -f "${REPORT_OUT}" ]` guard before calling `wc -l` at all.

2. **GMAIL creds sourced but never exported** (the *active*, currently
   recurring failure — every run from 2026-07-05 through 2026-07-19 per
   `launchd_health_weekly.log`). The #753 fix (7ee0d3f) added `source
   "$HOME/.claude/env/roborev_email.env"` for Step 2, but without `set -a`
   / `set +a` the sourced `GMAIL_USERNAME`/`GMAIL_APP_PASSWORD` are
   shell-local only — invisible to the `nix-shell --run "Rscript ..."`
   subprocess that runs `send_launchd_health_email.R`. Every recent run
   logs `sourced email credentials from ...` and then still fails with
   `GMAIL_USERNAME or GMAIL_APP_PASSWORD not set`.
   Fix: wrap the `source` in `set -a`/`set +a`, matching the
   already-working pattern in `roborev_weekly_rollup_cron.sh` and
   `roborev_daily_cron.sh`.

`send_launchd_health_email.R` was reviewed but needs no change — it
re-runs the aggregator into a fresh tempfile rather than reading
historical dated report files, so there's no "absent prior week" read
path to guard there.

This is the minimal stop-the-bleeding fix. The daily unified.duckdb
writer redesign for this job is tracked separately in #554 — not touched
here.

## Test plan

- [x] `bash -n bin/launchd_health_weekly_cron.sh`
- [x] Standalone repro: confirmed the pre-fix `wc -l < missing_file
      2>/dev/null || echo '?'` pattern leaks `line N: FILE: No such file or
      directory` to stderr (matches `launchd_health_weekly.err` exactly)
- [x] Standalone repro: confirmed the post-fix `[ -f ... ]` guard produces
      no stderr output and falls back to `?` lines
- [x] `Rscript -e 'parse(...)'` on `send_launchd_health_email.R` (unchanged,
      sanity check only)
- [ ] Next Sunday 09:00 run — verify no `.err` output and email sends
      successfully (cannot simulate GMAIL send/nix-shell subprocess
      inheritance in this sandbox)

Refs #554, #749, #753.
