### PR TITLE
fix(overnight-email): cast current_timestamp so branch_gc query stops erroring

### DIFF
--- a/.claude/scripts/send_overnight_self_review_email.R
+++ b/.claude/scripts/send_overnight_self_review_email.R
@@ -949,7 +949,7 @@ branch_gc_body <- tryCatch({
   bge <- DBI::dbGetQuery(con, "
     SELECT action, COUNT(*) AS n
     FROM branch_gc_events
-    WHERE fired_at >= current_timestamp - INTERVAL 24 HOUR
+    WHERE fired_at >= current_timestamp::TIMESTAMP - INTERVAL '24' HOUR
     GROUP BY action ORDER BY n DESC
   ")
   if (nrow(bge) == 0) {


### PR DESCRIPTION
## Summary

Section 3f "Branch GC (last 24h)" in `.claude/scripts/send_overnight_self_review_email.R` queried `branch_gc_events` using:

```sql
WHERE fired_at >= current_timestamp - INTERVAL 24 HOUR
```

`current_timestamp` in DuckDB is `TIMESTAMP WITH TIME ZONE`. DuckDB 1.4.4's R driver has no `-(TIMESTAMPTZ, INTERVAL)` operator without the ICU extension loaded, and the R connection in this script doesn't load ICU. This caused a Binder Error on every run, so the overnight email rendered "branch_gc query error: ..." instead of the branch-GC summary.

Every other timestamp-arithmetic query in this file already uses the cast form `current_timestamp::TIMESTAMP - INTERVAL '24' HOUR` — Section 3f was the only un-cast occurrence. This PR applies the same cast to fix it:

```sql
WHERE fired_at >= current_timestamp::TIMESTAMP - INTERVAL '24' HOUR
```

## Test plan

- [x] `parse()` on the edited script succeeds (no syntax errors introduced)
- [x] Ran the corrected query live against `~/.claude/logs/unified.duckdb` inside the project nix shell — returns a 6-row data frame of branch_gc actions (`kept_protected`, `kept_unmerged`, `kept_young`, `deleted_merged`, `kept_checked_out`, `deleted_reimpl`) with no Binder Error
- [ ] Next overnight email run (06:30 launchd job) should show Section 3f populated instead of the query-error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)