### PR TITLE
fix(kb-digest): repair 3-layer test rot behind the system2 env bug (fixes #848)

### DIFF
--- a/.claude/scripts/send_kb_digest_email.R
+++ b/.claude/scripts/send_kb_digest_email.R
@@ -30,7 +30,13 @@ suppressPackageStartupMessages({
 
 # ── Shared email styles (font sizes, palette, collapsible_block helper) ───────
 
-.scripts_dir_kb <- tryCatch(
+.scripts_dir_kb <- if (nzchar(Sys.getenv("KB_SCRIPTS_DIR"))) {
+  # Test/wrapper override: when this script is sourced from a temp runner in a
+  # tmpdir, commandArgs(--file=) resolves to the tmpdir, not the real scripts
+  # dir, so email_styles.R can't be found. KB_SCRIPTS_DIR lets the caller
+  # declare where the sibling scripts (email_styles.R, kb_digest.R) live.
+  Sys.getenv("KB_SCRIPTS_DIR")
+} else tryCatch(
   dirname(normalizePath(sys.frame(0L)$ofile, mustWork = FALSE)),
   error = function(e) {
     args <- commandArgs(trailingOnly = FALSE)
@@ -46,6 +52,12 @@ source(file.path(.scripts_dir_kb, "email_styles.R"))
 # ── Configuration ──────────────────────────────────────────────────────────────
 
 dry_run <- identical(Sys.getenv("EMAIL_DRY_RUN"), "1")
+
+# Define-only mode: when KB_DIGEST_DEFINE_ONLY is set, source() this file to get
+# its compute_*/helper functions and skip the side-effecting tail (dry-run print,
+# SMTP send, quit()). Used by test-kb-digest.R to unit-test the functions without
+# the CLI running to completion and terminating the child process.
+.kb_define_only <- nzchar(Sys.getenv("KB_DIGEST_DEFINE_ONLY"))
 
 knowledge_repo <- Sys.getenv(
   "KB_KNOWLEDGE_REPO",
@@ -842,6 +854,9 @@ email_body <- sprintf(
   qa_markers
 )
 
+# ── Side-effecting tail (skipped in define-only mode) ─────────────────────────
+if (!.kb_define_only) {
+
 # ── Dry-run mode ───────────────────────────────────────────────────────────────
 
 if (dry_run) {
@@ -902,3 +917,5 @@ tryCatch({
   cat(email_body, "\n")
   quit(status = 1L)
 })
+
+}  # end !.kb_define_only

--- a/tests/testthat/test-kb-digest.R
+++ b/tests/testthat/test-kb-digest.R
@@ -421,7 +421,7 @@ test_that("send_kb_digest_email.R dry-run produces HTML with QA markers", {
 
   out <- system2("Rscript", args = email_script,
                   stdout = TRUE, stderr = TRUE,
-                  env = c(Sys.getenv(), env_vars))
+                  env = env_vars)
   combined <- paste(out, collapse = "\n")
 
   expect_true(grepl("QA:kb_digest_date=", combined),
@@ -467,7 +467,7 @@ test_that("CRITICAL: email body dry-run does NOT leak raw wiki content", {
 
   out <- system2("Rscript", args = email_script,
                   stdout = TRUE, stderr = TRUE,
-                  env = c(Sys.getenv(), env_vars))
+                  env = env_vars)
   combined <- paste(out, collapse = "\n")
 
   pins <- get_fixture_body_pins(repo)
@@ -552,9 +552,11 @@ test_that("compute_fix_no_kb() returns list(count, rows) with correct structure 
   writeLines(rcode, tmp_r)
   on.exit(unlink(tmp_r), add = TRUE)
 
-  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1")
+  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1",
+                paste0("KB_SCRIPTS_DIR=", file.path(REPO_ROOT, ".claude", "scripts")),
+                "KB_DIGEST_DEFINE_ONLY=1")
   out <- system2("Rscript", args = tmp_r, stdout = TRUE, stderr = TRUE,
-                  env = c(Sys.getenv(), env_vars))
+                  env = env_vars)
   exit_code <- attr(out, "status") %||% 0L
 
   # exit 77 = llm repo not found on this machine — acceptable skip
@@ -609,9 +611,11 @@ test_that("compute_stale_raw() returns list(count, rows) excluding recent files 
   writeLines(rcode, tmp_r)
   on.exit(unlink(tmp_r), add = TRUE)
 
-  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1")
+  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1",
+                paste0("KB_SCRIPTS_DIR=", file.path(REPO_ROOT, ".claude", "scripts")),
+                "KB_DIGEST_DEFINE_ONLY=1")
   out <- system2("Rscript", args = tmp_r, stdout = TRUE, stderr = TRUE,
-                  env = c(Sys.getenv(), env_vars))
+                  env = env_vars)
 
   combined <- paste(out, collapse = "\n")
   expect_true(grepl("OK", combined),
@@ -650,8 +654,8 @@ test_that("compute_stale_raw() excludes files marked with a '# KEEP:' header (#2
     "knowledge_repo <- '", synth_kb, "'\n",
     "res <- compute_stale_raw(knowledge_repo)\n",
     "stopifnot(is.list(res))\n",
-    "found_kept <- any(sapply(res$rows, function(r) grepl('kept.txt', r$file)))\n",
-    "found_unkept <- any(sapply(res$rows, function(r) grepl('unkept.txt', r$file)))\n",
+    "found_kept <- any(sapply(res$rows, function(r) basename(r$file) == 'kept.txt'))\n",
+    "found_unkept <- any(sapply(res$rows, function(r) basename(r$file) == 'unkept.txt'))\n",
     "stopifnot(!found_kept)\n",
     "stopifnot(found_unkept)\n",
     "cat('OK\\n')\n"
@@ -660,9 +664,11 @@ test_that("compute_stale_raw() excludes files marked with a '# KEEP:' header (#2
   writeLines(rcode, tmp_r)
   on.exit(unlink(tmp_r), add = TRUE)
 
-  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1")
+  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1",
+                paste0("KB_SCRIPTS_DIR=", file.path(REPO_ROOT, ".claude", "scripts")),
+                "KB_DIGEST_DEFINE_ONLY=1")
   out <- system2("Rscript", args = tmp_r, stdout = TRUE, stderr = TRUE,
-                  env = c(Sys.getenv(), env_vars))
+                  env = env_vars)
 
   combined <- paste(out, collapse = "\n")
   expect_true(grepl("OK", combined),
@@ -709,9 +715,11 @@ test_that("compute_stale_raw() '# KEEP:' marker is case-insensitive and tolerate
   writeLines(rcode, tmp_r)
   on.exit(unlink(tmp_r), add = TRUE)
 
-  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1")
+  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1",
+                paste0("KB_SCRIPTS_DIR=", file.path(REPO_ROOT, ".claude", "scripts")),
+                "KB_DIGEST_DEFINE_ONLY=1")
   out <- system2("Rscript", args = tmp_r, stdout = TRUE, stderr = TRUE,
-                  env = c(Sys.getenv(), env_vars))
+                  env = env_vars)
 
   combined <- paste(out, collapse = "\n")
   expect_true(grepl("OK", combined),
@@ -761,9 +769,11 @@ test_that("compute_broken_backlinks() detects missing [[topic]] targets (#481)",
   writeLines(rcode, tmp_r)
   on.exit(unlink(tmp_r), add = TRUE)
 
-  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1")
+  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1",
+                paste0("KB_SCRIPTS_DIR=", file.path(REPO_ROOT, ".claude", "scripts")),
+                "KB_DIGEST_DEFINE_ONLY=1")
   out <- system2("Rscript", args = tmp_r, stdout = TRUE, stderr = TRUE,
-                  env = c(Sys.getenv(), env_vars))
+                  env = env_vars)
 
   combined <- paste(out, collapse = "\n")
   expect_true(grepl("OK", combined),
@@ -804,9 +814,11 @@ test_that("compute_new_no_wiki() returns list(count, rows) with correct structur
   writeLines(rcode, tmp_r)
   on.exit(unlink(tmp_r), add = TRUE)
 
-  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1")
+  env_vars <- c(paste0("KB_DIGEST_FILE=", tmp_digest), "EMAIL_DRY_RUN=1",
+                paste0("KB_SCRIPTS_DIR=", file.path(REPO_ROOT, ".claude", "scripts")),
+                "KB_DIGEST_DEFINE_ONLY=1")
   out <- system2("Rscript", args = tmp_r, stdout = TRUE, stderr = TRUE,
-                  env = c(Sys.getenv(), env_vars))
+                  env = env_vars)
 
   combined <- paste(out, collapse = "\n")
   expect_true(grepl("OK", combined),
@@ -833,7 +845,7 @@ test_that("dry-run email HTML includes all four KB-digest signal QA markers (#47
 
   out <- system2("Rscript", args = email_script,
                   stdout = TRUE, stderr = TRUE,
-                  env = c(Sys.getenv(), env_vars))
+                  env = env_vars)
   combined <- paste(out, collapse = "\n")
 
   # Each signal must embed its QA marker in the HTML output


### PR DESCRIPTION
Fixes #848. What began as "the `system2` env bug" turned out to be three stacked, pre-existing bugs — the env bug was masking the other two. All three fixed; suite now **FAIL 0 / WARN 0 / PASS 34**.

| Layer | Bug | Fix |
|---|---|---|
| 1 (reported) | Test dry-run passed `env = c(Sys.getenv(), env_vars)` — `Sys.getenv()` returns bare VALUEs, which `system2(env=)` needs as `NAME=VALUE`, mangling the child argv → no QA markers | Pass only `env_vars` (system2 already inherits the parent env) |
| 2 (unmasked) | Temp-runner tests source the script from a tmpdir, so `.scripts_dir_kb` resolved via `commandArgs(--file=)` to the tmpdir → `email_styles.R` not found | Added a `KB_SCRIPTS_DIR` override (checked first) + set it in the temp tests. Production unaffected (unset → existing logic) |
| 3 (unmasked) | The `compute_*` tests `source()` the whole CLI, which `quit()`s in dry-run before the tests' own assertions run | Added `KB_DIGEST_DEFINE_ONLY` — skips the side-effecting tail (dry-run/SMTP/quit) so `source()` defines the functions and returns. Set it in those tests |
| + | Test assertion `grepl('kept.txt', file)` also matched `'unkept.txt'` (substring) → false failure | Anchored to `basename(r$file) == 'kept.txt'` |

**No production behaviour change** — both new env flags default off; the dry-run/send path is unchanged when they're unset.

Verified: `testthat::test_file("tests/testthat/test-kb-digest.R")` → `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 34 ]`.

Note: this was salvaged and completed by the orchestrator after the account spend limit blocked subagents mid-task; it continues the original dispatch.
