### PR TITLE
fix(overnight-email): correct cron 'ok' count + exclude synthetic ClaudeProbe from sessions volume

### DIFF
--- a/.claude/scripts/send_overnight_self_review_email.R
+++ b/.claude/scripts/send_overnight_self_review_email.R
@@ -186,13 +186,19 @@ sec2_rows <- lapply(source_tables, function(tbl) {
     hook_events = "fired_at"
   )
 
+  # Exclude synthetic health-probe rows (project='ClaudeProbe') from the sessions
+  # volume so this health readout reflects real sessions, not the probe fleet.
+  # Interim email-layer fix pending source-level tagging in llm#812.
+  where_clause <- if (identical(tbl, "sessions")) "WHERE project NOT IN ('ClaudeProbe')" else ""
+
   info <- safe_query(sprintf("
     SELECT
       COUNT(*) AS total,
       COUNT(CASE WHEN %s >= current_timestamp::TIMESTAMP - INTERVAL '24' HOUR THEN 1 END) AS last_24h,
       MAX(%s) AS latest_ts
     FROM %s
-  ", ts_col, ts_col, tbl))
+    %s
+  ", ts_col, ts_col, tbl, where_clause))
 
   if (nrow(info) == 0L) {
     return(list(table = tbl, total = 0L, last_24h = 0L,
@@ -292,7 +298,8 @@ sec2_table <- sprintf(
   ACCENT_ORANGE
 )
 
-sec2_summary <- sprintf("%d source tables · %d stale/dead", length(source_tables), n_stale_tables)
+sec2_summary <- sprintf("%d source tables · %d stale/dead · sessions excl. synthetic ClaudeProbe (#812)",
+                        length(source_tables), n_stale_tables)
 
 sec2_block <- collapsible_block(
   "Source table volume (last 24h)",
@@ -671,7 +678,7 @@ if (nrow(cron_freshness) > 0L) {
 if (nrow(cron_health) > 0L) {
   n_fail  <- sum(cron_health$state %in% c("loaded_recent_fail", "unloaded", "missing"),
                  na.rm = TRUE)
-  n_ok    <- sum(cron_health$state == "loaded", na.rm = TRUE)
+  n_ok    <- sum(cron_health$state == "loaded_ok", na.rm = TRUE)
   n_plists <- nrow(cron_health)
 
   cron_rows_html <- paste(apply(cron_health, 1, function(r) {


### PR DESCRIPTION
## Summary

Two grounded bugs in `.claude/scripts/send_overnight_self_review_email.R` that make the overnight self-review email misleading:

### Fix 1 (llm#819) — cron-health "0 ok" is structurally always 0

The writer emits cron-health state `loaded_ok`, but the reader counted rows where `state == "loaded"` — a value the writer never emits. As a result the email's "N ok" count was always 0, even though roughly 15/21 launchd plists are actually healthy. Now counts `state == "loaded_ok"`.

### Fix 2 (llm#812) — synthetic ClaudeProbe rows inflate the sessions volume count

Verified against the live DB: on 2026-07-24 the `sessions` table gained 108 rows, of which 107 were synthetic `project='ClaudeProbe'` health-probe rows (model=NULL, placeholder duration) and only 1 was a real session. Section 2 ("Source table volume") counted all of them together, reporting a misleading "109". This PR excludes synthetic probe rows from the `sessions` counts via `WHERE project NOT IN ('ClaudeProbe')`, and the Section 2 summary line now notes the exclusion for transparency. This is an interim email-layer fix; the deeper source-level tagging fix remains tracked in llm#812.

## Test plan

- [x] `parse()` on the modified file succeeds (verified via nix shell)
- [ ] Manual review of the diff for correctness (both edits are minimal, scoped exactly to the two named bugs)
- [ ] Next overnight email run shows a nonzero "N ok" cron count and a sessions volume that excludes the ClaudeProbe fleet

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>