### PR TITLE
fix(launchd-health): daily writer + full plist enumeration + hide retired plists (llm#554)

### DIFF
--- a/.claude/launchd/com.claude.launchd-health-weekly.plist
+++ b/.claude/launchd/com.claude.launchd-health-weekly.plist
@@ -5,20 +5,23 @@
     <key>Label</key>
     <string>com.claude.launchd-health-weekly</string>
 
-    <!-- Run bin/launchd_health_weekly_cron.sh every Sunday at 09:00 local time -->
+    <!-- Run bin/launchd_health_weekly_cron.sh every day at 08:00 local time
+         (now daily per llm#554; was Sunday-only). 08:00 deliberately does
+         NOT overlap the 09:00 peak (worktree-gc, roborev-poll-merges,
+         roborev-project-backlog, config-pulse all fire then) — that
+         contention was implicated in silent duckdb write failures
+         (see the writer script's Step 1b retry-logic comment). -->
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/bin/launchd_health_weekly_cron.sh</string>
     </array>
 
-    <!-- Sunday = Weekday 0; Hour 9; Minute 0 -->
+    <!-- Daily; Hour 8; Minute 0 -->
     <key>StartCalendarInterval</key>
     <dict>
-        <key>Weekday</key>
-        <integer>0</integer>
         <key>Hour</key>
-        <integer>9</integer>
+        <integer>8</integer>
         <key>Minute</key>
         <integer>0</integer>
     </dict>

--- a/.claude/scripts/send_overnight_self_review_email.R
+++ b/.claude/scripts/send_overnight_self_review_email.R
@@ -836,6 +836,20 @@ cron_health <- safe_query("
     plist_label
 ")
 
+# Hide retired plists (llm#554): launchd_health_events is append-only, so a
+# plist_label retired/renamed/uninstalled (its .plist file removed from
+# ~/Library/LaunchAgents) still has a last-known row and would otherwise
+# keep appearing here forever as "unloaded" — e.g. com.claude.capability-
+# registry, retired 2026-07-23, showing up in this table long after removal.
+# Filter to labels whose plist file still exists on disk.
+if (nrow(cron_health) > 0L) {
+  .launch_agents_dir <- path.expand("~/Library/LaunchAgents")
+  .plist_installed <- vapply(cron_health$plist_label, function(lbl) {
+    file.exists(file.path(.launch_agents_dir, paste0(lbl, ".plist")))
+  }, logical(1))
+  cron_health <- cron_health[.plist_installed, , drop = FALSE]
+}
+
 # Freshness guard (llm#510 attempt #3): the ROW_NUMBER()-partitioned query
 # above answers "what is the latest known state per plist", which is only
 # trustworthy if the launchd_health_events table itself has been refreshed

--- a/bin/launchd_health_weekly_cron.sh
+++ b/bin/launchd_health_weekly_cron.sh
@@ -274,24 +274,48 @@ if [ "${_duckdb_ok}" = "1" ]; then
     # Escape single quotes in detail string
     _detail_sql="${_detail//"'"/"''"}"
 
-    duckdb "${UNIFIED_DB}" "
-      INSERT OR IGNORE INTO launchd_health_events
-        (id, fired_at, source, plist_label, state, last_exit_code, last_fired_at, next_fire_at, detail)
-      VALUES (
-        '${_evt_id}',
-        TIMESTAMPTZ '${_fired_at}',
-        'launchd_health_weekly_cron.sh',
-        '${_label}',
-        '${_state}',
-        ${_exit_col},
-        NULL,
-        NULL,
-        '${_detail_sql}'
-      );
-    " 2>/dev/null || log "duckdb WARN: launchd_health_events INSERT failed for ${_label} (non-fatal)"
+    # Retry on failure (llm#554): unified.duckdb is a single-writer file
+    # shared by ~20 launchd jobs, several of which fire at the same 09:00
+    # slot as this one. A `duckdb` CLI invocation opens a brand-new
+    # connection per INSERT, so a peer job holding the write lock at the
+    # instant this loop reaches a given plist causes that INSERT to fail —
+    # previously this was logged as a WARN and then SILENTLY counted as
+    # written anyway (the counter incremented unconditionally below),
+    # so the end-of-loop "N rows written" log lied about how many rows
+    # actually landed. Observed 2026-07-26: log said "23 rows written",
+    # the table only gained 2 — 21 INSERTs failed on lock contention and
+    # were miscounted as successes. Retry with a short backoff and only
+    # count genuine successes.
+    _insert_ok=0
+    for _attempt in 1 2 3; do
+      if duckdb "${UNIFIED_DB}" "
+        INSERT OR IGNORE INTO launchd_health_events
+          (id, fired_at, source, plist_label, state, last_exit_code, last_fired_at, next_fire_at, detail)
+        VALUES (
+          '${_evt_id}',
+          TIMESTAMPTZ '${_fired_at}',
+          'launchd_health_weekly_cron.sh',
+          '${_label}',
+          '${_state}',
+          ${_exit_col},
+          NULL,
+          NULL,
+          '${_detail_sql}'
+        );
+      " 2>/dev/null; then
+        _insert_ok=1
+        break
+      fi
+      sleep 1
+    done
 
-    _EVENTS_WRITTEN=$(( _EVENTS_WRITTEN + 1 ))
-    log "  ${_label}: ${_state} (exit=${_exit_code_val:-never})"
+    if [ "${_insert_ok}" = "1" ]; then
+      _EVENTS_WRITTEN=$(( _EVENTS_WRITTEN + 1 ))
+      log "  ${_label}: ${_state} (exit=${_exit_code_val:-never})"
+    else
+      log "duckdb WARN: launchd_health_events INSERT failed for ${_label} after 3 attempts (non-fatal, lock contention)"
+      log "  ${_label}: ${_state} (exit=${_exit_code_val:-never}) [NOT WRITTEN]"
+    fi
   done
 
   log "Step 1b done: ${_EVENTS_WRITTEN} launchd_health_events rows written"


### PR DESCRIPTION
## Summary

The overnight cron-health readout (in the daily self-review email) was untrustworthy for three compounding reasons:

1. **Writer was weekly, not daily.** `launchd_health_events` only got new rows on Sundays, so the daily email showed week-old per-job states the other six days.
2. **Enumeration "regression" was actually a silent write-count lie.** The Step 1b loop in `bin/launchd_health_weekly_cron.sh` already iterated every installed `com.claude.*.plist` — but each row's `duckdb` INSERT ran as its own fresh CLI connection with no retry. `unified.duckdb` is a single-writer file shared by ~20 launchd jobs, several of which fire at the *same* 09:00 slot as this one (worktree-gc, roborev-poll-merges, roborev-project-backlog, config-pulse — the report itself flags this contention). When a peer job held the write lock, the INSERT failed — but the success counter incremented unconditionally regardless of outcome. Confirmed directly from `~/.claude/logs/launchd_health_weekly.log`: on 2026-07-26, 21 of 23 INSERTs logged `duckdb WARN ... INSERT failed`, yet the loop still reported "23 rows written." The DB actually gained only 2 rows that day.
3. **Retired plists never disappeared.** `launchd_health_events` is append-only, so a plist removed from `~/Library/LaunchAgents` (e.g. `com.claude.capability-registry`, retired 2026-07-23) kept showing up in the email's cron-health table via its last-known stale row.

## Changes

- **`bin/launchd_health_weekly_cron.sh`** — Step 1b now retries each INSERT up to 3 times with a 1s backoff, and only increments the written-row counter on genuine success (previously it counted attempts, not successes).
- **`.claude/launchd/com.claude.launchd-health-weekly.plist`** — `StartCalendarInterval` changed from Sunday 09:00 to **daily 08:00**. Daily per llm#554; 08:00 also moves the job off the 09:00 collision that was implicated in the lock contention.
- **`.claude/scripts/send_overnight_self_review_email.R`** — `cron_health` now filters to `plist_label`s whose `.plist` file still exists under `~/Library/LaunchAgents`, hiding retired entries.

`launchd_health_report.R` was checked and needs no change — it enumerates live plist files directly via `list.files()`, so it can't show retired plists in the first place.

## Verification

- `bash -n bin/launchd_health_weekly_cron.sh` — pass.
- `plutil -lint` on the plist — OK; confirmed schedule is now `Hour=8, Minute=0` with no `Weekday` key (daily).
- `parse()` on both `send_overnight_self_review_email.R` and `launchd_health_report.R` — OK.
- Ran the actual writer (`EMAIL_DRY_RUN=1`, `SKIP_CRON_PULL=1`) against a scratch copy of `unified.duckdb`:
  - Uncontended run: log said "23 rows written"; DB query confirmed 23 actual rows, 23 distinct labels — counter is accurate.
  - **Contended run** (held a genuine open transaction on the scratch DB via a FIFO-blocked `duckdb` process, released mid-loop): `com.claude.branch-gc` exhausted its 3 retries while the lock was held, was correctly logged `[NOT WRITTEN]` and excluded from the count; final log said "22 rows written" and the DB confirmed exactly 22 rows/22 distinct labels. This reproduces and fixes the exact 2026-07-26 failure mode.
- `tests/testthat/test-launchd-health-report.R`: 20/20 pass, no regressions.

## Post-merge operator step

The plist change requires redeploy + reload (not done by this PR):

```bash
cp .claude/launchd/com.claude.launchd-health-weekly.plist ~/Library/LaunchAgents/
launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.claude.launchd-health-weekly.plist
launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.claude.launchd-health-weekly.plist
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)