### PR TITLE
fix(launchd): add PATH/HOME to worktree-gc plist so gh resolves

### DIFF
--- a/.claude/launchd/com.claude.worktree-gc.plist
+++ b/.claude/launchd/com.claude.worktree-gc.plist
@@ -27,6 +27,19 @@
         <string>--apply</string>
     </array>
 
+    <!-- Fix: launchd's default PATH (/usr/bin:/bin:/usr/sbin:/sbin) omits gh   -->
+    <!-- (Homebrew), so squash-merge detection in worktree_gc.sh's             -->
+    <!-- is_squash_merged() silently found nothing under the scheduler even    -->
+    <!-- though interactive runs (full PATH) detected merges correctly. HOME   -->
+    <!-- is set so gh reads ~/.config/gh for auth.                            -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+    </dict>
+
     <!-- Daily 09:00 (Mac reliably awake) -->
     <key>StartCalendarInterval</key>
     <dict>


### PR DESCRIPTION
## Summary
- `worktree_gc.sh`'s squash-merge detection (`is_squash_merged()`) shells out to `gh`, but launchd's default PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) does not include Homebrew, so `gh` was never found under the scheduled 09:00 run — only interactive runs (full shell PATH) detected squash-merges correctly.
- Adds an `EnvironmentVariables` dict to `.claude/launchd/com.claude.worktree-gc.plist` with `PATH` (including `/opt/homebrew/bin`, where `gh` resolves via `which gh`) and `HOME` (so `gh` reads `~/.config/gh` for auth).
- No change to schedule (`StartCalendarInterval` 09:00) or `ProgramArguments`.

## Deploy step required after merge (NOT done by this PR)
This PR only edits the repo copy of the plist. To take effect, an operator must redeploy the installed launchd job:
```bash
launchctl bootout gui/$(id -u)/com.claude.worktree-gc 2>/dev/null
cp .claude/launchd/com.claude.worktree-gc.plist ~/Library/LaunchAgents/
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude.worktree-gc.plist
```

## Test plan
- [x] `plutil -lint` on the edited plist reports OK
- [x] Confirmed `gh` resolves to `/opt/homebrew/bin/gh` (verified via `which gh`), and that directory is in the new PATH
- [ ] After deploy, confirm `launchctl print gui/$(id -u)/com.claude.worktree-gc` shows the new `EnvironmentVariables` block
- [ ] Confirm next scheduled 09:00 run's `worktree_gc.out`/`.err` shows squash-merged worktrees being detected/removed where previously they were not

🤖 Generated with [Claude Code](https://claude.com/claude-code)