### PR TITLE
fix(roborev-report): stop rendering review_id as a GitHub issue link (404) in outlier tables

### DIFF
--- a/.claude/scripts/send_roborev_email.R
+++ b/.claude/scripts/send_roborev_email.R
@@ -572,10 +572,6 @@ if (n_outliers > 0L) {
     bg <- if (i %% 2 == 0) dark_row_alt else dark_card
     rid  <- r[["review_id"]] %||% ""
     repo <- r[["repo"]] %||% ""
-    repo_url <- resolve_repo_url(repo)
-    id_link   <- if (nzchar(rid) && !is.null(repo_url))
-      sprintf('<a href="%s/issues/%s" style="color:%s;">%s</a>', repo_url, rid, accent_blue, rid)
-    else rid
     repo_link <- repo_link_or_text(repo, accent_blue)
     outlier_ttc_inner <- paste0(outlier_ttc_inner, sprintf(
       '<tr style="background-color:%s;">
@@ -586,7 +582,7 @@ if (n_outliers > 0L) {
         <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
       </tr>',
       bg,
-      dark_border, accent_blue, id_link,
+      dark_border, accent_blue, rid,
       dark_border, dark_text, repo_link,
       dark_border, accent_orange, fmt_num(r[["time_to_close_hrs"]]),
       dark_border, dark_text, fmt_int(r[["n_attempts"]]),
@@ -639,10 +635,6 @@ if (outliers_by_attempts_degenerate) {
       bg <- if (i %% 2 == 0) dark_row_alt else dark_card
       rid  <- r[["review_id"]] %||% ""
       repo <- r[["repo"]] %||% ""
-      repo_url <- resolve_repo_url(repo)
-      id_link   <- if (nzchar(rid) && !is.null(repo_url))
-        sprintf('<a href="%s/issues/%s" style="color:%s;">%s</a>', repo_url, rid, accent_blue, rid)
-      else rid
       repo_link <- repo_link_or_text(repo, accent_blue)
       outlier_att_inner <- paste0(outlier_att_inner, sprintf(
         '<tr style="background-color:%s;">
@@ -653,7 +645,7 @@ if (outliers_by_attempts_degenerate) {
           <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
         </tr>',
         bg,
-        dark_border, accent_blue, id_link,
+        dark_border, accent_blue, rid,
         dark_border, dark_text, repo_link,
         dark_border, accent_orange, fmt_int(r[["n_attempts"]]),
         dark_border, dark_text, fmt_num(r[["time_to_close_hrs"]]),


### PR DESCRIPTION
## Summary
- The Daily Report's outlier tables (Top-5 by Time-to-Close and by Attempts) rendered each roborev `review_id` as a GitHub issue link (`<repo>/issues/<review_id>`), but `review_id` is a roborev DB primary key, not a GitHub issue number — every such link 404s (e.g. `llmtelemetry/issues/7302`).
- Fix: render the ID as plain (styled) text in both outlier tables. The repo column already links correctly to the repo, and both tables already note that full detail lives on the dashboard/JSON snapshot.
- Removed the now-dead `id_link`/`repo_url` variables in these two blocks.

## Test plan
- [x] `parse("send_roborev_email.R")` succeeds
- [x] `EMAIL_DRY_RUN=1` run against the live 2026-07-27 snapshot produces valid HTML
- [x] `grep "issues/"` on the rendered HTML output returns no matches
- [x] Outlier IDs (7302, 7328, 7332, 7333, 7334) still render as visible styled text in the ID column
- [x] Repo column link (e.g. to `llmtelemetry`) is unaffected

Dispatch-Id: 4698e95c