### PR TITLE
fix(roborev): route refine/fix backups to claude-code, off dead codex (#723)

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -286,10 +286,13 @@ classify_backup_model = ''
 # to claude-code/sonnet (the verified-working combo). If roborev's binary still
 # ignores these on the next gemini outage, the per-agent-pin fix is upstream.
 review_backup_agent = 'claude-code'
+#723: codex backup is billing-dead ('Quota exceeded'); route refine/fix backups to
+# claude-code (only reliably-working agent). backup_model='sonnet' so the claude-code
+# backup does not inherit the global gemini refine_model pin (#746 poison → 404).
 # Backup agent for refine in this repo.
-refine_backup_agent = ''
+refine_backup_agent = 'claude-code'
 # Backup agent for fix in this repo.
-fix_backup_agent = ''
+fix_backup_agent = 'claude-code'
 # Backup agent for security review in this repo.
 security_backup_agent = ''
 # Backup agent for design review in this repo.
@@ -297,9 +300,9 @@ design_backup_agent = ''
 # Backup model for review in this repo.
 review_backup_model = 'sonnet'
 # Backup model for refine in this repo.
-refine_backup_model = ''
+refine_backup_model = 'sonnet'
 # Backup model for fix in this repo.
-fix_backup_model = ''
+fix_backup_model = 'sonnet'
 # Backup model for security review in this repo.
 security_backup_model = ''
 # Backup model for design review in this repo.


### PR DESCRIPTION
## Summary

`.roborev.toml` set `refine_backup_agent`/`fix_backup_agent` to `''` (empty
string). An empty per-repo value **shadows** the global default to empty —
so once the `codex` agent went billing-dead (`Quota exceeded`), the
refine/fix chains had no working backup at all.

This extends the pattern already merged in #752 for `review_backup_agent`
(`claude-code`) to the `refine`/`fix` backup chains:

- `refine_backup_agent = 'claude-code'`
- `fix_backup_agent = 'claude-code'`
- `refine_backup_model = 'sonnet'`
- `fix_backup_model = 'sonnet'`

The `backup_model = 'sonnet'` pin matters because the repo's global
`refine_model` is pinned to `gemini-2.5-flash-lite`; leaving the backup
model empty would hand that gemini model string to the non-gemini
`claude-code` backup agent, producing a 404 (the #746 poison pattern).

Note: the global `~/.roborev/config.toml` was already patched
operationally by the orchestrator as an immediate mitigation. This PR is
the durable per-repo half of the fix, checked into version control.

## Test plan

- [x] `python3 -c "import tomllib; tomllib.load(open('.roborev.toml','rb'))"` — parses cleanly
- [x] `git diff` confirms only the four target keys + one new comment changed; no other keys touched
- [ ] Next roborev refine/fix run on this repo falls back to claude-code/sonnet if codex is still billing-dead

Refs #723 #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)
