### PR TITLE
fix(kb): strip |alias in broken-backlink checker (false-positive piped links)

### DIFF
--- a/.claude/scripts/send_kb_digest_email.R
+++ b/.claude/scripts/send_kb_digest_email.R
@@ -569,6 +569,8 @@ compute_broken_backlinks <- function(knowledge_repo) {
         targets <- gsub("^\\[\\[|\\]\\]$", "", matches)
 
         for (tgt in targets) {
+          # Strip the display alias from [[target|alias]] before resolving.
+          tgt <- trimws(sub("\\|.*$", "", tgt))
           # Try candidate filenames
           tgt_slug <- gsub(" ", "-", tolower(tgt))
           candidates <- c(


### PR DESCRIPTION
## What

`compute_broken_backlinks()` in `send_kb_digest_email.R` (the KB digest's "Broken [[topic]] wiki backlinks" section) resolved `[[target|alias]]` links **without** stripping the `|alias` display text, so valid piped links were reported as broken.

Example false positive: `[[steve-newman-ai-toolkit|personal AI coding toolkit]]` → resolved as a filename literally containing `|personal AI coding toolkit` → "broken", even though `wiki/steve-newman-ai-toolkit.md` exists.

## Fix

Strip `|...` before building candidate filenames: `tgt <- trimws(sub("\\|.*$", "", tgt))`.

## Related

Surfaced while fixing the 9 backlinks flagged in the KB digest (the 8 genuinely-missing targets were unlinked separately in the local knowledge repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)