### PR TITLE
fix(roborev): versioned model_pricing table with effective-dates (llm#795)

### DIFF
--- a/.claude/scripts/roborev_metrics_etl.R
+++ b/.claude/scripts/roborev_metrics_etl.R
@@ -711,76 +711,188 @@ build_review_lifecycle <- function(jobs, reviews, markers) {
   )
 }
 
-# ── Pricing constants for cost_usd computation ────────────────────────────
+# ==== PRICING_BLOCK_START (llm#795) ═══════════════════════════════════════
+# tests/test_model_pricing.R sources this exact block in isolation (by
+# extracting the text between the START/END markers into a temp .R file),
+# so it can exercise the real production pricing logic against a controlled
+# fixture DB without running the rest of the ETL. Do NOT add code in this
+# block that depends on later top-level state (jobs_raw, duck_con, args,
+# etc.) — it must remain self-contained aside from UNIFIED_DB, DBI, and
+# duckdb, all of which the test also provides.
 #
-# Source: Anthropic API pricing as of 2026-05-31, plus codex/gemini estimates.
-# Units: USD per 1M tokens.
-# Update this table when pricing changes.  A follow-up issue will move this
-# to a versioned pricing table in unified.duckdb (#380).
+# ── Model pricing: versioned, date-effective, DB-backed ──────────────────
 #
-# Matching is prefix-based: longest-matching prefix wins.
-# Default (unknown model): sonnet-tier pricing.
+# Prices used to live in a hand-typed PRICING_TABLE literal here, with a
+# comment promising a migration to a versioned pricing table "under #380".
+# #380 was closed and unrelated — that promise never happened (a marker
+# with no expiry became a lie). Prices now live in the `model_pricing`
+# table in unified.duckdb (see roborev_metrics_schema.sql), which carries
+# an effective_from date and a source_url per row, so historical
+# agent_runs price at the rate that was actually in effect and every rate
+# is provenance-linked to the provider's pricing page. See llm#795.
+#
+# PRICING_SEED below is the CURRENT rate list. It is the single point of
+# truth for what gets upserted into model_pricing (via seed_model_pricing(),
+# called on every --apply run — the ETL's "schema init" skips ALL DDL/INSERT
+# once every expected table already exists, so a plain schema-file INSERT
+# alone would only ever fire once, at first table creation) and is also the
+# in-memory fallback used when unified.duckdb has no model_pricing rows yet
+# (e.g. a fresh DB in --dry-run mode before the first --apply has run).
+#
+# Units: USD per 1M tokens. Matching: longest-matching model_prefix wins;
+# among ties, the greatest effective_from <= the record's date wins.
+# model_prefix "__default__" is the fallback for unmatched/unknown models
+# (sonnet-tier pricing) — unchanged behaviour from before #795.
 
-PRICING_TABLE <- list(
-  # Anthropic Claude 4 Opus
-  list(prefix = "claude-opus-4",     input = 15.00, output = 75.00),
-  # Anthropic Claude 4 Sonnet
-  list(prefix = "claude-sonnet-4",   input =  3.00, output = 15.00),
-  # Anthropic Claude 4 Haiku
-  list(prefix = "claude-haiku-4",    input =  0.80, output =  4.00),
+PRICING_SEED_FLOOR_DATE <- "2024-01-01"  # conservative: prices ALL history at today's rates
+
+PRICING_SEED <- list(
+  # Anthropic Claude 4 series
+  list(prefix = "claude-opus-4",     input = 15.00,  output = 75.00,  src = "https://www.anthropic.com/pricing"),
+  list(prefix = "claude-sonnet-4",   input =  3.00,  output = 15.00,  src = "https://www.anthropic.com/pricing"),
+  list(prefix = "claude-haiku-4",    input =  0.80,  output =  4.00,  src = "https://www.anthropic.com/pricing"),
   # Anthropic Claude 3.7 series
-  list(prefix = "claude-opus-3-7",   input = 15.00, output = 75.00),
-  list(prefix = "claude-sonnet-3-7", input =  3.00, output = 15.00),
-  list(prefix = "claude-haiku-3-7",  input =  0.80, output =  4.00),
+  list(prefix = "claude-opus-3-7",   input = 15.00,  output = 75.00,  src = "https://www.anthropic.com/pricing"),
+  list(prefix = "claude-sonnet-3-7", input =  3.00,  output = 15.00,  src = "https://www.anthropic.com/pricing"),
+  list(prefix = "claude-haiku-3-7",  input =  0.80,  output =  4.00,  src = "https://www.anthropic.com/pricing"),
   # Anthropic Claude 3.5 series
-  list(prefix = "claude-opus-3-5",   input = 15.00, output = 75.00),
-  list(prefix = "claude-sonnet-3-5", input =  3.00, output = 15.00),
-  list(prefix = "claude-haiku-3-5",  input =  0.80, output =  4.00),
+  list(prefix = "claude-opus-3-5",   input = 15.00,  output = 75.00,  src = "https://www.anthropic.com/pricing"),
+  list(prefix = "claude-sonnet-3-5", input =  3.00,  output = 15.00,  src = "https://www.anthropic.com/pricing"),
+  list(prefix = "claude-haiku-3-5",  input =  0.80,  output =  4.00,  src = "https://www.anthropic.com/pricing"),
   # OpenAI / Codex
-  list(prefix = "gpt-5",             input =  0.15, output =  0.60),
-  list(prefix = "gpt-4",             input =  2.50, output = 10.00),
-  list(prefix = "gpt-3",             input =  0.50, output =  1.50),
-  list(prefix = "o1",                input = 15.00, output = 60.00),
-  list(prefix = "o3",                input = 10.00, output = 40.00),
+  list(prefix = "gpt-5",             input =  0.15,  output =  0.60,  src = "https://openai.com/api/pricing"),
+  list(prefix = "gpt-4",             input =  2.50,  output = 10.00,  src = "https://openai.com/api/pricing"),
+  list(prefix = "gpt-3",             input =  0.50,  output =  1.50,  src = "https://openai.com/api/pricing"),
+  list(prefix = "o1",                input = 15.00,  output = 60.00,  src = "https://openai.com/api/pricing"),
+  list(prefix = "o3",                input = 10.00,  output = 40.00,  src = "https://openai.com/api/pricing"),
   # Google Gemini
-  list(prefix = "gemini-2.5",        input =  0.075, output =  0.30),
-  list(prefix = "gemini-2",          input =  0.10,  output =  0.40),
-  list(prefix = "gemini-1",          input =  0.125, output =  0.375)
+  list(prefix = "gemini-2.5",        input =  0.075, output =  0.30,  src = "https://ai.google.dev/gemini-api/docs/pricing"),
+  list(prefix = "gemini-2",          input =  0.10,  output =  0.40,  src = "https://ai.google.dev/gemini-api/docs/pricing"),
+  list(prefix = "gemini-1",          input =  0.125, output =  0.375, src = "https://ai.google.dev/gemini-api/docs/pricing"),
+  # Default (unmatched/unknown model) — sonnet-tier, unchanged from before #795
+  list(prefix = "__default__",       input =  3.00,  output = 15.00,  src = "https://www.anthropic.com/pricing")
 )
 
-# Default pricing when no prefix matches (sonnet-tier)
+# Fallback-of-fallback only: used if the __default__ seed row is somehow
+# absent from both the DB and PRICING_SEED at lookup time.
 PRICING_DEFAULT_INPUT  <- 3.00
 PRICING_DEFAULT_OUTPUT <- 15.00
 
-# Return pricing (input, output) in USD per 1M tokens for a given model id.
-# Longest-prefix match wins.
-model_pricing <- function(model_id) {
-  if (is.na(model_id) || !nzchar(model_id) || model_id == "unknown") {
-    return(list(input = PRICING_DEFAULT_INPUT, output = PRICING_DEFAULT_OUTPUT))
-  }
-  # Sort by prefix length descending so longest prefix wins
-  sorted <- PRICING_TABLE[order(vapply(PRICING_TABLE,
-                                       function(x) nchar(x$prefix),
-                                       integer(1L)),
-                                decreasing = TRUE)]
-  for (entry in sorted) {
-    if (startsWith(tolower(model_id), tolower(entry$prefix))) {
-      return(list(input = entry$input, output = entry$output))
-    }
-  }
-  list(input = PRICING_DEFAULT_INPUT, output = PRICING_DEFAULT_OUTPUT)
+pricing_seed_df <- function() {
+  data.frame(
+    model_prefix        = vapply(PRICING_SEED, `[[`, character(1L), "prefix"),
+    input_usd_per_mtok  = vapply(PRICING_SEED, `[[`, double(1L),    "input"),
+    output_usd_per_mtok = vapply(PRICING_SEED, `[[`, double(1L),    "output"),
+    effective_from      = as.Date(PRICING_SEED_FLOOR_DATE),
+    source_url          = vapply(PRICING_SEED, `[[`, character(1L), "src"),
+    stringsAsFactors    = FALSE
+  )
 }
 
-# Compute cost in USD given token counts and model id.
+# Load the versioned pricing table ONCE at ETL start, via a short-lived
+# read-only connection that is fully shut down before returning (same
+# llm#595 pattern as the canonical-project guard above: a lingering
+# read-only instance would otherwise force every later dbConnect() to the
+# same path read-only too). Falls back to the embedded seed when the table
+# is absent or empty (e.g. a brand-new unified.duckdb).
+load_pricing_df <- function(db_path) {
+  seed_df <- pricing_seed_df()
+  if (!file.exists(db_path)) return(seed_df)
+  df <- tryCatch({
+    con <- DBI::dbConnect(duckdb::duckdb(), db_path, read_only = TRUE)
+    tryCatch(
+      DBI::dbGetQuery(con, "
+        SELECT model_prefix, input_usd_per_mtok, output_usd_per_mtok,
+               effective_from, source_url
+        FROM model_pricing"),
+      error = function(e) NULL,
+      finally = tryCatch(DBI::dbDisconnect(con, shutdown = TRUE), error = function(e) NULL)
+    )
+  }, error = function(e) NULL)
+  if (is.null(df) || nrow(df) == 0L) return(seed_df)
+  df$effective_from <- as.Date(df$effective_from)
+  df
+}
+
+PRICING_DF <- load_pricing_df(UNIFIED_DB)
+
+# Return pricing (input, output) in USD per 1M tokens for a given model id,
+# priced at the rate in effect on `at_date` (defaults to today when
+# NULL/NA — current behaviour for records with no usable timestamp).
+# Longest-matching model_prefix wins; ties broken by the greatest
+# effective_from <= at_date.
+model_pricing <- function(model_id, at_date = NULL, pricing_df = PRICING_DF) {
+  default_row <- pricing_df[pricing_df$model_prefix == "__default__", , drop = FALSE]
+  default_pricing <- if (nrow(default_row) > 0L) {
+    list(input = default_row$input_usd_per_mtok[[1L]],
+         output = default_row$output_usd_per_mtok[[1L]])
+  } else {
+    list(input = PRICING_DEFAULT_INPUT, output = PRICING_DEFAULT_OUTPUT)
+  }
+
+  if (is.null(model_id) || is.na(model_id) || !nzchar(model_id) || model_id == "unknown") {
+    return(default_pricing)
+  }
+
+  at_date <- if (is.null(at_date) || is.na(at_date)) Sys.Date() else as.Date(at_date)
+
+  candidates <- pricing_df[
+    pricing_df$model_prefix != "__default__" &
+      pricing_df$effective_from <= at_date &
+      startsWith(tolower(model_id), tolower(pricing_df$model_prefix)),
+    ,
+    drop = FALSE
+  ]
+  if (nrow(candidates) == 0L) return(default_pricing)
+
+  # Longest-matching prefix wins; among ties, the most recent effective_from.
+  ord <- order(-nchar(candidates$model_prefix), -as.numeric(candidates$effective_from))
+  candidates <- candidates[ord, , drop = FALSE]
+  list(input = candidates$input_usd_per_mtok[[1L]], output = candidates$output_usd_per_mtok[[1L]])
+}
+
+# Compute cost in USD given token counts, model id, and the record's date
+# (selects the price in effect at that time — see model_pricing()).
 # Tokens are approximate (from byte-count heuristic when CLI doesn't expose them).
-compute_cost_usd <- function(prompt_tokens, completion_tokens, model_id) {
-  p <- model_pricing(model_id)
+compute_cost_usd <- function(prompt_tokens, completion_tokens, model_id, at_date = NULL) {
+  p <- model_pricing(model_id, at_date)
   cost_in  <- if (!is.na(prompt_tokens)     && prompt_tokens > 0L)
                 (prompt_tokens     / 1e6) * p$input  else 0.0
   cost_out <- if (!is.na(completion_tokens) && completion_tokens > 0L)
                 (completion_tokens / 1e6) * p$output else 0.0
   cost_in + cost_out
 }
+
+# Upsert PRICING_SEED into model_pricing, idempotently, on every --apply run.
+# Called after schema init (see the "Schema init" section below) rather than
+# relying solely on the schema file's seed INSERT, because schema init is
+# skipped entirely once every expected table already exists (llm#595 fix 1) —
+# so a schema-file-only seed would never re-run in steady state.
+seed_model_pricing <- function(con) {
+  seed_df <- pricing_seed_df()
+  ok <- tryCatch({
+    for (i in seq_len(nrow(seed_df))) {
+      dbExecute(con, "
+        INSERT INTO model_pricing
+          (model_prefix, input_usd_per_mtok, output_usd_per_mtok, effective_from, source_url)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT (model_prefix, effective_from) DO NOTHING",
+        params = list(seed_df$model_prefix[i], seed_df$input_usd_per_mtok[i],
+                      seed_df$output_usd_per_mtok[i],
+                      as.character(seed_df$effective_from[i]),
+                      seed_df$source_url[i]))
+    }
+    TRUE
+  }, error = function(e) {
+    log_msg("WARN: model_pricing seed failed: ", conditionMessage(e))
+    FALSE
+  })
+  if (isTRUE(ok)) {
+    cat(sprintf("roborev_metrics_etl.R: model_pricing seed — %d rows ensured\n", nrow(seed_df)))
+  }
+  invisible(ok)
+}
+# ==== PRICING_BLOCK_END (llm#795) ═════════════════════════════════════════
 
 # Bytes-to-tokens approximation: 4 bytes ≈ 1 token (English/code prose).
 # Used when the CLI does not expose token counts.  Conservative — actual token
@@ -874,15 +986,17 @@ read_codex_fallback_jsonl <- function(log_dir) {
       prompt_tok  <- bytes_to_tokens(prompt_bytes)
       complet_tok <- bytes_to_tokens(resp_bytes)
 
-      # Cost computation
-      cost <- compute_cost_usd(prompt_tok, complet_tok, model_id)
-
-      # Parse timestamp
+      # Parse timestamp (moved ahead of cost computation, llm#795: the
+      # record's date selects which model_pricing effective_from row applies)
       ts_val <- tryCatch({
         ts_norm <- sub("Z$", "+0000", ts_raw)
         ts_norm <- sub("([+-][0-9]{2}):([0-9]{2})$", "\\1\\2", ts_norm)
         as.POSIXct(ts_norm, tz = "UTC", format = "%Y-%m-%dT%H:%M:%S%z")
       }, error = function(e) as.POSIXct(NA_real_, origin = "1970-01-01"))
+
+      # Cost computation, priced at the rate in effect on the record's date
+      cost <- compute_cost_usd(prompt_tok, complet_tok, model_id,
+                                at_date = if (is.na(ts_val)) NA else as.Date(ts_val))
 
       rows[[length(rows) + 1L]] <- data.frame(
         invocation_id          = as.character(inv_id),
@@ -2199,6 +2313,10 @@ if (length(expected_tables) > 0L && all(expected_tables %in% existing_tables)) {
     quit(status = 1L)
   })
 }
+
+# Always (re-)seed model_pricing, regardless of whether schema init ran or
+# was skipped above — see seed_model_pricing()'s docstring (llm#795).
+seed_model_pricing(duck_con)
 
 # ── Upsert helper using DuckDB INSERT OR REPLACE ──────────────────────────
 

--- a/.claude/scripts/roborev_metrics_schema.sql
+++ b/.claude/scripts/roborev_metrics_schema.sql
@@ -5,12 +5,15 @@
 -- Do NOT modify column names or types without a coordinated bump across both repos.
 -- Tracked in llm#226.
 --
--- All 8 tables are created on every ETL invocation (idempotent).
+-- All 9 tables are created on every ETL invocation (idempotent).
 -- Slice 1 populates: roborev_daily_metrics, roborev_review_lifecycle.
 -- Slice 2 populates: roborev_agent_performance, roborev_threshold_changes,
 --   roborev_cadence_efficacy, codex_provider_invocations (#380).
 -- Slice 3 (#286) populates: roborev_finding_lineage;
 --   view roborev_finding_lineage_summary is rebuilt as CREATE OR REPLACE VIEW.
+-- model_pricing (llm#795) is seeded on every ETL --apply run via
+--   seed_model_pricing() in roborev_metrics_etl.R (not just at first
+--   table creation — see that function's docstring).
 
 -- ── roborev_daily_metrics ─────────────────────────────────────────────────
 -- Per-day × per-repo rollup.
@@ -134,7 +137,7 @@ CREATE TABLE IF NOT EXISTS roborev_finding_lineage (
 -- One row per codex_with_fallback.sh invocation (from ~/.claude/logs/codex_fallback/*.jsonl).
 -- Populated by roborev_metrics_etl.R via read_codex_fallback_jsonl().
 -- Token counts are approximated from byte sizes (4 bytes ≈ 1 token).
--- Cost is computed from embedded pricing constants in the ETL.
+-- Cost is computed via the versioned model_pricing table below (llm#795).
 -- PK: invocation_id
 CREATE TABLE IF NOT EXISTS codex_provider_invocations (
   invocation_id          VARCHAR   NOT NULL,
@@ -153,6 +156,60 @@ CREATE TABLE IF NOT EXISTS codex_provider_invocations (
   cost_usd               DOUBLE,
   PRIMARY KEY (invocation_id)
 );
+
+-- ── model_pricing ─────────────────────────────────────────────────────────
+-- Versioned, date-effective LLM pricing (llm#795). Replaces the previously
+-- hand-typed PRICING_TABLE literal that lived in roborev_metrics_etl.R —
+-- that literal carried a stale comment promising a migration "under #380"
+-- (closed, unrelated) that never happened.
+--
+-- Seeded here (first table creation only) AND by roborev_metrics_etl.R's
+-- seed_model_pricing() on every --apply run — the ETL's schema-init step
+-- skips ALL DDL/INSERT once every expected table already exists, so this
+-- seed INSERT below would otherwise only ever fire once.
+--
+-- Matching: longest-matching model_prefix wins; among ties, the greatest
+-- effective_from <= the record's date wins. model_prefix = '__default__'
+-- is the fallback for unmatched/unknown models (sonnet-tier pricing,
+-- unchanged behaviour from before #795).
+-- PK: (model_prefix, effective_from)
+CREATE TABLE IF NOT EXISTS model_pricing (
+  model_prefix         VARCHAR NOT NULL,
+  input_usd_per_mtok   DOUBLE  NOT NULL,
+  output_usd_per_mtok  DOUBLE  NOT NULL,
+  effective_from       DATE    NOT NULL,
+  source_url           VARCHAR,
+  PRIMARY KEY (model_prefix, effective_from)
+);
+
+-- Seed rows — behaviour-preserving migration: identical input/output pairs
+-- to the PRICING_TABLE literal this replaces. effective_from is a single
+-- conservative floor date (2024-01-01) for every row, so ALL historical
+-- agent_runs rows price at today's rates — identical to the prior embedded-
+-- constant behaviour. source_url points at the provider's official pricing
+-- page as of 2026-07-30.
+INSERT INTO model_pricing
+  (model_prefix, input_usd_per_mtok, output_usd_per_mtok, effective_from, source_url)
+VALUES
+  ('claude-opus-4',     15.00,  75.00,  DATE '2024-01-01', 'https://www.anthropic.com/pricing'),
+  ('claude-sonnet-4',    3.00,  15.00,  DATE '2024-01-01', 'https://www.anthropic.com/pricing'),
+  ('claude-haiku-4',     0.80,   4.00,  DATE '2024-01-01', 'https://www.anthropic.com/pricing'),
+  ('claude-opus-3-7',   15.00,  75.00,  DATE '2024-01-01', 'https://www.anthropic.com/pricing'),
+  ('claude-sonnet-3-7',  3.00,  15.00,  DATE '2024-01-01', 'https://www.anthropic.com/pricing'),
+  ('claude-haiku-3-7',   0.80,   4.00,  DATE '2024-01-01', 'https://www.anthropic.com/pricing'),
+  ('claude-opus-3-5',   15.00,  75.00,  DATE '2024-01-01', 'https://www.anthropic.com/pricing'),
+  ('claude-sonnet-3-5',  3.00,  15.00,  DATE '2024-01-01', 'https://www.anthropic.com/pricing'),
+  ('claude-haiku-3-5',   0.80,   4.00,  DATE '2024-01-01', 'https://www.anthropic.com/pricing'),
+  ('gpt-5',              0.15,   0.60,  DATE '2024-01-01', 'https://openai.com/api/pricing'),
+  ('gpt-4',              2.50,  10.00,  DATE '2024-01-01', 'https://openai.com/api/pricing'),
+  ('gpt-3',              0.50,   1.50,  DATE '2024-01-01', 'https://openai.com/api/pricing'),
+  ('o1',                15.00,  60.00,  DATE '2024-01-01', 'https://openai.com/api/pricing'),
+  ('o3',                10.00,  40.00,  DATE '2024-01-01', 'https://openai.com/api/pricing'),
+  ('gemini-2.5',         0.075,  0.30,  DATE '2024-01-01', 'https://ai.google.dev/gemini-api/docs/pricing'),
+  ('gemini-2',           0.10,   0.40,  DATE '2024-01-01', 'https://ai.google.dev/gemini-api/docs/pricing'),
+  ('gemini-1',           0.125,  0.375, DATE '2024-01-01', 'https://ai.google.dev/gemini-api/docs/pricing'),
+  ('__default__',        3.00,  15.00,  DATE '2024-01-01', 'https://www.anthropic.com/pricing')
+ON CONFLICT (model_prefix, effective_from) DO NOTHING;
 
 -- ── roborev_finding_lineage_summary (view) ────────────────────────────────
 -- Per-finding summary: attempt count, time-to-close, verdict chain.

--- a/tests/test_model_pricing.R
+++ b/tests/test_model_pricing.R
@@ -1,0 +1,200 @@
+#!/usr/bin/env Rscript
+# tests/test_model_pricing.R
+#
+# testthat tests for the versioned, date-effective model_pricing lookup in
+# .claude/scripts/roborev_metrics_etl.R (llm#795).
+#
+# Strategy:
+#   1. Extracts the PRICING_BLOCK_START..PRICING_BLOCK_END text region out of
+#      roborev_metrics_etl.R into a temp .R file, so the test exercises the
+#      REAL production pricing logic (not a duplicated copy) without running
+#      the rest of the ETL (arg parsing, jobs_raw, duck_con, etc. are not
+#      needed by this block and are not available at test time).
+#   2. Builds a scratch DuckDB from the real roborev_metrics_schema.sql
+#      (creates model_pricing + seeds the real production rates) — NEVER
+#      touches ~/.claude/logs/unified.duckdb.
+#   3. Inserts two rows for a synthetic, never-real model_prefix
+#      ("test-widget-model") with different effective_from dates, so the
+#      date-window assertions do NOT rely on the real seed data changing.
+#   4. Sources the extracted block with UNIFIED_DB pointed at the scratch DB,
+#      then asserts: a record dated BEFORE the price change prices at the
+#      old rate, a record dated AFTER prices at the new rate, and an unknown
+#      model still routes to the sonnet-tier default.
+#
+# Run:
+#   nix-shell default.nix --run "Rscript tests/test_model_pricing.R"
+#
+# Tracked in llm#795.
+
+suppressPackageStartupMessages({
+  library(testthat)
+  library(DBI)
+  library(duckdb)
+})
+
+`%||%` <- function(a, b) if (!is.null(a) && length(a) > 0L) a else b
+
+# ── Locate the ETL script + schema file ───────────────────────────────────
+
+this_file <- tryCatch(
+  normalizePath(sys.frames()[[1L]]$ofile, mustWork = FALSE),
+  error = function(e) {
+    args <- commandArgs(trailingOnly = FALSE)
+    file_flag <- grep("^--file=", args, value = TRUE)
+    if (length(file_flag) > 0L) sub("^--file=", "", file_flag[1L]) else "."
+  }
+)
+script_dir <- normalizePath(dirname(this_file), mustWork = FALSE)
+
+etl_script    <- normalizePath(
+  file.path(script_dir, "..", ".claude", "scripts", "roborev_metrics_etl.R"),
+  mustWork = FALSE
+)
+schema_file   <- normalizePath(
+  file.path(script_dir, "..", ".claude", "scripts", "roborev_metrics_schema.sql"),
+  mustWork = FALSE
+)
+
+if (!file.exists(etl_script)) {
+  candidates <- file.path(Sys.getenv("HOME"), "docs_gh", "llm", ".claude",
+                          "scripts", "roborev_metrics_etl.R")
+  etl_script <- candidates[file.exists(candidates)][1L] %||% etl_script
+}
+if (!file.exists(schema_file)) {
+  candidates <- file.path(Sys.getenv("HOME"), "docs_gh", "llm", ".claude",
+                          "scripts", "roborev_metrics_schema.sql")
+  schema_file <- candidates[file.exists(candidates)][1L] %||% schema_file
+}
+
+test_that("ETL script and schema file exist", {
+  expect_true(file.exists(etl_script),
+              info = sprintf("Expected ETL script at: %s", etl_script))
+  expect_true(file.exists(schema_file),
+              info = sprintf("Expected schema file at: %s", schema_file))
+})
+
+if (!file.exists(etl_script) || !file.exists(schema_file)) {
+  message("Skipping execution tests — ETL script or schema file not found")
+  q(status = 0L)
+}
+
+# ── Extract the pricing block in isolation ────────────────────────────────
+
+etl_lines  <- readLines(etl_script, warn = FALSE)
+start_idx  <- grep("PRICING_BLOCK_START", etl_lines)
+end_idx    <- grep("PRICING_BLOCK_END", etl_lines)
+
+test_that("pricing block markers are present exactly once", {
+  expect_length(start_idx, 1L)
+  expect_length(end_idx, 1L)
+  expect_true(start_idx < end_idx)
+})
+
+if (length(start_idx) != 1L || length(end_idx) != 1L || !(start_idx < end_idx)) {
+  message("Skipping execution tests — pricing block markers malformed")
+  q(status = 0L)
+}
+
+pricing_code_lines <- etl_lines[(start_idx + 1L):(end_idx - 1L)]
+pricing_tmp_file   <- tempfile("roborev_pricing_block_", fileext = ".R")
+writeLines(pricing_code_lines, pricing_tmp_file)
+on.exit(unlink(pricing_tmp_file), add = TRUE)
+
+# ── Build a scratch DuckDB from the real schema (never unified.duckdb) ────
+
+scratch_db <- tempfile("pricing_test_", fileext = ".duckdb")
+on.exit(unlink(scratch_db), add = TRUE)
+
+apply_schema <- function(db_path, schema_path) {
+  schema_sql  <- readLines(schema_path, warn = FALSE)
+  schema_text <- paste(schema_sql, collapse = "\n")
+  schema_text <- gsub("--[^\n]*", "", schema_text)
+  stmts       <- strsplit(schema_text, ";")[[1L]]
+  stmts       <- trimws(stmts)
+  stmts       <- stmts[nzchar(stmts)]
+
+  con <- DBI::dbConnect(duckdb::duckdb(), db_path)
+  on.exit(tryCatch(DBI::dbDisconnect(con, shutdown = TRUE), error = function(e) NULL),
+          add = TRUE)
+  for (stmt in stmts) {
+    DBI::dbExecute(con, stmt)
+  }
+  invisible(NULL)
+}
+
+apply_schema(scratch_db, schema_file)
+
+# Insert two rows for a synthetic prefix that never collides with real
+# production model ids — the date-window assertions below depend ONLY on
+# these two rows, not on the real seed data.
+insert_test_prefix_rows <- function(db_path) {
+  con <- DBI::dbConnect(duckdb::duckdb(), db_path)
+  on.exit(tryCatch(DBI::dbDisconnect(con, shutdown = TRUE), error = function(e) NULL),
+          add = TRUE)
+  DBI::dbExecute(con, "
+    INSERT INTO model_pricing
+      (model_prefix, input_usd_per_mtok, output_usd_per_mtok, effective_from, source_url)
+    VALUES
+      ('test-widget-model', 1.00, 2.00,  DATE '2024-01-01', 'https://example.test/old'),
+      ('test-widget-model', 5.00, 10.00, DATE '2026-06-01', 'https://example.test/new')
+    ON CONFLICT (model_prefix, effective_from) DO NOTHING")
+  invisible(NULL)
+}
+
+insert_test_prefix_rows(scratch_db)
+
+test_that("scratch DB has model_pricing with our synthetic rows", {
+  con <- DBI::dbConnect(duckdb::duckdb(), scratch_db, read_only = TRUE)
+  on.exit(tryCatch(DBI::dbDisconnect(con, shutdown = TRUE), error = function(e) NULL))
+  n <- DBI::dbGetQuery(con, "
+    SELECT COUNT(*) AS n FROM model_pricing WHERE model_prefix = 'test-widget-model'")$n
+  expect_equal(as.integer(n), 2L)
+})
+
+# ── Source the real pricing block, pointed at the scratch DB ──────────────
+
+UNIFIED_DB <- scratch_db          # nolint: used by the sourced pricing block
+log_msg    <- function(...) invisible(NULL)  # stub — pricing block only calls this on error
+
+source(pricing_tmp_file)
+
+test_that("PRICING_DF loaded from the scratch DB (not just the R-side seed)", {
+  expect_true(exists("PRICING_DF"))
+  expect_true("test-widget-model" %in% PRICING_DF$model_prefix)
+})
+
+# ── Date-window assertions (llm#795 core requirement) ─────────────────────
+
+test_that("a record dated BEFORE the price change prices at the OLD rate", {
+  p <- model_pricing("test-widget-model-v1", at_date = as.Date("2025-01-01"))
+  expect_equal(p$input,  1.00)
+  expect_equal(p$output, 2.00)
+})
+
+test_that("a record dated AFTER the price change prices at the NEW rate", {
+  p <- model_pricing("test-widget-model-v1", at_date = as.Date("2026-06-15"))
+  expect_equal(p$input,  5.00)
+  expect_equal(p$output, 10.00)
+})
+
+test_that("an unknown model still routes to the sonnet-tier default", {
+  p <- model_pricing("totally-unknown-model-zzz", at_date = as.Date("2026-06-15"))
+  expect_equal(p$input,  3.00)
+  expect_equal(p$output, 15.00)
+})
+
+test_that("compute_cost_usd reflects the date-windowed rate change", {
+  cost_old <- compute_cost_usd(1e6, 1e6, "test-widget-model-v1", at_date = as.Date("2025-01-01"))
+  cost_new <- compute_cost_usd(1e6, 1e6, "test-widget-model-v1", at_date = as.Date("2026-06-15"))
+  expect_equal(cost_old, 1.00 + 2.00)
+  expect_equal(cost_new, 5.00 + 10.00)
+})
+
+test_that("compute_cost_usd spot-check matches prior embedded-literal behaviour", {
+  # claude-opus-4: input 15.00 / output 75.00 per 1M tokens (unchanged, llm#795
+  # is a behaviour-preserving migration).
+  cost <- compute_cost_usd(1e6, 1e6, "claude-opus-4", at_date = as.Date("2026-07-30"))
+  expect_equal(cost, 15.00 + 75.00)
+})
+
+cat("\n--- All tests completed ---\n")


### PR DESCRIPTION
## Summary

Replaces the hand-typed `PRICING_TABLE` literal in `.claude/scripts/roborev_metrics_etl.R` with a versioned, date-effective `model_pricing` table in `unified.duckdb`. The old literal carried a stale comment promising a migration "under #380" — #380 was closed and unrelated, so that promise never happened (a marker with no expiry became a lie).

**Behaviour-preserving migration** — same 17 rates + sonnet-tier default as before, now provenance-linked to each provider's official pricing page and effective-dated.

- New `model_pricing` table: `model_prefix`, `input_usd_per_mtok`, `output_usd_per_mtok`, `effective_from`, `source_url`. All seed rows use `effective_from = 2024-01-01` (a conservative floor date) so ALL historical `agent_runs` price at today's rates — identical to the prior embedded-constant behaviour.
- `seed_model_pricing()` upserts the seed on **every** `--apply` run (idempotent via `ON CONFLICT DO NOTHING`). This matters because the ETL's schema-init step skips all DDL/INSERT once every expected table already exists — a schema-file-only seed would otherwise only ever fire once, at first table creation.
- `model_pricing()` / `compute_cost_usd()` are now date-aware: longest-matching `model_prefix` wins, ties broken by the greatest `effective_from <= at_date`. Unknown/unmatched models still route to the sonnet-tier default (`__default__` row).
- `read_codex_fallback_jsonl()` reorders timestamp parsing ahead of the cost computation so each record prices at the rate in effect on its own date.

## Verification

- `parse()` on the modified ETL script: clean.
- New test `tests/test_model_pricing.R` (testthat): sources the production pricing code in isolation (via `PRICING_BLOCK_START`/`END` markers extracted into a temp file) against a scratch DuckDB seeded with a synthetic `model_prefix` carrying two `effective_from` rows (a price change) — asserts a record dated before the change prices at the old rate, a record dated after prices at the new rate, and an unknown model still routes to the sonnet-tier default. All assertions pass.
- Ran the full ETL end-to-end against a temp `unified.duckdb` + synthetic `reviews.db` + synthetic `codex_fallback` JSONL: `model_pricing` populated with all 18 rows (17 models + default); a `claude-opus-4` spot-check with 1e6/1e6 tokens computed `cost_usd = 90.0` (15.00 + 75.00), identical to the old embedded literal.
- Re-ran the ETL a second time against the same DB to confirm the GOTCHA fix: log showed `schema init skipped — all 9 tables present` followed by `model_pricing seed — 18 rows ensured`, with the row count staying at 18 (no duplicates) — the seed step reliably fires even when schema DDL is skipped.
- `r_code_check.sh` (ast-grep + jarl): 0 new errors; one new warning is the same accepted "raw SQL for SELECT" pattern already used elsewhere in the file (canonical-project guard).

## Test plan

- [x] `parse()` succeeds on `roborev_metrics_etl.R`
- [x] `tests/test_model_pricing.R` passes (9 test blocks, all green)
- [x] End-to-end `--apply` run against a temp DB populates `model_pricing` and reproduces the exact prior cost for a spot-check model
- [x] Idempotency verified across two consecutive `--apply` runs (schema-init-skip path)

Closes #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
