### PR TITLE
fix(hooks): stop clobbering ended_at/model via global session marker race (#803)

### DIFF
--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -1166,6 +1166,18 @@ fi
 # Record session start time for session_stop braindump sweep (fast write, stay sync)
 date '+%Y-%m-%d %H:%M:%S' > "$CLAUDE_RUNTIME_ROOT/logs/.session_start_time"
 
+# ── Phase 12b: Reap stale open sessions — BACKGROUND (llm#803) ────────
+# Closes `sessions` rows whose Stop hook never fired the real session-end
+# write (crash, kill -9, /clear, machine sleep) — the safety net for the
+# abnormal-termination gap that the /bye-gated write in session_stop.sh
+# cannot cover by design. See session_reaper.sql for the staleness rule and
+# imputed-duration rationale. Backgrounded + timeout-bounded: never blocks
+# session start; runs once per new session as an opportunistic sweep.
+_reaper_script="$CLAUDE_DIR/scripts/session_reaper.sh"
+if [ -x "$_reaper_script" ]; then
+  nohup timeout 20 "$_reaper_script" > /dev/null 2>&1 &
+fi
+
 # ── Phase 13: Braindumps + dated issues — BACKGROUND (DuckDB/network; shown cached) ──
 # Cache pattern: background job writes output; next session reads it instantly.
 _p13_cache="${HOME}/.claude/logs/session_init_phase13_cache.txt"

--- a/.claude/hooks/session_stop.sh
+++ b/.claude/hooks/session_stop.sh
@@ -58,11 +58,76 @@ if [ -x "$MIX_SCRIPT" ]; then
   timeout 35 "$MIX_SCRIPT" >/dev/null 2>&1 || true
 fi
 
-# ── Log session stop to unified DuckDB ───────────────────────────────
+# ── Resolve stable session ID (llm#273) ──────────────────────────────────────
+# Priority: CLAUDE_SESSION_ID → PPID-anchored file → .current_session
+# Moved ahead of the DB-stop write below (llm#803) so that write uses the
+# same robust resolution as the rest of this file, instead of trusting the
+# single global `.current_session` marker on its own (see llm#803 rationale
+# in the block below).
+_STOP_SESSION_ID="${CLAUDE_SESSION_ID:-}"
+_STOP_LOG_DIR="$CLAUDE_RUNTIME_ROOT/logs"
+_STOP_PPID_ANCHOR="$_STOP_LOG_DIR/.llmtelemetry_ppid_session.${PPID:-0}"
+if [ -z "$_STOP_SESSION_ID" ] && [ -f "$_STOP_PPID_ANCHOR" ]; then
+  _STOP_SESSION_ID=$(cat "$_STOP_PPID_ANCHOR" 2>/dev/null || echo "")
+fi
+if [ -z "$_STOP_SESSION_ID" ] && [ -f "$_STOP_LOG_DIR/.current_session" ]; then
+  _STOP_SESSION_ID=$(cat "$_STOP_LOG_DIR/.current_session" 2>/dev/null || echo "")
+fi
+
+# ── One-shot /bye sentinel detection ──────────────────────────────────
+# IMPORTANT: The Stop hook fires after EVERY Claude response, not only /bye.
+# Gated on a per-session sentinel (llm#273) that /bye writes before invoking
+# the Stop hook. Non-/bye stops leave `_bye_detected=0`. The per-session
+# sentinel is deleted immediately after use — one-shot. Backward-compat: also
+# accept the legacy global sentinel when no per-session ID resolved above.
+# Moved ahead of the DB-stop write below (llm#803) so both that write and the
+# pattern-detection/refine blocks further down share one resolution.
+_BYE_SENTINEL_PS="${CLAUDE_RUNTIME_ROOT}/.bye-requested.${_STOP_SESSION_ID}"
+_BYE_SENTINEL_GLOBAL="${CLAUDE_RUNTIME_ROOT}/.bye-requested"
+_bye_detected=0
+if [ -n "$_STOP_SESSION_ID" ] && [ -f "$_BYE_SENTINEL_PS" ]; then
+  rm -f "$_BYE_SENTINEL_PS"  # consume per-session sentinel — one-shot
+  _bye_detected=1
+elif [ -f "$_BYE_SENTINEL_GLOBAL" ]; then
+  rm -f "$_BYE_SENTINEL_GLOBAL"  # consume global sentinel — one-shot (backward-compat)
+  _bye_detected=1
+fi
+
+# ── Log session stop to unified DuckDB (llm#803) ─────────────────────
+# Root cause of 57% NULL `ended_at` + a median observed duration of only
+# ~36 seconds across 4620 rows: this block used to run UNGATED on every
+# Stop event (which fires after every single response, not just /bye),
+# guarded only by the existence of the single GLOBAL `.current_session`
+# marker file. log_session.sh's own `stop` case deletes that marker as soon
+# as it fires. So the FIRST Stop event of ANY session — often seconds after
+# the very first response — both (a) stamped `ended_at` prematurely, and
+# (b) deleted the one shared marker, starving every other concurrently
+# running session (worktrees, subagents, parallel terminals routinely used
+# in this environment) of the ability to resolve its own session id here,
+# leaving THEIR rows' `ended_at` permanently NULL.
+#
+# Fix: gate this write on the same one-shot `_bye_detected` sentinel used by
+# the pattern-detection/refine blocks further down, and resolve the session
+# id via `_STOP_SESSION_ID` (CLAUDE_SESSION_ID → PPID anchor → marker file)
+# instead of the raw marker file. The write now fires exactly once, at the
+# session's real end. Sessions that never call /bye (crash, kill, /clear)
+# still show `ended_at IS NULL` afterward — that gap is by design, and is
+# closed by the `session_reaper.sql` sweep (see session_init.sh) rather than
+# by guessing at an end time here.
 _log_script="$CLAUDE_DIR/scripts/log_session.sh"
-if [ -x "$_log_script" ] && [ -f "$CLAUDE_RUNTIME_ROOT/logs/.current_session" ]; then
-  _sid=$(cat "$CLAUDE_RUNTIME_ROOT/logs/.current_session" 2>/dev/null || echo "")
-  "$_log_script" stop "$_sid" "$(basename "$(pwd)")" "" 2>/dev/null || true
+if [ "$_bye_detected" -eq 1 ] && [ -x "$_log_script" ] && [ -n "$_STOP_SESSION_ID" ]; then
+  # Best-effort model capture (llm#803): no reliable env var carries the
+  # active model at SessionStart, but by the time /bye fires the session's
+  # transcript almost certainly has at least one assistant turn, and every
+  # turn embeds a top-level "model" field. Scoped by session id (filename),
+  # not "newest transcript across all projects", to stay correct even with
+  # multiple concurrent sessions. Empty is fine — log_session.sh COALESCEs.
+  _stop_transcript=$(ls -t "${CLAUDE_RUNTIME_ROOT}/projects/"*/"${_STOP_SESSION_ID}.jsonl" 2>/dev/null | head -1)
+  _stop_model=""
+  if [ -n "$_stop_transcript" ] && [ -f "$_stop_transcript" ]; then
+    _stop_model=$(grep -o '"model":"[^"]*"' "$_stop_transcript" 2>/dev/null | tail -1 | cut -d'"' -f4)
+  fi
+  "$_log_script" stop "$_STOP_SESSION_ID" "$(basename "$(pwd)")" "" "$_stop_model" 2>/dev/null || true
 fi
 
 # ── Decision log reminder ────────────────────────────────────────────
@@ -148,38 +213,12 @@ for p in pending:
   fi
 fi
 
-# ── Resolve stable session ID (llm#273) ──────────────────────────────────────
-# Mirrors the resolution in llmtelemetry_emit.sh so both hooks agree on the
-# session ID when checking per-session sentinels.
-# Priority: CLAUDE_SESSION_ID → PPID-anchored file → .current_session
-_STOP_SESSION_ID="${CLAUDE_SESSION_ID:-}"
-_STOP_LOG_DIR="$CLAUDE_RUNTIME_ROOT/logs"
-_STOP_PPID_ANCHOR="$_STOP_LOG_DIR/.llmtelemetry_ppid_session.${PPID:-0}"
-if [ -z "$_STOP_SESSION_ID" ] && [ -f "$_STOP_PPID_ANCHOR" ]; then
-  _STOP_SESSION_ID=$(cat "$_STOP_PPID_ANCHOR" 2>/dev/null || echo "")
-fi
-if [ -z "$_STOP_SESSION_ID" ] && [ -f "$_STOP_LOG_DIR/.current_session" ]; then
-  _STOP_SESSION_ID=$(cat "$_STOP_LOG_DIR/.current_session" 2>/dev/null || echo "")
-fi
-
 # ── Pattern Detection (Phase 1 Validation, Option 4 Hybrid) ──────────────
 # IMPORTANT: The Stop hook fires after EVERY Claude response, not only /bye.
 # Running pattern detection (paid Opus API call) on every response would be
-# a massive cost regression. We gate on a per-session sentinel that /bye writes
-# before invoking the Stop hook. Non-/bye stops skip this block entirely.
-# The per-session sentinel is deleted immediately after use (llm#273).
-# Backward-compat: also accept the legacy global sentinel when no per-session ID.
-_BYE_SENTINEL_PS="${CLAUDE_RUNTIME_ROOT}/.bye-requested.${_STOP_SESSION_ID}"
-_BYE_SENTINEL_GLOBAL="${CLAUDE_RUNTIME_ROOT}/.bye-requested"
-_bye_detected=0
-if [ -n "$_STOP_SESSION_ID" ] && [ -f "$_BYE_SENTINEL_PS" ]; then
-  rm -f "$_BYE_SENTINEL_PS"  # consume per-session sentinel — one-shot
-  _bye_detected=1
-elif [ -f "$_BYE_SENTINEL_GLOBAL" ]; then
-  rm -f "$_BYE_SENTINEL_GLOBAL"  # consume global sentinel — one-shot (backward-compat)
-  _bye_detected=1
-fi
-
+# a massive cost regression. Reuses `_bye_detected` (resolved + consumed once,
+# earlier in this file, alongside the llm#803 DB-stop-write gate) so this
+# block also only runs on the real session end, not every response.
 if [ "$_bye_detected" -eq 1 ] && [ -f "${CLAUDE_DIR}/scripts/detect_patterns.sh" ]; then
   TRANSCRIPT=$(ls -t "${CLAUDE_RUNTIME_ROOT}/projects/"*/*.jsonl 2>/dev/null | head -1)
   if [ -n "$TRANSCRIPT" ]; then

--- a/.claude/scripts/backfill_ended_at_803.sh
+++ b/.claude/scripts/backfill_ended_at_803.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# backfill_ended_at_803.sh — ONE-OFF backfill for llm#803.
+#
+# At the time this issue was filed, `sessions.ended_at` was NULL for 2637 of
+# 4620 rows (57%) — historical rows that predate the session_stop.sh /bye-gate
+# fix and the session_reaper.sh ongoing sweep (both llm#803). This script
+# applies the SAME rule as session_reaper.sql (see that file for the full
+# staleness/imputed-duration rationale) once, against the existing backlog,
+# and prints before/after counts plus a sanity check.
+#
+# This is NOT wired into any hook and does not run automatically — it is a
+# manual, one-off remediation. Run it once against the live DB after review;
+# re-running it is harmless (idempotent: WHERE ended_at IS NULL means already
+# backfilled rows are never touched again).
+#
+# Usage:
+#   backfill_ended_at_803.sh <path-to-unified.duckdb>
+#
+# Validate first against a scratch copy, e.g.:
+#   cp ~/.claude/logs/unified.duckdb /tmp/sess_test.duckdb
+#   backfill_ended_at_803.sh /tmp/sess_test.duckdb
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SQL_FILE="${SCRIPT_DIR}/session_reaper.sql"
+DB="${1:?Usage: backfill_ended_at_803.sh <path-to-unified.duckdb>}"
+
+if [ ! -f "$DB" ]; then
+  echo "ERROR: DB not found at $DB" >&2
+  exit 1
+fi
+if [ ! -f "$SQL_FILE" ]; then
+  echo "ERROR: SQL file not found at $SQL_FILE" >&2
+  exit 1
+fi
+if ! command -v duckdb >/dev/null 2>&1; then
+  echo "ERROR: duckdb not on PATH. Run via: nix-shell <llm>/default.nix --run '$0 $DB'" >&2
+  exit 1
+fi
+
+echo "== Before =="
+duckdb -init /dev/null "$DB" -c "
+  SELECT COUNT(*) AS total,
+         SUM(CASE WHEN ended_at IS NULL THEN 1 ELSE 0 END) AS null_ended
+  FROM sessions;
+"
+
+echo "== Applying backfill (session_reaper.sql rule) =="
+duckdb -init /dev/null "$DB" -c ".read '${SQL_FILE}'"
+
+echo "== After =="
+duckdb -init /dev/null "$DB" -c "
+  SELECT COUNT(*) AS total,
+         SUM(CASE WHEN ended_at IS NULL THEN 1 ELSE 0 END) AS null_ended
+  FROM sessions;
+"
+
+echo "== Sanity check: any ended_at < started_at? (expect 0) =="
+duckdb -init /dev/null "$DB" -c "
+  SELECT COUNT(*) AS bad_rows FROM sessions WHERE ended_at < started_at;
+"

--- a/.claude/scripts/log_session.sh
+++ b/.claude/scripts/log_session.sh
@@ -34,9 +34,17 @@ fi
 
 case "$ACTION" in
   start)
+    # llm#803: optional 5th arg MODEL. No reliable harness env var carries the
+    # active model at SessionStart time (before any assistant turn exists),
+    # so today's callers (session_init.sh) never pass it and this stays NULL
+    # at start -- it is populated later by `stop`, which can read the model
+    # out of the session's own transcript JSONL once at least one turn has
+    # happened. The param exists so a future caller with a reliable source
+    # can populate it directly without a log_session.sh change.
+    MODEL_START="${5:-}"
     duckdb -init /dev/null "$DB" -c "
-      INSERT OR REPLACE INTO sessions (session_id, project, started_at, summary)
-      VALUES ('$SESSION_ID', '$PROJECT', current_timestamp, '$SUMMARY');
+      INSERT OR REPLACE INTO sessions (session_id, project, started_at, summary, model)
+      VALUES ('$SESSION_ID', '$PROJECT', current_timestamp, '$SUMMARY', NULLIF('$MODEL_START', ''));
     " 2>/dev/null || true
     # Store session ID for stop to read
     echo "$SESSION_ID" > "$HOME/.claude/logs/.current_session"
@@ -46,11 +54,17 @@ case "$ACTION" in
     if [ "$SESSION_ID" = "" ] && [ -f "$HOME/.claude/logs/.current_session" ]; then
       SESSION_ID=$(cat "$HOME/.claude/logs/.current_session")
     fi
+    # llm#803: optional 5th arg MODEL, sourced by the caller (session_stop.sh)
+    # from the session's transcript JSONL (each assistant turn embeds a
+    # top-level "model" field). COALESCE means a blank/missing value never
+    # clobbers a model recorded by an earlier `stop` call for this session.
+    MODEL_STOP="${5:-}"
     duckdb -init /dev/null "$DB" -c "
       UPDATE sessions
       SET ended_at = current_timestamp,
           duration_min = EXTRACT(EPOCH FROM (current_timestamp - started_at)) / 60.0,
-          summary = COALESCE(NULLIF('$SUMMARY', ''), summary)
+          summary = COALESCE(NULLIF('$SUMMARY', ''), summary),
+          model = COALESCE(NULLIF('$MODEL_STOP', ''), model)
       WHERE session_id = '$SESSION_ID';
     " 2>/dev/null || true
     rm -f "$HOME/.claude/logs/.current_session"

--- a/.claude/scripts/session_reaper.sh
+++ b/.claude/scripts/session_reaper.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# session_reaper.sh — llm#803 safety net for sessions whose Stop hook never
+# fired the real session-end write (crash, kill -9, /clear, machine sleep).
+#
+# The normal path (session_stop.sh, gated on the one-shot /bye sentinel —
+# see llm#803) writes `ended_at` exactly once, at the session's real end.
+# This script closes the remaining rows: `ended_at IS NULL` and stale by the
+# threshold documented in session_reaper.sql.
+#
+# Invoked from session_init.sh, backgrounded + timeout-bounded by the
+# caller — must never block session start. Always exits 0 (best-effort).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DB="${HOME}/.claude/logs/unified.duckdb"
+SQL_FILE="${SCRIPT_DIR}/session_reaper.sql"
+
+[ -f "$DB" ] || exit 0
+[ -f "$SQL_FILE" ] || exit 0
+command -v duckdb >/dev/null 2>&1 || exit 0
+
+duckdb -init /dev/null "$DB" -c ".read '${SQL_FILE}'" 2>/dev/null || true
+exit 0

--- a/.claude/scripts/session_reaper.sql
+++ b/.claude/scripts/session_reaper.sql
@@ -1,0 +1,29 @@
+-- session_reaper.sql — llm#803
+--
+-- Closes `sessions` rows that were abandoned without ever firing a real
+-- session-end Stop event (killed session, crashed harness, /clear, machine
+-- sleep/reboot). The normal path (session_stop.sh, gated on the one-shot
+-- /bye sentinel — see llm#803) writes `ended_at` exactly once, at the
+-- session's real end. Sessions that never call /bye legitimately never hit
+-- that path, so `ended_at` stays NULL forever without this sweep.
+--
+-- Staleness threshold: 6 hours since started_at. Chosen above the observed
+-- p99 real session duration (~96 minutes across 4620 historical rows with a
+-- genuine ended_at) plus a buffer for long working sessions, while staying
+-- far below "abandoned for days". A currently-running session's own row is
+-- never touched by this rule: its started_at is "just now", so it cannot be
+-- more than 6 hours old yet.
+--
+-- Imputed end time: `started_at + INTERVAL 2 HOUR`, a fixed conservative
+-- estimate. A session with no stop event 6+ hours after it started almost
+-- certainly ended long before the reaper runs; 2 hours approximates a
+-- typical working session without polluting duration_min with multi-day
+-- outliers for rows that sat open across a sleep/reboot. The imputed nature
+-- is recorded in `summary` so downstream analytics can filter or exclude
+-- these rows from duration-sensitive aggregates.
+UPDATE sessions
+SET ended_at = started_at + INTERVAL 2 HOUR,
+    duration_min = 120.0,
+    summary = trim(COALESCE(summary, '') || ' [llm#803 reaper: ended_at is an ESTIMATE, no Stop event observed within 6h]')
+WHERE ended_at IS NULL
+  AND started_at < current_timestamp - INTERVAL 6 HOUR;


### PR DESCRIPTION
## Summary

Fixes #803: `sessions.ended_at` was NULL for 57% of rows (2637/4620), and `model` NULL for ~98% (4512/4620).

## Root cause (diagnosed, not assumed)

The `Stop` hook **was already wired** to `log_session.sh stop` (via `session_stop.sh`) — the gap was not "the Stop hook doesn't fire." The actual bug:

`session_stop.sh`'s DB-stop-write block ran **unconditionally on every Stop event** (which fires after *every* Claude response, not just `/bye`), guarded only by the existence of a single **global** `.current_session` marker file. `log_session.sh`'s own `stop` case deletes that marker as soon as it fires. So the very first Stop event of *any* session — often seconds after the first response — both:

1. Stamped `ended_at` **prematurely** (confirmed: median observed `duration_min` across all 4620 rows with a real `ended_at` was **36 seconds**), and
2. **Deleted the one shared marker**, starving every other concurrently-running session (worktrees, subagents, parallel terminals — routine in this environment) of the ability to resolve its own session id there — leaving *their* rows' `ended_at` permanently NULL.

This explains the per-project NULL-rate spread I measured against the live DB (read-only):

| project | total | null ended_at |
|---|---|---|
| ClaudeProbe | 1872 | 1737 (93%) |
| llmtelemetry | 1403 | 424 (30%) |
| llm | 133 | 53 (40%) |

`ClaudeProbe` is an automated/synthetic project unrelated to interactive use and dominates the raw 57% average — worth a separate look, not addressed here.

## Fixes

- **`session_stop.sh`**: gate the DB-stop write on the same one-shot `/bye` sentinel (`_bye_detected`) already used by the pattern-detection/refine blocks further down in this file, and resolve the session id via the existing `CLAUDE_SESSION_ID → PPID-anchor → marker-file` chain (llm#273) instead of trusting the raw marker directly. The write now fires exactly once, at the session's real end. Moved that resolution logic earlier in the file (was previously computed *after* the block that needed it) rather than duplicating it.
- **`log_session.sh`**: added a `model` column to both the `start` INSERT and `stop` UPDATE (COALESCE-safe, so a blank value never clobbers one already recorded). No reliable harness env var carries the active model at `SessionStart` (verified: no `CLAUDE_MODEL`/`ANTHROPIC_MODEL`-style var exists in any hook in this repo), so `stop` sources it from the session's own transcript JSONL — confirmed each assistant turn embeds a top-level `"model":"..."` field — scoped by session-id filename (not "newest transcript across all projects") to stay correct under concurrency.
- **`session_reaper.sh` + `session_reaper.sql`** (new, wired into `session_init.sh`, backgrounded + `timeout 20`): safety net for sessions that never call `/bye` (crash, `kill -9`, `/clear`, machine sleep). Closes `ended_at IS NULL` rows stale by 6h+ with a documented, conservative imputed `ended_at` (`started_at + 2h`), flagged in `summary` so duration-sensitive aggregates can exclude them. Rationale for both thresholds is in the SQL file's header comment (6h vs. observed p99 real duration of ~96 min; 2h imputed vs. polluting `duration_min` with multi-day outliers).
- **`backfill_ended_at_803.sh`** (new, one-off, NOT wired into any hook): applies the same reaper rule once against the existing backlog. **Validated against a `/tmp` copy of the live DB only** — the live DB was never mutated by this session:
  - Before: `total=4620, null_ended=2637`
  - After: `total=4620, null_ended=12`
  - Sanity check `ended_at < started_at`: **72** rows — but confirmed via a read-only query against the live DB (untouched, pre-existing, unrelated to this backfill) that these 72 rows already had `ended_at < started_at` *before* the backfill ran. The backfill's own imputed value (`started_at + 2h`) can never produce `ended_at < started_at`. Flagging as a separate historical data-quality artifact worth its own issue — same underlying marker-race bug, different symptom, out of scope here.

## Validation

- `bash -n` clean on all 5 touched/new scripts.
- SQL shapes for both the `start` INSERT and `stop` UPDATE (with `model`) hand-tested against a disposable `/tmp` DuckDB copy (not the live DB) — confirmed `model` COALESCE behaves as expected.
- `backfill_ended_at_803.sh` dry-run test above against a `/tmp` copy.
- No `devtools::test()` applicable — this is a Bash/SQL hooks change with no R package code touched.

## Not merging

Per `pr-shipping-discipline` / human-in-the-loop rules — opening PR only, no merge.
