### PR TITLE
fix(rollup-email): restore table open tag, drop separator rows, open collapsible by default

### DIFF
--- a/.claude/scripts/send_roborev_weekly_rollup_email.R
+++ b/.claude/scripts/send_roborev_weekly_rollup_email.R
@@ -152,32 +152,34 @@ md_to_simple_html <- function(md) {
                                 dark_muted, EMAIL_FONT_SUBTITLE, inner)
     } else if (grepl("^\\|", l) && grepl("\\|$", l)) {
       # Table row
+      table_open <- ""
       if (!in_table) {
-        html_parts[i] <- sprintf(
-          '<table style="border-collapse:collapse; width:100%%; font-size:%s; margin:8px 0;">\n',
+        table_open <- sprintf(
+          '<table style="border-collapse:collapse; width:100%%; font-size:%s; margin:8px 0;">',
           EMAIL_FONT_BODY
         )
         in_table <- TRUE
       }
-      # Skip separator rows (|---|...)
-      if (grepl("^\\|[\\s-|]+\\|$", l)) {
-        html_parts[i] <- ""
-        next
-      }
       cells <- strsplit(trimws(sub("^\\|", "", sub("\\|$", "", l))), "\\|")[[1L]]
       cells <- trimws(cells)
-      is_header <- i > 1L && !grepl("^\\|[\\s-|]+\\|$", lines[min(i + 1L, length(lines))])
-      cell_tag <- "td"
+      # Skip markdown separator rows: every cell looks like ---, :---, ---:, :---:
+      if (length(cells) > 0L && all(grepl("^:?-{2,}:?$", cells))) {
+        html_parts[i] <- table_open  # preserve <table> if a separator was somehow first
+        next
+      }
       cell_style <- sprintf('style="padding:5px 8px; border:1px solid %s; color:%s;"',
                              dark_border, dark_text)
       bg <- if ((i %% 2L) == 0L) dark_row_alt else dark_card
       cells_html <- paste0(
         vapply(cells, function(c) {
-          sprintf('<%s %s>%s</%s>', cell_tag, cell_style, c, cell_tag)
+          sprintf('<td %s>%s</td>', cell_style, c)
         }, character(1L)),
         collapse = ""
       )
-      html_parts[i] <- sprintf('<tr style="background-color:%s;">%s</tr>', bg, cells_html)
+      html_parts[i] <- paste0(
+        table_open,
+        sprintf('<tr style="background-color:%s;">%s</tr>', bg, cells_html)
+      )
     } else {
       if (in_table) {
         html_parts[i] <- paste0("</table>\n",
@@ -192,7 +194,7 @@ md_to_simple_html <- function(md) {
     }
   }
   if (in_table) html_parts[length(html_parts)] <- paste0(html_parts[length(html_parts)], "</table>")
-  paste(html_parts, collapse = "\n")
+  paste(html_parts[nzchar(html_parts)], collapse = "\n")
 }
 
 body_inner_html <- md_to_simple_html(rollup_md)
@@ -200,7 +202,8 @@ rollup_lines <- length(strsplit(rollup_md, "\n")[[1L]])
 body_inner <- collapsible_block(
   "&#x1F4CB; Weekly Rollup",
   sprintf("~%d lines", rollup_lines),
-  body_inner_html
+  body_inner_html,
+  open = TRUE
 )
 
 # Dashboard CTA


### PR DESCRIPTION
## Summary

Fixes the mashed-text rendering in the weekly roborev rollup email (`.claude/scripts/send_roborev_weekly_rollup_email.R`).

`md_to_simple_html()` had two bugs plus an unwanted collapsed-by-default state:

- **Bug A — missing `<table>` open tag.** In the table-row branch, when a table starts it set `html_parts[i] <- '<table ...>'` then **unconditionally overwrote** `html_parts[i]` with the `<tr>` markup a few lines later. Every table therefore emitted `<tr>...</tr>...</table>` with **no opening `<table>`** — the browser/mail client then renders the orphan `<tr>`/`<td>` content as raw mashed text (the "ReasonCount%" symptom reported).
- **Bug B — separator rows leaked through.** The skip regex `^\|[\s-|]+\|$` does not match a markdown separator row like `|--------|-------|` under R's default POSIX regex engine, so the separator row rendered as a literal data row of dashes.
- **Collapsible now opens by default.** `collapsible_block(..., open = TRUE)` so recipients see the tables immediately instead of needing to click to expand.

## Fix

- Table-row branch now builds the `<table ...>` opening tag as a separate `table_open` string that is prepended to the first `<tr>` only when a new table starts, instead of being clobbered.
- Separator-row detection now checks that every cell in the row matches `^:?-{2,}:?$` (handles `---`, `:---`, `---:`, `:---:`) rather than relying on a regex applied to the whole raw line.
- Filter out empty `html_parts` entries before joining, so a blank line from a skipped separator row doesn't leave a stray blank line inside the HTML.
- `body_inner <- collapsible_block(..., open = TRUE)`.

## Verification

Ran with `EMAIL_DRY_RUN=1` against the real weekly rollup data:

- `grep -c "<table "` → **4**, `grep -c "</table>"` → **4** (Global Summary, Per-Project, Close-Reason, Top Stuck — every table opens and closes exactly once)
- `grep -n ">--"` → **0 matches** (no leaked separator-dash cells)
- `<details open style="margin: 12px 0;">` present — collapsible is expanded by default

Before (per-table): `<tr>...</tr>...</table>` (no opening tag) plus a spurious `<td>--------</td>` row.
After: `<table ...><tr>(header)</tr><tr>(data)</tr>...</table>`, no separator artifacts.

## Test plan

- [x] `parse()` on the edited script succeeds
- [x] `EMAIL_DRY_RUN=1` dry-run produces well-formed HTML (verified table open/close counts, no leaked separator rows, `<details open>` present)
- [ ] Reviewer to eyeball the rendered HTML in `/tmp/rollup_fixed.html` (agent scratch, not committed) or trigger a real dry-run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)