### PR TITLE
fix(self-review): stop Detector 6 parallel-sprawl false positive

### DIFF
--- a/.claude/scripts/self_review_stage1.sql
+++ b/.claude/scripts/self_review_stage1.sql
@@ -360,40 +360,72 @@ ON CONFLICT (finding_id) DO NOTHING;
 -- usage metrics. The Anthropic panel shows sessions as the primary billing
 -- unit; queuing is cheaper than parallel sprawl.
 --
--- Method: Build a global running total of concurrent sessions by processing
--- session-start (+1) and session-end (-1) events in chronological order.
--- NULL ended_at is treated as current_timestamp (session still running).
--- The per-day peak is the maximum of that running total observed across all
--- event timestamps that fall within the calendar day.
+-- Fix (#804): The original query had two compounding bugs that made
+-- peak_concurrent grow monotonically forever (133 in May -> 913 in Jun ->
+-- 2585+ in Jul, while ground truth for 2026-07-21 was 86 short sessions,
+-- avg duration 1.2 min, real peak ~1-3):
+--   1. The running SUM(delta) OVER (ORDER BY ts ...) was GLOBAL across all
+--      sessions ever recorded, with no reset per calendar day — so every day
+--      inherited the entire backlog of previously-"open" sessions.
+--   2. The session-end (-1) event used COALESCE(ended_at, current_timestamp),
+--      so every session with NULL ended_at (57% of rows — the session-stop
+--      hook never wrote it back) was counted as still running *right now*,
+--      forever, instead of ending on the day it actually started.
+-- Combined, the backlog of never-closed sessions accumulated across every
+-- day from its start date through "today", inflating every subsequent day's
+-- peak by the same growing amount.
+--
+-- Method (fixed): Partition the running total PER calendar day (day_bucket =
+-- the session's start day) instead of computing one global cumulative sum.
+-- Cap a NULL ended_at session's contribution to started_at + 1 minute (a
+-- short, bounded estimate close to the ~1-2 min median session duration seen
+-- in this telemetry) instead of "now" — so a stale/never-closed session can
+-- inflate at most the single day it started on, never every day since.
+-- The per-day peak is the maximum of that day's own running total.
 --
 -- Threshold: ≥ 4 concurrent sessions at any moment on a calendar day.
 -- Finding scope: one finding per flagged calendar day (stable, idempotent).
 -- Recommendation: queue instead of running 4+ at once.
 -- Severity: info
 -- ─────────────────────────────────────────────────────────────────────────────
-WITH parallel_events AS (
-    -- +1 event when a session starts
+-- Ref: #804 — global unbounded running sum + COALESCE(ended_at, now()) made
+-- peak_concurrent grow without bound; fixed via per-day partitioning + a
+-- bounded (1 min) cap on never-closed sessions.
+WITH session_bounds AS (
     SELECT
-        started_at                                      AS ts,
-        1                                               AS delta
-    FROM sessions
-    WHERE started_at IS NOT NULL
-    UNION ALL
-    -- -1 event when a session ends (NULL ended_at → treat as still running)
-    SELECT
-        COALESCE(ended_at, current_timestamp)           AS ts,
-        -1                                              AS delta
+        session_id,
+        started_at,
+        -- Partition key: the session's own start day. Both of its events
+        -- (start, end) are tagged with this key so the running sum below
+        -- resets per day regardless of what the (possibly capped) end
+        -- timestamp happens to be.
+        CAST(started_at AS DATE)                              AS day_bucket,
+        -- NULL ended_at (session-stop hook never fired / crashed session) is
+        -- capped at +1 minute instead of "now" (#804 fix for bug 2).
+        COALESCE(ended_at, started_at + INTERVAL '1' MINUTE)   AS effective_end
     FROM sessions
     WHERE started_at IS NOT NULL
 ),
+parallel_events AS (
+    -- +1 event when a session starts
+    SELECT day_bucket, started_at    AS ts, 1  AS delta FROM session_bounds
+    UNION ALL
+    -- -1 event when a session ends (real ended_at, or the 1-minute cap above)
+    SELECT day_bucket, effective_end AS ts, -1 AS delta FROM session_bounds
+),
 parallel_running AS (
     SELECT
+        day_bucket,
         ts,
         delta,
         -- Starts (delta=1) are sorted before ends (delta=-1) at identical
         -- timestamps so simultaneous starts are all counted before any
         -- simultaneous end, giving a conservative (higher) peak count.
+        -- PARTITION BY day_bucket resets the running sum at the start of
+        -- each calendar day (#804 fix for bug 1) instead of accumulating
+        -- across the entire history of the table.
         SUM(delta) OVER (
+            PARTITION BY day_bucket
             ORDER BY ts, CASE WHEN delta = 1 THEN 0 ELSE 1 END
             ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
         )                                               AS concurrent_count
@@ -401,10 +433,10 @@ parallel_running AS (
 ),
 parallel_daily_peak AS (
     SELECT
-        CAST(ts AS DATE)        AS day_bucket,
+        day_bucket,
         MAX(concurrent_count)   AS peak_concurrent
     FROM parallel_running
-    GROUP BY CAST(ts AS DATE)
+    GROUP BY day_bucket
     HAVING MAX(concurrent_count) >= 4
 )
 INSERT INTO self_review_findings_stage1


### PR DESCRIPTION
## Summary

Fixes #804 — Detector 6 ("parallel-session sprawl") in
`.claude/scripts/self_review_stage1.sql` reported `peak_concurrent: 2624`
for a day with only ~86 short sessions (avg duration 1.2 min), a false
positive that grew monotonically forever (133 in May → 913 in June → 2585+
in July).

## Root cause — two compounding bugs

1. **No per-day reset.** The running total
   `SUM(delta) OVER (ORDER BY ts ...)` was a single global cumulative sum
   across the entire `sessions` table, with no `PARTITION BY` day. Every
   day's peak therefore inherited the *entire backlog* of every
   previously-"open" session ever recorded, not just sessions active that
   day.
2. **Unbounded "still running" assumption.** The session-end (`-1`) event
   used `COALESCE(ended_at, current_timestamp)`. 57% of `sessions` rows have
   `ended_at IS NULL` (the session-stop hook never wrote it back — crashed
   or short-lived sessions). Each of those rows was therefore counted as
   "still open, right now" indefinitely, so the never-closed backlog kept
   growing and inflating every subsequent day's peak by the same amount.

## Fix

- Partition the running sum `PARTITION BY day_bucket` (the session's own
  start day), so each day's peak only reflects sessions relevant to that
  day and the sum resets at day boundaries.
- Cap `NULL ended_at` sessions at `started_at + INTERVAL '1' MINUTE`
  instead of `current_timestamp`, so a stale/never-closed session inflates
  at most the single day it started on, never every day since.

`HAVING MAX(concurrent_count) >= 4` threshold semantics are unchanged.

## Validation

Validated against a **read-only** snapshot of the live
`~/.claude/logs/unified.duckdb` (opened via `duckdb -readonly`, never
written to). A plain `cp` of the file mid-write produced a corrupted
snapshot (`Serialization Error: field id mismatch`) because the DB is
actively appended to by telemetry writers — `EXPORT DATABASE` /
`IMPORT DATABASE` was used instead to get a consistent copy for the
full-script (`INSERT ... ON CONFLICT DO NOTHING`) end-to-end test.

**Before (buggy query), most recent days:**

| day | peak_concurrent |
|---|---|
| 2026-07-23 | 2624 |
| 2026-07-22 | 2618 |
| 2026-07-21 | 2585 |
| 2026-07-20 | 2517 |
| 2026-07-11 | 2417 |

**Ground truth for 2026-07-21:** 86 sessions started, avg duration 1.2 min,
33 with `NULL ended_at`. Restricting to only sessions with a *known* real
`ended_at` (dropping all NULL-ended rows), true peak concurrency that day
was **1**.

**After (fixed query), same days:**

| day | peak_concurrent |
|---|---|
| 2026-07-23 | 2 |
| 2026-07-22 | 2 |
| 2026-07-21 | 7 |
| 2026-07-20 | 10 |
| 2026-07-11 | 8 |

2026-07-21 and 2026-07-20 stay in the high single/low-double digits rather
than `< 5` — inspecting the raw `started_at` timestamps for those days shows
genuine bursts of several sessions starting within seconds of each other
(e.g. 8 session-starts within ~20 seconds around 21:08–21:09 on 07-21).
That is real near-simultaneous session activity (consistent with this
user's documented practice of running parallel worktree sessions — see
`auto-delegation` rule), not a computation artifact — the detector is
correctly still flagging it as an info-level signal per its own threshold
(`>= 4`). What's fixed is the *unbounded growth into the thousands*, not
the detector's sensitivity to genuine bursts.

Total finding counts before/after (via the full script, run against a
writable copy imported from the read-only export):

| | before | after |
|---|---|---|
| `parallel_session_sprawl` findings | 96 | 39 |

## Follow-up required after merge (not done by this PR)

The `self_review_findings_stage1` table on the live DB already holds 96
stale rows from prior (buggy) runs of this detector. `finding_id` is keyed
only on `day_bucket` (`'parallel_sprawl_' || md5(day_bucket::VARCHAR)`), so
`ON CONFLICT (finding_id) DO NOTHING` means the corrected query will
**never overwrite** those old wrong values — new correct rows are silently
skipped as "already exists." A one-time cleanup is needed after this PR
lands:

```sql
DELETE FROM self_review_findings_stage1 WHERE finding_type = 'parallel_session_sprawl';
```

Run once against `~/.claude/logs/unified.duckdb`, then the next
`self_review_stage1.sh` run will repopulate with corrected values. This PR
does **not** run that DELETE — no write to the live DB was made per the
dispatch's read-only-live-DB constraint.

## Test plan

- [x] Read-only validation against the live `unified.duckdb` (never
      modified) confirms the fixed CTE produces bounded, day-scoped peak
      values instead of unbounded growth
- [x] Full `self_review_stage1.sql` script executed end-to-end (INSERT +
      `ON CONFLICT DO NOTHING`) against a writable `IMPORT DATABASE` copy
      of the live snapshot — script parses and runs cleanly, all 10
      detectors still produce their expected finding counts
- [ ] Maintainer runs the one-time `DELETE` above against the live DB after
      merge, so the next overnight run repopulates corrected findings
