### PR TITLE
fix(roborev-report): link top-10 finding IDs to their GitHub commit

### DIFF
--- a/.claude/scripts/roborev_daily_report.R
+++ b/.claude/scripts/roborev_daily_report.R
@@ -337,6 +337,81 @@ load_attempts_heuristic <- function(lifecycle_df) {
   })
 }
 
+# ── Load commit SHA (git_ref) for outlier IDs ─────────────────────────────────
+#
+# review_id -> reviews.job_id -> review_jobs.git_ref. git_ref holds either a
+# single commit SHA (the common case) or a "SHA_A..SHA_B" range (roborev
+# range reviews — e.g. a post-merge catch-up covering several commits).
+# commit_sha travels into the JSON snapshot's outlier tables so the email
+# renderer can link each finding ID to the exact GitHub commit/compare view
+# roborev reviewed (llm#835 fixed the prior — wrong — attempt that linked IDs
+# to <repo>/issues/<id>, a 404 since review_id is a roborev DB primary key,
+# not a GitHub issue number).
+#
+# Returns a data.frame(review_id, commit_sha) or NULL on any failure — the
+# caller must treat NULL/NA as "no link available", never fabricate a SHA.
+
+load_commit_sha <- function(lifecycle_df) {
+  if (nrow(lifecycle_df) == 0L || !file.exists(REVIEWS_DB)) {
+    return(NULL)
+  }
+  review_ids <- lifecycle_df$review_id[!is.na(lifecycle_df$review_id)]
+  if (length(review_ids) == 0L) return(NULL)
+
+  tryCatch({
+    tmp_con <- dbConnect(duckdb::duckdb(), ":memory:")
+    on.exit(
+      tryCatch(dbDisconnect(tmp_con, shutdown = TRUE), error = function(e) NULL),
+      add = TRUE
+    )
+    invisible(tryCatch(
+      dbExecute(tmp_con, "LOAD sqlite"),
+      error = function(e) {
+        invisible(tryCatch(dbExecute(tmp_con, "INSTALL sqlite"), error = function(e2) NULL))
+        invisible(dbExecute(tmp_con, "LOAD sqlite"))
+      }
+    ))
+    dbExecute(tmp_con,
+      sprintf("ATTACH '%s' AS rdb (TYPE sqlite, READ_ONLY)", REVIEWS_DB)
+    )
+
+    id_list <- paste(review_ids, collapse = ", ")
+    sql <- sprintf("
+      SELECT
+        rv.id AS review_id,
+        rj.git_ref AS commit_sha
+      FROM rdb.reviews rv
+      LEFT JOIN rdb.review_jobs rj ON rj.id = rv.job_id
+      WHERE rv.id IN (%s)
+    ", id_list)
+    df <- dbGetQuery(tmp_con, sql)
+    if (nrow(df) == 0L) return(NULL)
+    df
+  }, error = function(e) {
+    message("roborev_daily_report.R: commit_sha query error: ", conditionMessage(e))
+    NULL
+  })
+}
+
+# ── Join commit SHA to lifecycle slice ────────────────────────────────────────
+
+enrich_with_commit_sha <- function(lifecycle_df) {
+  if (nrow(lifecycle_df) == 0L) {
+    lifecycle_df$commit_sha <- character(0L)
+    return(lifecycle_df)
+  }
+
+  sha_df <- load_commit_sha(lifecycle_df)
+  if (is.null(sha_df)) {
+    sha_df <- data.frame(review_id = integer(), commit_sha = character(),
+                          stringsAsFactors = FALSE)
+  }
+
+  # Left-join: reviews without a resolvable git_ref get commit_sha = NA
+  # (rendered as plain-text ID downstream — never a broken link).
+  merge(lifecycle_df, sha_df, by = "review_id", all.x = TRUE)
+}
+
 # ── Join attempts to lifecycle slice ──────────────────────────────────────────
 
 enrich_with_attempts <- function(con, lifecycle_df, has_lineage) {
@@ -585,10 +660,20 @@ compute_outliers <- function(df, bounds = NULL) {
       review_id = integer(), repo = character(),
       n_attempts = integer(), time_to_close_hrs = double(),
       close_reason = character(), created_at = character(),
+      commit_sha = character(),
       stringsAsFactors = FALSE
     )
     return(list(by_attempts = empty_df, by_time = empty_df))
   }
+
+  # commit_sha may be absent if enrich_with_commit_sha() was never called on
+  # the input df (e.g. an older caller) — default to NA rather than error.
+  sha_col <- if (!is.null(found_closed$commit_sha)) {
+    as.character(found_closed$commit_sha)
+  } else {
+    rep(NA_character_, nrow(found_closed))
+  }
+  found_closed$commit_sha <- sha_col
 
   # Top-10 by attempts
   by_att <- found_closed[order(-found_closed$n_attempts, -found_closed$time_to_close_hrs), ]
@@ -600,6 +685,7 @@ compute_outliers <- function(df, bounds = NULL) {
     time_to_close_hrs = round(as.numeric(by_att$time_to_close_hrs), 2),
     close_reason      = as.character(by_att$close_reason),
     created_at        = format(by_att$created_at, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+    commit_sha        = as.character(by_att$commit_sha),
     stringsAsFactors  = FALSE
   )
 
@@ -613,6 +699,7 @@ compute_outliers <- function(df, bounds = NULL) {
     time_to_close_hrs = round(as.numeric(by_ttc$time_to_close_hrs), 2),
     close_reason      = as.character(by_ttc$close_reason),
     created_at        = format(by_ttc$created_at, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+    commit_sha        = as.character(by_ttc$commit_sha),
     stringsAsFactors  = FALSE
   )
 
@@ -746,6 +833,7 @@ outlier_end   <- anchor_date
 outlier_start <- anchor_date - as.difftime(OUTLIER_WINDOW_DAYS, units = "days")
 df_outliers_window <- load_window_by_closed_at(con, outlier_start, outlier_end)
 df_outliers_window <- enrich_with_attempts(con, df_outliers_window, has_lineage_table)
+df_outliers_window <- enrich_with_commit_sha(df_outliers_window)
 outliers_recent <- compute_outliers(
   df_outliers_window,
   bounds = list(start = outlier_start, end = outlier_end)

--- a/.claude/scripts/send_roborev_email.R
+++ b/.claude/scripts/send_roborev_email.R
@@ -193,6 +193,35 @@ repo_link_or_text <- function(slug, colour) {
   sprintf('<a href="%s" style="color:%s;">%s</a>', url, colour, slug)
 }
 
+# id_link_for_outlier(): renders an outlier-table finding ID as a link to the
+# GitHub commit (or compare view, for range reviews) roborev actually
+# reviewed, using review_jobs.git_ref (persisted in the JSON snapshot as
+# commit_sha — see roborev_daily_report.R's load_commit_sha()). Falls back to
+# a plain-text ID when the repo slug doesn't resolve to a known public GitHub
+# URL, or when commit_sha is missing/NA/blank — llm#835 established that
+# fabricating a link (there: <repo>/issues/<review_id>, a 404) is worse than
+# no link, since review_id is a roborev DB primary key, not a GitHub issue
+# number.
+id_link_for_outlier <- function(rid, commit_sha, repo, colour) {
+  if (is.null(rid) || !nzchar(as.character(rid))) return("")
+  if (is.null(commit_sha) || is.na(commit_sha) || !nzchar(commit_sha)) {
+    return(as.character(rid))
+  }
+  repo_url <- resolve_repo_url(repo)
+  if (is.null(repo_url)) return(as.character(rid))
+
+  target_url <- if (grepl("\\.\\.", commit_sha)) {
+    shas <- strsplit(commit_sha, "\\.\\.")[[1]]
+    if (length(shas) != 2L || !nzchar(shas[1]) || !nzchar(shas[2])) {
+      return(as.character(rid))
+    }
+    sprintf("%s/compare/%s...%s", repo_url, shas[1], shas[2])
+  } else {
+    sprintf("%s/commit/%s", repo_url, commit_sha)
+  }
+  sprintf('<a href="%s" style="color:%s;">%s</a>', target_url, colour, rid)
+}
+
 # ── Extract window slices ──────────────────────────────────────────────────────
 
 d1 <- snap[["global_windows"]][["d1"]]  # 1-day window — llm#449
@@ -572,6 +601,8 @@ if (n_outliers > 0L) {
     bg <- if (i %% 2 == 0) dark_row_alt else dark_card
     rid  <- r[["review_id"]] %||% ""
     repo <- r[["repo"]] %||% ""
+    commit_sha <- r[["commit_sha"]] %||% NA_character_
+    id_link <- id_link_for_outlier(rid, commit_sha, repo, accent_blue)
     repo_link <- repo_link_or_text(repo, accent_blue)
     outlier_ttc_inner <- paste0(outlier_ttc_inner, sprintf(
       '<tr style="background-color:%s;">
@@ -582,7 +613,7 @@ if (n_outliers > 0L) {
         <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
       </tr>',
       bg,
-      dark_border, accent_blue, rid,
+      dark_border, accent_blue, id_link,
       dark_border, dark_text, repo_link,
       dark_border, accent_orange, fmt_num(r[["time_to_close_hrs"]]),
       dark_border, dark_text, fmt_int(r[["n_attempts"]]),
@@ -635,6 +666,8 @@ if (outliers_by_attempts_degenerate) {
       bg <- if (i %% 2 == 0) dark_row_alt else dark_card
       rid  <- r[["review_id"]] %||% ""
       repo <- r[["repo"]] %||% ""
+      commit_sha <- r[["commit_sha"]] %||% NA_character_
+      id_link <- id_link_for_outlier(rid, commit_sha, repo, accent_blue)
       repo_link <- repo_link_or_text(repo, accent_blue)
       outlier_att_inner <- paste0(outlier_att_inner, sprintf(
         '<tr style="background-color:%s;">
@@ -645,7 +678,7 @@ if (outliers_by_attempts_degenerate) {
           <td style="padding:4px 5px; border:1px solid %s; color:%s;">%s</td>
         </tr>',
         bg,
-        dark_border, accent_blue, rid,
+        dark_border, accent_blue, id_link,
         dark_border, dark_text, repo_link,
         dark_border, accent_orange, fmt_int(r[["n_attempts"]]),
         dark_border, dark_text, fmt_num(r[["time_to_close_hrs"]]),


### PR DESCRIPTION
## Summary

- The Daily Report email's outlier tables ("top-10 by time-to-close" / "top-10
  by attempts-to-close") rendered each finding ID as plain text. This makes it
  a clickable link to the GitHub commit (or compare view) roborev reviewed.
- `roborev_daily_report.R` gains `load_commit_sha()` / `enrich_with_commit_sha()`,
  joining `reviews.job_id -> review_jobs.git_ref` (via the existing sqlite-attach
  pattern already used for the attempts heuristic). `commit_sha` is now carried
  into the JSON snapshot's `outliers_recent_7d.by_time` / `by_attempts` tables.
- `send_roborev_email.R` gains `id_link_for_outlier()`, used in both outlier
  loops in place of the bare `rid`.

## URL rules

- Owner is always `JohnGavin`; `repo` is the slug already resolved by the
  existing `resolve_repo_url()` (only known-public / locally-verified GitHub
  repos get a link — same guard that already protects the Repo column).
- Single SHA: `https://github.com/JohnGavin/<repo>/commit/<sha>`
- Range `A..B` (roborev range/catch-up reviews, `git_ref` stored as two dots):
  `https://github.com/JohnGavin/<repo>/compare/<A>...<B>` (three dots in the
  compare path — GitHub's convention, not a typo).
- `commit_sha` NA/blank, or repo doesn't resolve to a public URL: plain-text ID
  (no broken link) — this is the lesson from
  [#835](https://github.com/JohnGavin/llm/pull/835), which had linked
  `review_id` to `<repo>/issues/<review_id>` and 404'd, since `review_id` is a
  roborev DB primary key, not a GitHub issue number.

## Before / after (one row, id 7935, repo `llm`)

Before:
```html
<td ...>7935</td>
```

After:
```html
<td ...><a href="https://github.com/JohnGavin/llm/commit/d4da02eeadc67383c73722b51e90f0f93fa7db3b" style="color:#4fc3f7;">7935</a></td>
```

A `historical`/`premortem` row (repo not in `KNOWN_PUBLIC_REPOS`, no local
git remote) still degrades to plain text, e.g. `7633`, `7920`.

## Verify

- `Rscript -e 'parse(...)'` succeeds for both changed files.
- Full run of `roborev_daily_report.R` (no `--dry-run`, pointed at a scratch
  `ROBOREV_DAILY_DIR`) against live `unified.duckdb` + `~/.roborev/reviews.db`
  produced a JSON snapshot whose `outliers_recent_7d.by_time` rows carry a
  populated `commit_sha` (verified all 10 rows resolve to real 40-char SHAs).
- `send_roborev_email.R` with `EMAIL_DRY_RUN=1` against that snapshot rendered
  the linked cell shown above.
- Isolated unit check of `id_link_for_outlier()`'s range branch: a `A..B`
  git_ref produces `.../compare/A...B`; an `NA_character_` commit_sha
  degrades to the plain ID.

## Test plan

- [x] Parse-check both changed files
- [x] Full dry-run of `roborev_daily_report.R` against live data (scratch
      output dir) — `commit_sha` populated
- [x] `EMAIL_DRY_RUN=1` render against the regenerated snapshot — linked `<a>`
      cell confirmed
- [x] Range-SHA and NA-SHA branches unit-checked in isolation
