### PR TITLE
fix(launchd): enumerate plists for self-heal + decouple health DB-write from email exit

### DIFF
--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -1136,26 +1136,56 @@ if [ -f "$_rdb" ] && [ -x "$_sqlite" ]; then
 fi
 
 # ── Phase 11d: auto-rebootstrap unloaded launchd plists ──
-# Detect known plists that have become unloaded and rebootstrap them.
-# See JohnGavin/llm#148 sub-fix 3. Uses /bin/launchctl (not in nix-shell PATH).
-_KNOWN_LABELS="com.roborev.auto-refine com.claude.roborev-autoclose com.claude.roborev-poll-merges com.claude.pr-status-pulse com.claude.wiki-health-pulse com.claude.config-pulse com.claude.knowledge-pulse"
-_lc=/bin/launchctl
-if [ -x "$_lc" ]; then
-  _uid=$(/usr/bin/id -u)
+# Detect com.claude.* launchd jobs that have become unloaded and rebootstrap
+# them. Broadened (llm#819) from a hardcoded allowlist (originally
+# JohnGavin/llm#148 sub-fix 3) to enumerate every installed
+# com.claude.*.plist, so any legitimately-installed job that got unloaded
+# (e.g. a logout/login cycle) self-heals — not just the original short list.
+# Uses /bin/launchctl (not in nix-shell PATH).
+#
+# A plist is SKIPPED (never touched) if either:
+#   (a) its label appears in $_SELFHEAL_OPTOUT (space-separated, seeded
+#       empty — add a label here only if it has no `.plist.deprecated*`
+#       marker yet but should still be excluded), or
+#   (b) a retirement marker exists for it: $CLAUDE_DIR/launchd/<label>.plist.deprecated*
+#       (the naming convention already used for retired jobs there).
+#
+# Only currently-UNLOADED jobs are re-bootstrapped (existing `launchctl print`
+# existence check, preserved). Loaded-but-failing jobs (non-zero
+# LastExitStatus) are deliberately OUT OF SCOPE for this phase.
+# TODO(llm#819): a `launchctl kickstart` path for loaded-but-failing jobs was
+# considered and explicitly deferred — higher blast radius, needs its own
+# review — do not add it here without a fresh design pass.
+_SELFHEAL_OPTOUT=" "
+phase_11d_selfheal() {
+  _lc=/bin/launchctl
+  [ -x "$_lc" ] || return 0
+  _uid=$(/usr/bin/id -u 2>/dev/null) || true
+  [ -n "${_uid:-}" ] || return 0
   _rebooted=""
-  for _label in $_KNOWN_LABELS; do
-    _plist="$HOME/Library/LaunchAgents/$_label.plist"
+  for _plist in "$HOME"/Library/LaunchAgents/com.claude.*.plist; do
     [ -f "$_plist" ] || continue
+    _label=$(basename "$_plist" .plist)
+    case " $_SELFHEAL_OPTOUT " in
+      *" $_label "*) continue ;;
+    esac
+    _deprecated=0
+    for _marker in "$CLAUDE_DIR"/launchd/"$_label".plist.deprecated*; do
+      [ -e "$_marker" ] && _deprecated=1 && break
+    done
+    [ "$_deprecated" = "1" ] && continue
     if ! "$_lc" print "gui/$_uid/$_label" >/dev/null 2>&1; then
       if "$_lc" bootstrap "gui/$_uid" "$_plist" >/dev/null 2>&1; then
-        _rebooted="${_rebooted}$_label "
+        _rebooted="${_rebooted}${_label} "
       fi
     fi
   done
   if [ -n "$_rebooted" ]; then
     WARNINGS="${WARNINGS}INFO: re-bootstrapped unloaded plists: ${_rebooted}"
   fi
-fi
+  return 0
+}
+phase_11d_selfheal || true
 
 # ── Phase 12: Log session start to unified DuckDB — BACKGROUND (~0.74s DuckDB cost) ──
 _log_script="$CLAUDE_DIR/scripts/log_session.sh"

--- a/bin/launchd_health_weekly_cron.sh
+++ b/bin/launchd_health_weekly_cron.sh
@@ -306,33 +306,33 @@ log "Step 2: sending launchd health email..."
 "${NIX_SHELL_BIN}" "${LLM_NIX}" --run "Rscript '${SCRIPTS_DIR}/send_launchd_health_email.R'" 2>>"${LOG_FILE}"
 STEP2_EXIT=$?
 
+# The job's exit code reflects Step 1b (the DB write — the useful work),
+# NOT Step 2 (the email). A missing-GMAIL-creds or transient send failure
+# used to `exit "${STEP2_EXIT}"` here, which made the whole cron job report
+# failure (surfacing as loaded_recent_fail in launchd_health_events) even
+# though Step 1b had already landed its rows successfully. Log a warning and
+# continue to Step 3/4 instead (llm#819).
+_email_failed=0
 if [ "${STEP2_EXIT}" -ne 0 ]; then
-  log "ERROR: send_launchd_health_email.R exited ${STEP2_EXIT}"
-  # Update housekeeping_runs with failed status before exiting
-  if [ "${_duckdb_ok}" = "1" ]; then
-    _run_ended="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-    duckdb "${UNIFIED_DB}" "
-      UPDATE housekeeping_runs
-      SET ended_at = TIMESTAMPTZ '${_run_ended}',
-          status = 'failed',
-          rows_written = ${_EVENTS_WRITTEN}
-      WHERE id = '${_run_id}';
-    " 2>/dev/null || true
-  fi
-  exit "${STEP2_EXIT}"
+  log "WARNING: send_launchd_health_email.R exited ${STEP2_EXIT} — email failed, but NOT failing the job (Step 1b DB write already landed)"
+  _email_failed=1
+else
+  log "Step 2 done"
 fi
-log "Step 2 done"
 
 # ── Step 3: Update housekeeping_runs end row ──────────────────────────────────
 if [ "${_duckdb_ok}" = "1" ]; then
   _run_ended="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  _run_status="ok"
+  [ "${_email_failed}" = "1" ] && _run_status="partial"
   duckdb "${UNIFIED_DB}" "
     UPDATE housekeeping_runs
     SET ended_at = TIMESTAMPTZ '${_run_ended}',
+        status = '${_run_status}',
         rows_written = ${_EVENTS_WRITTEN}
     WHERE id = '${_run_id}';
   " 2>/dev/null || log "duckdb WARN: housekeeping_runs UPDATE failed (non-fatal)"
-  log "Step 3: housekeeping_runs updated (rows_written=${_EVENTS_WRITTEN})"
+  log "Step 3: housekeeping_runs updated (status=${_run_status}, rows_written=${_EVENTS_WRITTEN})"
 fi
 
 # ── Step 4: Prune old reports (keep 30 days) ──────────────────────────────────


### PR DESCRIPTION
## Summary

Safe slice of [llm#819](https://github.com/JohnGavin/llm/issues/819). The "0 ok" email-reader bug referenced in that issue is **already fixed and merged separately** — this PR does not touch the email reader.

### 1. `session_init.sh` Phase 11d — broaden self-heal from a hardcoded allowlist to enumeration

Previously, Phase 11d re-bootstrapped unloaded launchd jobs only if their label appeared in a hardcoded `_KNOWN_LABELS` list. Any legitimately-installed job outside that list (e.g. `com.claude.worktree-gc`, `com.claude.launchd-health-weekly`) that got unloaded — for example by a macOS logout/login cycle — was silently never self-healed.

Now the phase enumerates every `~/Library/LaunchAgents/com.claude.*.plist` file and re-bootstraps any that are currently unloaded, **except**:
- labels with a retirement marker under `.claude/launchd/<label>.plist.deprecated*` (the naming convention already used for retired jobs there, e.g. `com.claude.capability-registry.plist.deprecated-2026-07-23`)
- labels listed in `_SELFHEAL_OPTOUT` (seeded empty — no hardcoded exclusions were needed since existing deprecated jobs already carry the marker)

**Deliberately out of scope:** a `launchctl kickstart` path for jobs that are *loaded but failing* (non-zero `LastExitStatus`) was considered and explicitly deferred — that's a more aggressive intervention with a different blast-radius profile and needs its own design review. Left a `# TODO(llm#819)` comment at the point in the code where it was considered.

**Blast-radius note:** `session_init.sh` runs on *every* session start. The new logic is wrapped in a `phase_11d_selfheal()` function invoked with `|| true`, and every command substitution that can fail (`id -u`) is guarded, so an unexpected error here cannot abort the hook (this is the exact failure mode from llm#695 — an unguarded substitution under `set -euo pipefail` silently aborting a hook). **This file needs careful human review before merge** given how frequently it runs.

### 2. `bin/launchd_health_weekly_cron.sh` — decouple the job's exit code from the email step

Step 1b (writing `launchd_health_events` rows to `unified.duckdb`) is the useful work of this job. Step 2 (sending the summary email) used to `exit "${STEP2_EXIT}"` on failure, so a missing-GMAIL-creds or transient send error made the *entire* job report failure — even though the DB rows had already landed successfully. This is why the weekly health job showed `loaded_recent_fail` in its own `launchd_health_events` row despite good underlying data.

Now: an email failure logs a `WARNING`, marks the `housekeeping_runs` row `partial` (was `ok`/`failed`), and the script continues through Step 3 (housekeeping_runs end row) and Step 4 (report pruning), exiting 0. All existing logging is preserved.

## Test plan

- [x] `bash -n .claude/hooks/session_init.sh` — pass
- [x] `bash -n bin/launchd_health_weekly_cron.sh` — pass
- [ ] shellcheck — not installed in this environment (laptop-local only per `roborev-resolution` rule notes on jarl-style tooling); skipped. `bash -n` is the hard gate per the dispatch instructions.
- [ ] No live `launchctl bootstrap/bootout/kickstart` was executed — static checks only, per dispatch scope.
- [ ] Human review of `session_init.sh` diff before merge (high blast radius — runs every session start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
