### PR TITLE
feat(kb-digest): exclude '# KEEP:'-marked raw files from promotion-staleness signal (llm#298)

### DIFF
--- a/.claude/scripts/send_kb_digest_email.R
+++ b/.claude/scripts/send_kb_digest_email.R
@@ -404,7 +404,9 @@ signal_479_qa <- sprintf(
 # ── Signal #480: raw/ files awaiting wiki promotion (>14d) ────────────────────
 #
 # Files under knowledge/raw/ where mtime > 14 days AND no wiki/ file references
-# the filename. Table: file | days_old | size.
+# the filename AND the file is not marked `# KEEP:` in its first 5 lines
+# (permanent append-only source the user keeps indefinitely — see
+# compute_stale_raw() below). Table: file | days_old | size.
 # QA marker: <!-- QA:kb_signal_480=N -->
 
 compute_stale_raw <- function(knowledge_repo) {
@@ -447,6 +449,17 @@ compute_stale_raw <- function(knowledge_repo) {
       is_referenced <- grepl(fname, wiki_text, fixed = TRUE)
       if (is_referenced) next
 
+      # `# KEEP:` opt-out marker: a raw file whose first 5 lines contain a
+      # line matching `^#\s*KEEP:` (case-insensitive) is permanent append-only
+      # source material the user intends to keep indefinitely — never flag it
+      # as awaiting promotion, even if unreferenced and past the 14d window.
+      # An unreadable/binary file falls through to normal staleness logic
+      # rather than erroring the whole digest.
+      head_lines <- tryCatch(readLines(f, n = 5L, warn = FALSE),
+                              error = function(e) character(0L))
+      is_keep <- any(grepl("^#\\s*KEEP:", head_lines, ignore.case = TRUE))
+      if (is_keep) next
+
       # Format size
       size_bytes <- info$size
       size_str <- if (size_bytes > 1024 * 1024) {
@@ -478,7 +491,7 @@ signal_480_html <- if (signal_480$count == 0L) {
     title         = "raw/ files awaiting wiki promotion (>14d)",
     summary_stats = "0 found — all raw files promoted or referenced",
     html_body     = sprintf(
-      '<p style="color:%s; font-style:italic;">No raw files older than 14 days are awaiting wiki promotion.</p>',
+      '<p style="color:%s; font-style:italic;">No raw files older than 14 days are awaiting wiki promotion. Files with a "# KEEP:" header line are treated as permanent source and excluded.</p>',
       DARK_MUTED
     )
   )

--- a/tests/testthat/test-kb-digest.R
+++ b/tests/testthat/test-kb-digest.R
@@ -618,6 +618,106 @@ test_that("compute_stale_raw() returns list(count, rows) excluding recent files 
               info = paste("compute_stale_raw() failed:", combined))
 })
 
+test_that("compute_stale_raw() excludes files marked with a '# KEEP:' header (#298)", {
+  email_script <- file.path(REPO_ROOT, ".claude", "scripts", "send_kb_digest_email.R")
+  skip_if_not(file.exists(email_script), "send_kb_digest_email.R not found")
+
+  tmp_digest <- tempfile(fileext = ".md")
+  writeLines("## Test\nDummy digest.", tmp_digest)
+  on.exit(unlink(tmp_digest))
+
+  # Synthetic knowledge repo with:
+  #   kept.txt    — old, unreferenced, marked "# KEEP:" — must NOT be flagged
+  #   unkept.txt  — old, unreferenced, no marker        — must be flagged
+  synth_kb <- tempfile("kb_test_")
+  dir.create(file.path(synth_kb, "raw"), recursive = TRUE)
+  dir.create(file.path(synth_kb, "wiki"), recursive = TRUE)
+
+  kept_file <- file.path(synth_kb, "raw", "kept.txt")
+  writeLines(c("# KEEP: source archive", "permanent source content"), kept_file)
+
+  unkept_file <- file.path(synth_kb, "raw", "unkept.txt")
+  writeLines(c("no marker here", "stale unreferenced content"), unkept_file)
+
+  old_mtime <- Sys.time() - 20 * 86400
+  Sys.setFileTime(kept_file, old_mtime)
+  Sys.setFileTime(unkept_file, old_mtime)
+
+  on.exit(unlink(synth_kb, recursive = TRUE), add = TRUE)
+
+  rcode <- paste0(
+    "source('", email_script, "', local=TRUE)\n",
+    "knowledge_repo <- '", synth_kb, "'\n",
+    "res <- compute_stale_raw(knowledge_repo)\n",
+    "stopifnot(is.list(res))\n",
+    "found_kept <- any(sapply(res$rows, function(r) grepl('kept.txt', r$file)))\n",
+    "found_unkept <- any(sapply(res$rows, function(r) grepl('unkept.txt', r$file)))\n",
+    "stopifnot(!found_kept)\n",
+    "stopifnot(found_unkept)\n",
+    "cat('OK\\n')\n"
+  )
+  tmp_r <- tempfile(fileext = ".R")
+  writeLines(rcode, tmp_r)
+  on.exit(unlink(tmp_r), add = TRUE)
+
+  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1")
+  out <- system2("Rscript", args = tmp_r, stdout = TRUE, stderr = TRUE,
+                  env = c(Sys.getenv(), env_vars))
+
+  combined <- paste(out, collapse = "\n")
+  expect_true(grepl("OK", combined),
+              info = paste("compute_stale_raw() KEEP-marker exclusion failed:", combined))
+})
+
+test_that("compute_stale_raw() '# KEEP:' marker is case-insensitive and tolerates spacing (#298)", {
+  email_script <- file.path(REPO_ROOT, ".claude", "scripts", "send_kb_digest_email.R")
+  skip_if_not(file.exists(email_script), "send_kb_digest_email.R not found")
+
+  tmp_digest <- tempfile(fileext = ".md")
+  writeLines("## Test\nDummy digest.", tmp_digest)
+  on.exit(unlink(tmp_digest))
+
+  synth_kb <- tempfile("kb_test_")
+  dir.create(file.path(synth_kb, "raw"), recursive = TRUE)
+  dir.create(file.path(synth_kb, "wiki"), recursive = TRUE)
+
+  # Variant spacing/casing: no space after '#', lowercase 'keep', extra spaces.
+  nospace_file <- file.path(synth_kb, "raw", "nospace.txt")
+  writeLines(c("#KEEP: tight header", "content"), nospace_file)
+
+  lower_file <- file.path(synth_kb, "raw", "lower.txt")
+  writeLines(c("#   keep: loose lowercase header", "content"), lower_file)
+
+  old_mtime <- Sys.time() - 20 * 86400
+  Sys.setFileTime(nospace_file, old_mtime)
+  Sys.setFileTime(lower_file, old_mtime)
+
+  on.exit(unlink(synth_kb, recursive = TRUE), add = TRUE)
+
+  rcode <- paste0(
+    "source('", email_script, "', local=TRUE)\n",
+    "knowledge_repo <- '", synth_kb, "'\n",
+    "res <- compute_stale_raw(knowledge_repo)\n",
+    "stopifnot(is.list(res))\n",
+    "found_nospace <- any(sapply(res$rows, function(r) grepl('nospace.txt', r$file)))\n",
+    "found_lower <- any(sapply(res$rows, function(r) grepl('lower.txt', r$file)))\n",
+    "stopifnot(!found_nospace)\n",
+    "stopifnot(!found_lower)\n",
+    "cat('OK\\n')\n"
+  )
+  tmp_r <- tempfile(fileext = ".R")
+  writeLines(rcode, tmp_r)
+  on.exit(unlink(tmp_r), add = TRUE)
+
+  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1")
+  out <- system2("Rscript", args = tmp_r, stdout = TRUE, stderr = TRUE,
+                  env = c(Sys.getenv(), env_vars))
+
+  combined <- paste(out, collapse = "\n")
+  expect_true(grepl("OK", combined),
+              info = paste("compute_stale_raw() KEEP-marker case/spacing tolerance failed:", combined))
+})
+
 test_that("compute_broken_backlinks() detects missing [[topic]] targets (#481)", {
   email_script <- file.path(REPO_ROOT, ".claude", "scripts", "send_kb_digest_email.R")
   skip_if_not(file.exists(email_script), "send_kb_digest_email.R not found")


### PR DESCRIPTION
## Summary
- Adds a `# KEEP:` opt-out marker for the KB digest's Signal #480 ("raw/ files awaiting wiki promotion (>14d)"). Append-only source files the user intends to keep indefinitely no longer get nagged about forever with no way to opt out.
- `compute_stale_raw()` in `.claude/scripts/send_kb_digest_email.R` now skips a raw/ file when any of its **first 5 lines** matches `^#\s*KEEP:` case-insensitively (e.g. `# KEEP: source archive`), in addition to the existing "referenced by a wiki page" exclusion. An unreadable/binary file falls through to normal staleness logic (tryCatch around the `readLines(n=5)` call) rather than erroring the whole digest.
- Wiki-referenced files are still auto-cleared exactly as before — this adds a third, independent exclusion; existing behavior is unchanged for files without the marker.
- Updated the signal's empty-state copy and the surrounding code comment to document the convention so the email is self-documenting.

## Test plan
- [x] `parse()` succeeds on the modified `send_kb_digest_email.R`
- [x] New tests in `tests/testthat/test-kb-digest.R`:
  - `compute_stale_raw() excludes files marked with a '# KEEP:' header (#298)` — a KEEP-marked, old, unreferenced file is NOT flagged; an identical unmarked file IS flagged (guards against over-filtering)
  - `compute_stale_raw() '# KEEP:' marker is case-insensitive and tolerates spacing (#298)` — `#KEEP:` (no space) and `#   keep:` (lowercase, extra spacing) both match
- [x] Full `testthat::test_file()` run on `test-kb-digest.R`: both new tests pass (`fail=0 error=0 pass=1` each). Two pre-existing, unrelated tests ("send_kb_digest_email.R dry-run produces HTML with QA markers" and "dry-run email HTML includes all four KB-digest signal QA markers") fail in this sandboxed agent environment due to a pre-existing `system2(..., env = c(Sys.getenv(), env_vars))` environment-vector bug unrelated to this change (confirmed via `git diff` that neither test was touched by this PR).

Tracked in llm#298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
