### PR TITLE
fix(vignettes): dark Cleveland dot-plots, shared palettes, mandatory captions across all vignettes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ Cumulative lab notes. Track completed work, **failed approaches**, accuracy chec
 
 Convention: newest entries at top. Each entry has a date, what was done, and why.
 
+## 2026-08-01 — vignette visualization compliance sweep, companion size trims, KB backlinks, launchd diagnosis
+
+### Completed
+- **Vignette viz compliance** (PR #859): 7 bar charts → Cleveland dot plots; black `#000000` bg + white `#ffffff` axes/gridlines/labels in the shared `theme_dashboard` (was transparent → invisible ink in dark mode); one named `PALETTE` per page (narrative-colour-persistence) replacing per-chart `scale_*_viridis_d`; mandatory 3+ sentence `fig-cap`/`tbl-cap` on plots/tables/diagrams; config-evolution & knowledge-evolution architecture mermaids `flowchart LR → TB`; excluded `_companions/` from the rule/skill file counts in `config-evolution/_setup.qmd` (dashboard was mislabeling companions as oversized rules); `$/min` ratio precision → `signif(x,3)`.
+- **Full vignette audit:** 61 visual objects, 31 without a caption (10 plots / 17 tables / 4 diagrams); 7 bar charts; 0 plots with a black background.
+- **Companion size trims** (PR #858): `roborev-resolution-details` 474→294 (new `roborev-resolution-incidents.md`, 86), `auto-delegation-dispatch-details` 393→300 — duplication removed only, no normative content lost. All top-level rules already ≤150; the flagged files were companions.
+- **KB backlinks:** fixed the `[[target|alias]]` false-positive in the digest checker (PR #857); unlinked 8 non-existent `[[topic]]` links in the two steve-newman wiki pages (local knowledge repo commit).
+- Reopened **#463** (config-size tracker) + filed **#856** (enforce a `_companions/` limit + fix the dashboard companion-count bug).
+- **launchd diagnosis:** all 25 `com.claude` jobs are loaded with last-exit-status 0; the report's "—" run counts = empty `launchd_runs` ledger (0 plists wrap `launchd_run_record.sh`) — the known llm#300 instrumentation gap, not job failures.
+
+### Failed Approaches
+- **Telemetry `.rds` regeneration** (PR #859 commit 2, telemetry SOURCE only): tried to regenerate the committed `inst/extdata/vignettes/*.rds` via `tar_make` in the worktree nix shell. (1) First run lacked `pkgload::load_all()` → "no package called llm". (2) Per-target `tar_make(names = all_of(n))` failed — the loop variable doesn't survive `tar_make`'s tidyselect eval boundary ("object 'n' not found"). (3) Corrected literal `starts_with("vig_")` build + `load_all` built only **3 of 56** vig_ targets (the DAG halts early on upstream data targets needing full local pipeline data); the fixed dark-dot-plot snapshots did NOT regenerate, and the 3 that changed were unrelated data drift (discarded, not committed). Conclusion: telemetry snapshots must be regenerated in a full-data maintainer environment; there is **no committed reproducible exporter** (originally hand-exported in #64) — a reproducibility gap worth its own issue.
+
+### Known Limitations
+- **Telemetry vignette plots:** SOURCE fixed in #859, but the committed `.rds` snapshots are stale — the deployed telemetry plots keep the old bar-chart/light styling until the snapshots are regenerated in a full-data env.
+- `dashboard-filter-placement-details.md` still 171 lines (>150 warn, <300 hard) — left as-is.
+- PRs #857/#858/#859 are open, **not merged**.
+
 ## 2026-07-31 — roborev cluster closeout (#676/#746 verified+closed, #723 backup-chain fix), vignette tab styling
 
 ### Completed

--- a/R/tar_plans/plan_predictions.R
+++ b/R/tar_plans/plan_predictions.R
@@ -4,6 +4,17 @@
 
 library(targets)
 
+# Named palette for the two fixed metric series compared on this page
+# (narrative-colour-persistence rule). Contrast >=4.5:1 on #000000, shared
+# hues with TELEMETRY_PALETTE (see plan_vignette_outputs.R) for consistency
+# across telemetry pages. theme_dashboard() and ACCESSIBLE_QUALITATIVE_COLORS
+# are also defined in plan_vignette_outputs.R and are available here since
+# both files compile into the same package namespace.
+PRED_PALETTE <- c(
+  "Mean Predicted" = "#4ea8de",
+  "Actual Success" = "#f08080"
+)
+
 #' Prediction Calibration Targets
 #'
 #' Cross-project prediction tracking with Brier scores,
@@ -114,7 +125,13 @@ plan_predictions <- function() {
           )
         DT::datatable(
           display,
-          caption = "Prediction calibration by project.",
+          caption = htmltools::tags$caption(
+            style = "caption-side: bottom; text-align: left;",
+            sprintf(
+              "This table breaks down cross-project prediction calibration by project name, covering %d project(s). For each project it reports the number of predictions logged, how many have resolved to a known outcome, the observed success rate among resolved predictions, and the Brier score (lower is better, 0 is perfect). Projects with few resolved predictions show 'N/A' for rate and score until more outcomes are recorded.",
+              nrow(display)
+            )
+          ),
           extensions = "Buttons",
           rownames = FALSE,
           options = list(
@@ -125,7 +142,7 @@ plan_predictions <- function() {
           )
         )
       },
-      packages = c("DT", "dplyr")
+      packages = c("DT", "dplyr", "htmltools")
     ),
 
     tar_target(
@@ -141,15 +158,18 @@ plan_predictions <- function() {
           )
         DT::datatable(
           display,
-          caption = sprintf(
-            "Global calibration (Brier: %.3f, n=%d resolved).",
-            cal$brier_score, cal$n_resolved
+          caption = htmltools::tags$caption(
+            style = "caption-side: bottom; text-align: left;",
+            sprintf(
+              "This table groups all resolved cross-project predictions into probability buckets and compares the mean predicted probability against the mean observed outcome in each bucket. A well-calibrated forecaster should show a gap near zero in every row; large positive gaps mean predictions were too confident, large negative gaps mean predictions were under-confident. Across all %d resolved predictions, the overall Brier score is %.3f (0 is perfect, 0.25 is the uninformative baseline).",
+              cal$n_resolved, cal$brier_score
+            )
           ),
           rownames = FALSE,
           options = list(dom = "t", pageLength = 10)
         )
       },
-      packages = c("DT", "dplyr")
+      packages = c("DT", "dplyr", "htmltools")
     ),
 
     # === Vignette plots ===
@@ -160,6 +180,16 @@ plan_predictions <- function() {
         if (is.null(pred_global_rolling_brier) ||
             nrow(pred_global_rolling_brier) == 0) return(NULL)
 
+        # project_name is a dynamic, unbounded set (new projects appear over
+        # time), so it cannot be enumerated in a fixed named PALETTE ahead of
+        # time. Build a scale_color_manual() vector at plot-build time from
+        # the shared accessible qualitative colours instead of viridis.
+        projects <- sort(unique(pred_global_rolling_brier$project_name))
+        proj_palette <- stats::setNames(
+          rep_len(ACCESSIBLE_QUALITATIVE_COLORS, length(projects)),
+          projects
+        )
+
         ggplot2::ggplot(
           pred_global_rolling_brier,
           ggplot2::aes(x = prediction_num, y = cumulative_brier,
@@ -167,11 +197,12 @@ plan_predictions <- function() {
         ) +
           ggplot2::geom_line() +
           ggplot2::geom_hline(yintercept = 0.25, linetype = "dashed",
-                              color = "red", alpha = 0.5) +
+                              color = "#ffd93d", alpha = 0.7) +
           ggplot2::annotate("text", x = 1, y = 0.26,
                             label = "Uninformative baseline",
-                            hjust = 0, size = 3, color = "red") +
+                            hjust = 0, size = 3, color = "#ffd93d") +
           ggplot2::scale_y_continuous(limits = c(0, 0.5)) +
+          ggplot2::scale_color_manual(values = proj_palette) +
           ggplot2::labs(
             title = "Cross-Project Rolling Brier Score",
             subtitle = "Cumulative calibration over time (lower is better)",
@@ -179,7 +210,7 @@ plan_predictions <- function() {
             y = "Cumulative Brier Score",
             color = "Project"
           ) +
-          ggplot2::theme_minimal()
+          theme_dashboard()
       },
       packages = c("ggplot2")
     ),
@@ -208,21 +239,30 @@ plan_predictions <- function() {
             values_to = "rate"
           )
 
+        # Order projects by their actual success rate so the grouped dot
+        # plot reads top-to-bottom from best to worst observed outcome.
+        order_basis <- plot_data |>
+          dplyr::filter(metric == "Actual Success") |>
+          dplyr::arrange(rate) |>
+          dplyr::pull(project_name)
+        plot_data <- plot_data |>
+          dplyr::mutate(project_name = factor(project_name, levels = order_basis))
+
         ggplot2::ggplot(
           plot_data,
-          ggplot2::aes(x = project_name, y = rate, fill = metric)
+          ggplot2::aes(x = rate, y = project_name, color = metric)
         ) +
-          ggplot2::geom_col(position = "dodge") +
-          ggplot2::scale_y_continuous(labels = scales::percent_format()) +
-          ggplot2::scale_fill_manual(
-            values = c("Mean Predicted" = "steelblue", "Actual Success" = "coral")
+          ggplot2::geom_line(
+            ggplot2::aes(group = project_name), color = "#ffffff", linewidth = 0.4
           ) +
-          ggplot2::coord_flip() +
+          ggplot2::geom_point(size = 4) +
+          ggplot2::scale_x_continuous(labels = scales::percent_format(accuracy = 1)) +
+          ggplot2::scale_color_manual(values = PRED_PALETTE) +
           ggplot2::labs(
             title = "Predicted vs Actual Success Rate by Project",
-            x = NULL, y = "Rate", fill = NULL
+            x = "Rate", y = NULL, color = NULL
           ) +
-          ggplot2::theme_minimal()
+          theme_dashboard()
       },
       packages = c("ggplot2", "dplyr", "tidyr", "scales")
     )

--- a/R/tar_plans/plan_vignette_outputs.R
+++ b/R/tar_plans/plan_vignette_outputs.R
@@ -4,6 +4,57 @@
 
 library(targets)
 
+# Shared black-background / white-ink ggplot theme for every telemetry plot
+# (accessibility: dark-mode-completeness rule — black #000000, white #ffffff,
+# never dark blue/grey placeholders). Defined here (not exported) so it is
+# available inside every tar_target() expression across the telemetry plans,
+# since all R/ files compile into one package namespace.
+theme_dashboard <- function(base_size = 14) {
+  ggplot2::theme_minimal(base_size = base_size) +
+    ggplot2::theme(
+      plot.background    = ggplot2::element_rect(fill = "#000000", color = NA),
+      panel.background   = ggplot2::element_rect(fill = "#000000", color = NA),
+      legend.background  = ggplot2::element_rect(fill = "#000000", color = NA),
+      strip.background   = ggplot2::element_rect(fill = "#000000", color = "#ffffff"),
+      panel.grid.major   = ggplot2::element_line(color = "#ffffff", linewidth = 0.3),
+      panel.grid.minor   = ggplot2::element_line(color = "#ffffff", linewidth = 0.15),
+      text          = ggplot2::element_text(color = "#ffffff"),
+      axis.text     = ggplot2::element_text(color = "#ffffff"),
+      axis.title    = ggplot2::element_text(color = "#ffffff"),
+      plot.title    = ggplot2::element_text(color = "#ffffff", face = "bold"),
+      plot.subtitle = ggplot2::element_text(color = "#ffffff"),
+      strip.text    = ggplot2::element_text(color = "#ffffff"),
+      legend.text   = ggplot2::element_text(color = "#ffffff"),
+      legend.title  = ggplot2::element_text(color = "#ffffff"),
+      legend.position = "bottom"
+    )
+}
+
+# Shared named palette for the LLM Usage/GitHub Activity telemetry pages
+# (narrative-colour-persistence rule: same entity -> same colour everywhere).
+# All hex values are >=4.5:1 contrast on #000000.
+TELEMETRY_PALETTE <- c(
+  "accent"      = "#4ea8de", # single-series lines/points (cost, commits, gemini, model-cost dots)
+  "trend"       = "#f08080", # LOESS/trend overlay lines
+  "Input"       = "#69d4a0", # token-type breakdown
+  "Output"      = "#4ea8de",
+  "Cache"       = "#ffd93d",
+  "Last Week"   = "#69d4a0", # session-recency period
+  "Older"       = "#c084fc"
+)
+
+# Fixed-size accessible qualitative palette used to colour dynamic, unbounded
+# category sets (e.g. project names) that cannot be enumerated in a fixed
+# named vector ahead of time. Recycled and named per-plot via setNames().
+ACCESSIBLE_QUALITATIVE_COLORS <- c(
+  "#4ea8de", "#69d4a0", "#ffd93d", "#f08080",
+  "#c084fc", "#f4a261", "#2dd4bf", "#fb7185"
+)
+
+# Ratio/rate labeller (e.g. $/min): at most signif(x, 3) to avoid spurious
+# precision on computed rates (visualization number-formatting rule).
+label_dollar_signif <- function(x) paste0("$", signif(x, 3))
+
 #' Vignette Output Targets
 #'
 #' All computation for vignettes/telemetry.qmd lives here.
@@ -43,7 +94,13 @@ plan_vignette_outputs <- function() {
         if (nrow(summary_stats) == 0) return(NULL)
         DT::datatable(
           summary_stats,
-          caption = "Current Usage Status",
+          caption = htmltools::tags$caption(
+            style = "caption-side: bottom; text-align: left;",
+            sprintf(
+              "This table summarises the current Claude usage status across %d day(s) of cached ccusage data. Values are computed by llm::summarize_llm_usage() directly from the daily usage records ingested into inst/extdata. Use it to check whether spend, token usage, or session counts have drifted from recent norms before drilling into the trend charts below.",
+              length(unique(vig_daily_data$date))
+            )
+          ),
           extensions = "Buttons",
           rownames = FALSE,
           options = list(
@@ -55,7 +112,7 @@ plan_vignette_outputs <- function() {
           )
         )
       },
-      packages = c("DT")
+      packages = c("DT", "htmltools")
     ),
 
     # Daily cost trend plot
@@ -68,11 +125,12 @@ plan_vignette_outputs <- function() {
           dplyr::group_by(date) |>
           dplyr::summarise(daily_cost = sum(totalCost, na.rm = TRUE), .groups = "drop") |>
           ggplot2::ggplot(ggplot2::aes(x = date, y = daily_cost)) +
-          ggplot2::geom_col(fill = "steelblue", alpha = 0.7) +
-          ggplot2::geom_smooth(method = "loess", se = FALSE, color = "darkred") +
+          ggplot2::geom_line(color = TELEMETRY_PALETTE[["accent"]], linewidth = 0.8) +
+          ggplot2::geom_point(color = TELEMETRY_PALETTE[["accent"]], size = 1.5) +
+          ggplot2::geom_smooth(method = "loess", se = FALSE, color = TELEMETRY_PALETTE[["trend"]]) +
           ggplot2::scale_y_continuous(labels = scales::dollar_format()) +
           ggplot2::labs(title = "Daily Costs", x = "Date", y = "Cost (USD)") +
-          ggplot2::theme_minimal()
+          theme_dashboard()
       },
       packages = c("ggplot2", "dplyr", "scales")
     ),
@@ -89,11 +147,11 @@ plan_vignette_outputs <- function() {
           dplyr::arrange(date) |>
           dplyr::mutate(cumulative_cost = cumsum(daily_cost)) |>
           ggplot2::ggplot(ggplot2::aes(x = date, y = cumulative_cost)) +
-          ggplot2::geom_area(fill = "steelblue", alpha = 0.3) +
-          ggplot2::geom_line(color = "steelblue") +
+          ggplot2::geom_area(fill = TELEMETRY_PALETTE[["accent"]], alpha = 0.3) +
+          ggplot2::geom_line(color = TELEMETRY_PALETTE[["accent"]]) +
           ggplot2::scale_y_continuous(labels = scales::dollar_format()) +
           ggplot2::labs(title = "Cumulative Spending", x = "Date", y = "Cumulative Cost (USD)") +
-          ggplot2::theme_minimal()
+          theme_dashboard()
       },
       packages = c("ggplot2", "dplyr", "scales")
     ),
@@ -106,32 +164,67 @@ plan_vignette_outputs <- function() {
 
         model_stats <- llm::get_model_breakdown(vig_daily_data)
         if (!is.null(model_stats) && nrow(model_stats) > 0 && "modelName" %in% names(model_stats)) {
-          p1 <- ggplot2::ggplot(model_stats, ggplot2::aes(x = reorder(modelName, total_cost), y = total_cost)) +
-            ggplot2::geom_col(fill = "steelblue") +
-            ggplot2::coord_flip() +
-            ggplot2::scale_y_continuous(labels = scales::dollar_format()) +
-            ggplot2::labs(title = "Cost by Model", x = NULL, y = "USD") +
-            ggplot2::theme_minimal()
+          p1 <- ggplot2::ggplot(
+            model_stats,
+            ggplot2::aes(x = total_cost, y = reorder(modelName, total_cost))
+          ) +
+            ggplot2::geom_segment(
+              ggplot2::aes(x = 0, xend = total_cost, yend = reorder(modelName, total_cost)),
+              color = TELEMETRY_PALETTE[["accent"]]
+            ) +
+            ggplot2::geom_point(color = TELEMETRY_PALETTE[["accent"]], size = 4) +
+            ggplot2::geom_text(
+              ggplot2::aes(label = scales::dollar(total_cost)),
+              hjust = -0.3, color = "#ffffff", size = 3.2
+            ) +
+            ggplot2::scale_x_continuous(
+              labels = scales::dollar_format(),
+              expand = ggplot2::expansion(mult = c(0, 0.15))
+            ) +
+            ggplot2::labs(title = "Cost by Model", x = "USD", y = NULL) +
+            theme_dashboard()
         } else {
-          p1 <- ggplot2::ggplot() + ggplot2::labs(title = "No model breakdown data available") + ggplot2::theme_void()
+          p1 <- ggplot2::ggplot() +
+            ggplot2::labs(title = "No model breakdown data available") +
+            ggplot2::theme_void() +
+            ggplot2::theme(
+              plot.background = ggplot2::element_rect(fill = "#000000", color = NA),
+              text = ggplot2::element_text(color = "#ffffff")
+            )
         }
 
+        # Aggregate token usage by type across the full tracked period, so
+        # the "breakdown" reads as a categorical comparison (input vs output
+        # vs cache) rather than an undifferentiated stacked-bar wall of dates.
         token_data <- vig_daily_data |>
-          dplyr::mutate(date = as.Date(as.character(date))) |>
-          dplyr::group_by(date) |>
           dplyr::summarise(
             Input = sum(inputTokens, na.rm = TRUE),
             Output = sum(outputTokens, na.rm = TRUE),
-            Cache = sum(cacheCreationTokens + cacheReadTokens, na.rm = TRUE),
-            .groups = "drop"
+            Cache = sum(cacheCreationTokens + cacheReadTokens, na.rm = TRUE)
           ) |>
-          tidyr::pivot_longer(-date, names_to = "type", values_to = "tokens")
+          tidyr::pivot_longer(dplyr::everything(), names_to = "type", values_to = "tokens")
 
-        p2 <- ggplot2::ggplot(token_data, ggplot2::aes(x = date, y = tokens / 1e6, fill = type)) +
-          ggplot2::geom_col() +
-          ggplot2::scale_y_continuous(labels = scales::label_comma(suffix = "M")) +
-          ggplot2::labs(title = "Token Usage", y = "Millions") +
-          ggplot2::theme_minimal()
+        p2 <- ggplot2::ggplot(
+          token_data,
+          ggplot2::aes(x = tokens / 1e6, y = reorder(type, tokens), color = type)
+        ) +
+          ggplot2::geom_segment(
+            ggplot2::aes(x = 0, xend = tokens / 1e6, yend = reorder(type, tokens)),
+            linewidth = 1
+          ) +
+          ggplot2::geom_point(size = 4) +
+          ggplot2::geom_text(
+            ggplot2::aes(label = scales::comma(tokens, scale = 1e-6, suffix = "M", accuracy = 0.1)),
+            hjust = -0.3, color = "#ffffff", size = 3.2
+          ) +
+          ggplot2::scale_color_manual(values = TELEMETRY_PALETTE) +
+          ggplot2::scale_x_continuous(
+            labels = scales::label_comma(suffix = "M"),
+            expand = ggplot2::expansion(mult = c(0, 0.2))
+          ) +
+          ggplot2::labs(title = "Total Token Usage by Type", x = "Millions", y = NULL) +
+          theme_dashboard() +
+          ggplot2::theme(legend.position = "none")
 
         gridExtra::grid.arrange(p1, p2, ncol = 1)
       },
@@ -151,11 +244,26 @@ plan_vignette_outputs <- function() {
             dplyr::arrange(date) |>
             dplyr::collect()
           if (nrow(gm_daily) == 0) return(NULL)
-          ggplot2::ggplot(gm_daily, ggplot2::aes(x = as.Date(date), y = total_cost)) +
-            ggplot2::geom_col(fill = "#4fc3f7") +
-            ggplot2::scale_y_continuous(labels = scales::dollar_format()) +
-            ggplot2::labs(title = "Gemini Daily Costs", x = "Date", y = "USD") +
-            ggplot2::theme_minimal()
+          gm_daily <- gm_daily |> dplyr::mutate(date = as.Date(date))
+          ggplot2::ggplot(
+            gm_daily,
+            ggplot2::aes(x = total_cost, y = reorder(as.character(date), total_cost))
+          ) +
+            ggplot2::geom_segment(
+              ggplot2::aes(x = 0, xend = total_cost, yend = reorder(as.character(date), total_cost)),
+              color = TELEMETRY_PALETTE[["accent"]]
+            ) +
+            ggplot2::geom_point(color = TELEMETRY_PALETTE[["accent"]], size = 4) +
+            ggplot2::geom_text(
+              ggplot2::aes(label = scales::dollar(total_cost)),
+              hjust = -0.3, color = "#ffffff", size = 3
+            ) +
+            ggplot2::scale_x_continuous(
+              labels = scales::dollar_format(),
+              expand = ggplot2::expansion(mult = c(0, 0.15))
+            ) +
+            ggplot2::labs(title = "Gemini Daily Costs", x = "USD", y = "Date") +
+            theme_dashboard()
         }, error = function(e) { cli::cli_warn("Target failed: {conditionMessage(e)}"); NULL })
       },
       packages = c("ggplot2", "dplyr", "DBI", "duckdb", "scales")
@@ -196,10 +304,11 @@ plan_vignette_outputs <- function() {
           dplyr::group_by(date, period) |>
           dplyr::summarise(avg_dur = mean(duration_mins), .groups = "drop") |>
           ggplot2::ggplot(ggplot2::aes(x = date, y = avg_dur)) +
-          ggplot2::geom_point(ggplot2::aes(color = period)) +
-          ggplot2::geom_smooth(method = "loess", se = FALSE) +
-          ggplot2::labs(title = "Avg Session Duration", y = "Minutes") +
-          ggplot2::theme_minimal()
+          ggplot2::geom_point(ggplot2::aes(color = period), size = 2) +
+          ggplot2::geom_smooth(method = "loess", se = FALSE, color = TELEMETRY_PALETTE[["trend"]]) +
+          ggplot2::scale_color_manual(values = TELEMETRY_PALETTE) +
+          ggplot2::labs(title = "Avg Session Duration", y = "Minutes", color = "Period") +
+          theme_dashboard()
       },
       packages = c("ggplot2", "dplyr")
     ),
@@ -213,11 +322,12 @@ plan_vignette_outputs <- function() {
           dplyr::group_by(date, period) |>
           dplyr::summarise(avg_cost = mean(cost_per_min), .groups = "drop") |>
           ggplot2::ggplot(ggplot2::aes(x = date, y = avg_cost)) +
-          ggplot2::geom_point(ggplot2::aes(color = period)) +
-          ggplot2::geom_smooth(method = "loess", se = FALSE) +
-          ggplot2::scale_y_continuous(labels = scales::dollar_format()) +
-          ggplot2::labs(title = "Cost per Minute", y = "$/min") +
-          ggplot2::theme_minimal()
+          ggplot2::geom_point(ggplot2::aes(color = period), size = 2) +
+          ggplot2::geom_smooth(method = "loess", se = FALSE, color = TELEMETRY_PALETTE[["trend"]]) +
+          ggplot2::scale_color_manual(values = TELEMETRY_PALETTE) +
+          ggplot2::scale_y_continuous(labels = label_dollar_signif) +
+          ggplot2::labs(title = "Cost per Minute", y = "$/min", color = "Period") +
+          theme_dashboard()
       },
       packages = c("ggplot2", "dplyr", "scales")
     ),
@@ -229,15 +339,17 @@ plan_vignette_outputs <- function() {
         if (is.null(vig_session_metrics) || nrow(vig_session_metrics) == 0) return(NULL)
         ggplot2::ggplot(vig_session_metrics, ggplot2::aes(x = duration_mins, y = cost_per_min)) +
           ggplot2::geom_point(ggplot2::aes(color = period), alpha = 0.6) +
-          ggplot2::geom_smooth(method = "loess", color = "red") +
-          ggplot2::scale_y_continuous(labels = scales::dollar_format()) +
+          ggplot2::geom_smooth(method = "loess", color = TELEMETRY_PALETTE[["trend"]]) +
+          ggplot2::scale_color_manual(values = TELEMETRY_PALETTE) +
+          ggplot2::scale_y_continuous(labels = label_dollar_signif) +
           ggplot2::labs(
             title = "Cost Intensity vs Duration",
             subtitle = "Are longer sessions more cost efficient?",
             x = "Duration (mins)",
-            y = "Cost/Min ($)"
+            y = "Cost/Min ($)",
+            color = "Period"
           ) +
-          ggplot2::theme_minimal()
+          theme_dashboard()
       },
       packages = c("ggplot2", "scales")
     ),
@@ -255,12 +367,12 @@ plan_vignette_outputs <- function() {
             dplyr::mutate(model_clean = gsub("claude-", "", models, fixed = TRUE))
 
           ggplot2::ggplot(model_usage, ggplot2::aes(x = date, y = cost_per_min)) +
-            ggplot2::geom_point(alpha = 0.4, color = "steelblue") +
-            ggplot2::geom_smooth(method = "loess", se = FALSE, color = "darkred") +
+            ggplot2::geom_point(alpha = 0.4, color = TELEMETRY_PALETTE[["accent"]]) +
+            ggplot2::geom_smooth(method = "loess", se = FALSE, color = TELEMETRY_PALETTE[["trend"]]) +
             ggplot2::facet_wrap(~model_clean, scales = "free_y", ncol = 2) +
-            ggplot2::scale_y_continuous(labels = scales::dollar_format()) +
+            ggplot2::scale_y_continuous(labels = label_dollar_signif) +
             ggplot2::labs(title = "Cost Efficiency by Model", y = "Cost/Min ($)") +
-            ggplot2::theme_minimal()
+            theme_dashboard()
         }, error = function(e) { cli::cli_warn("Target failed: {conditionMessage(e)}"); NULL })
       },
       packages = c("ggplot2", "dplyr", "tidyr", "scales")
@@ -282,7 +394,13 @@ plan_vignette_outputs <- function() {
 
         DT::datatable(
           tbl_data,
-          caption = "Max5 Usage Blocks",
+          caption = htmltools::tags$caption(
+            style = "caption-side: bottom; text-align: left;",
+            sprintf(
+              "This table lists the %d most recent Max5 usage blocks, each block representing one continuous Claude session window. Duration is shown as HH:MM, cost in USD, and tokens as a comma-formatted count. Rows are sorted by session start time, most recent first, so you can spot unusually long or expensive sessions quickly.",
+              nrow(tbl_data)
+            )
+          ),
           extensions = "Buttons",
           rownames = FALSE,
           options = list(
@@ -294,7 +412,7 @@ plan_vignette_outputs <- function() {
           )
         )
       },
-      packages = c("DT", "dplyr", "scales")
+      packages = c("DT", "dplyr", "scales", "htmltools")
     ),
 
     # === CI & Git Stats section ===
@@ -329,10 +447,10 @@ plan_vignette_outputs <- function() {
         vig_workflow_runs |>
           dplyr::filter(conclusion == "success", !is.na(duration_mins)) |>
           ggplot2::ggplot(ggplot2::aes(x = reorder(name, duration_mins), y = duration_mins)) +
-          ggplot2::geom_boxplot(fill = "steelblue", alpha = 0.7) +
+          ggplot2::geom_boxplot(fill = TELEMETRY_PALETTE[["accent"]], alpha = 0.7, color = "#ffffff") +
           ggplot2::coord_flip() +
           ggplot2::labs(title = "Workflow Runtimes", x = NULL, y = "Minutes") +
-          ggplot2::theme_minimal()
+          theme_dashboard()
       },
       packages = c("ggplot2", "dplyr")
     ),
@@ -347,13 +465,25 @@ plan_vignette_outputs <- function() {
           git_log |>
             dplyr::mutate(date = as.Date(time)) |>
             dplyr::count(date) |>
-            ggplot2::ggplot(ggplot2::aes(x = date, y = n)) +
-            ggplot2::geom_col(fill = "steelblue") +
-            ggplot2::labs(title = "Recent Commits", y = "Count") +
-            ggplot2::theme_minimal()
+            ggplot2::ggplot(ggplot2::aes(x = n, y = reorder(as.character(date), n))) +
+            ggplot2::geom_segment(
+              ggplot2::aes(x = 0, xend = n, yend = reorder(as.character(date), n)),
+              color = TELEMETRY_PALETTE[["accent"]]
+            ) +
+            ggplot2::geom_point(color = TELEMETRY_PALETTE[["accent"]], size = 4) +
+            ggplot2::geom_text(
+              ggplot2::aes(label = n),
+              hjust = -0.3, color = "#ffffff", size = 3
+            ) +
+            ggplot2::scale_x_continuous(
+              labels = scales::comma,
+              expand = ggplot2::expansion(mult = c(0, 0.15))
+            ) +
+            ggplot2::labs(title = "Recent Commits", x = "Count", y = "Date") +
+            theme_dashboard()
         }, error = function(e) { cli::cli_warn("Target failed: {conditionMessage(e)}"); NULL })
       },
-      packages = c("ggplot2", "dplyr", "gert"),
+      packages = c("ggplot2", "dplyr", "gert", "scales"),
       cue = tar_cue(mode = "always")
     ),
 
@@ -372,7 +502,13 @@ plan_vignette_outputs <- function() {
             dplyr::count(ext, sort = TRUE)
           DT::datatable(
             tbl_data,
-            caption = "File Types",
+            caption = htmltools::tags$caption(
+              style = "caption-side: bottom; text-align: left;",
+              sprintf(
+                "This table counts every tracked file in the repository by extension, excluding .git, _targets, and renv directories. It covers %s files across %d distinct extensions and is recomputed on every pipeline run. Use it to sanity-check that the repository's file mix (R source, vignettes, config, data) matches expectations.",
+                scales::comma(sum(tbl_data$n)), nrow(tbl_data)
+              )
+            ),
             extensions = "Buttons",
             rownames = FALSE,
             options = list(
@@ -385,7 +521,7 @@ plan_vignette_outputs <- function() {
           )
         }, error = function(e) { cli::cli_warn("Target failed: {conditionMessage(e)}"); NULL })
       },
-      packages = c("DT", "dplyr", "tibble", "fs")
+      packages = c("DT", "dplyr", "tibble", "fs", "htmltools", "scales")
     ),
 
     # === Pipeline Metrics section ===
@@ -464,9 +600,11 @@ plan_vignette_outputs <- function() {
           vig_pipeline_summary$plan_tbl,
           caption = htmltools::tags$caption(
             style = "caption-side: bottom; text-align: left;",
-            sprintf("Pipeline has %d plans with %d total targets.",
-                    vig_pipeline_summary$total_plans,
-                    vig_pipeline_summary$total_targets)
+            sprintf(
+              "This table lists every targets plan file under R/tar_plans and how many tar_target()/tar_quarto() calls each one defines. The pipeline currently has %d plans with %d total targets, sorted by target count descending. Use it to spot which plan files are growing large enough to warrant splitting.",
+              vig_pipeline_summary$total_plans,
+              vig_pipeline_summary$total_targets
+            )
           ),
           rownames = FALSE,
           options = list(dom = "t", pageLength = 20, order = list(list(1, "desc")))
@@ -481,12 +619,15 @@ plan_vignette_outputs <- function() {
         if (is.null(vig_pipeline_summary)) return(NULL)
         DT::datatable(
           vig_pipeline_summary$top_size |> dplyr::select(target, size),
-          caption = "Top 5 targets by stored size.",
+          caption = htmltools::tags$caption(
+            style = "caption-side: bottom; text-align: left;",
+            "This table ranks the five largest targets currently stored in the _targets cache by their serialized size on disk. Size is reported in the most readable unit (KB, MB, or GB) depending on magnitude. Large targets here are the best candidates for storage-format optimisation (e.g. switching to qs or parquet) if the pipeline's disk footprint becomes a concern."
+          ),
           rownames = FALSE,
           options = list(dom = "t", pageLength = 5)
         )
       },
-      packages = c("DT", "dplyr")
+      packages = c("DT", "dplyr", "htmltools")
     ),
 
     tar_target(
@@ -495,12 +636,15 @@ plan_vignette_outputs <- function() {
         if (is.null(vig_pipeline_summary)) return(NULL)
         DT::datatable(
           vig_pipeline_summary$top_time |> dplyr::select(target, time),
-          caption = "Top 5 targets by compute time.",
+          caption = htmltools::tags$caption(
+            style = "caption-side: bottom; text-align: left;",
+            "This table ranks the five slowest targets in the most recent pipeline run by wall-clock compute time, shown in minutes or seconds depending on magnitude. Compute time is read from targets::tar_meta() metadata captured after tar_make() completes. Targets appearing here repeatedly are the best candidates for caching, parallelisation via crew, or algorithmic optimisation."
+          ),
           rownames = FALSE,
           options = list(dom = "t", pageLength = 5)
         )
       },
-      packages = c("DT", "dplyr")
+      packages = c("DT", "dplyr", "htmltools")
     ),
 
     # === GitHub Activity section ===
@@ -555,10 +699,12 @@ plan_vignette_outputs <- function() {
           tbl,
           caption = htmltools::tags$caption(
             style = "caption-side: bottom; text-align: left;",
-            sprintf("Total: %d commits over %d days (started %s).",
-                    vig_commit_velocity$total_commits,
-                    vig_commit_velocity$age_days,
-                    vig_commit_velocity$started)
+            sprintf(
+              "This table shows weekly commit counts for the repository since it was created. Across %d days (started %s) the project has accumulated %d total commits, giving a sense of overall development velocity. Use it alongside the pipeline metrics table to see whether commit activity and pipeline growth are moving together.",
+              vig_commit_velocity$age_days,
+              vig_commit_velocity$started,
+              vig_commit_velocity$total_commits
+            )
           ),
           rownames = FALSE,
           options = list(dom = "t", pageLength = 20, order = list(list(1, "desc")))
@@ -635,12 +781,20 @@ plan_vignette_outputs <- function() {
         )
         DT::datatable(
           tbl,
-          caption = "GitHub issues, pull requests, and CI workflows.",
+          caption = htmltools::tags$caption(
+            style = "caption-side: bottom; text-align: left;",
+            sprintf(
+              "This table summarises the repository's GitHub issue, pull request, and CI workflow activity as of the last pipeline run. There are currently %d open and %d closed issues (%d total), %d open and %d merged pull requests (%d total), and %d active CI workflow(s). Use it as a quick health check before diving into the individual issue and PR lists.",
+              ga$issues_open, ga$issues_closed, ga$issues_total,
+              ga$prs_open, ga$prs_merged, ga$prs_total,
+              ga$workflows_active
+            )
+          ),
           rownames = FALSE,
           options = list(dom = "t", pageLength = 5)
         )
       },
-      packages = c("DT", "tibble")
+      packages = c("DT", "tibble", "htmltools")
     ),
 
     # Codebase metrics
@@ -685,13 +839,19 @@ plan_vignette_outputs <- function() {
 
           DT::datatable(
             tbl,
-            caption = sprintf("%s codebase metrics.", pkg_name),
+            caption = htmltools::tags$caption(
+              style = "caption-side: bottom; text-align: left;",
+              sprintf(
+                "This table reports structural metrics for the %s package (version %s): counts of R source files, test files, vignettes, targets plan files, and exported functions, plus total non-comment lines of R code. Metrics are recomputed directly from the repository tree and NAMESPACE on every pipeline run, so they always reflect the current checkout. Use it to track codebase growth over time alongside the commit velocity and pipeline metrics tables.",
+                pkg_name, version
+              )
+            ),
             rownames = FALSE,
             options = list(dom = "t", pageLength = 10)
           )
         }, error = function(e) { cli::cli_warn("Target failed: {conditionMessage(e)}"); NULL })
       },
-      packages = c("DT", "tibble")
+      packages = c("DT", "tibble", "htmltools")
     ),
 
     # GitHub stats table
@@ -717,7 +877,10 @@ plan_vignette_outputs <- function() {
           )
           DT::datatable(
             stats_data,
-            caption = "GitHub Stats",
+            caption = htmltools::tags$caption(
+              style = "caption-side: bottom; text-align: left;",
+              "This table shows top-level GitHub repository statistics: star and fork counts, the number of open issues, the number of branches, and the date of the most recent commit. Values are fetched live from the GitHub API on every pipeline run, so they reflect the repository's current state rather than a cached snapshot. Use it as a quick external-visibility check alongside the internal codebase and pipeline metrics tables."
+            ),
             extensions = "Buttons",
             rownames = FALSE,
             options = list(
@@ -730,7 +893,7 @@ plan_vignette_outputs <- function() {
           )
         }, error = function(e) { cli::cli_warn("Target failed: {conditionMessage(e)}"); NULL })
       },
-      packages = c("DT", "gh", "lubridate", "tibble"),
+      packages = c("DT", "gh", "lubridate", "tibble", "htmltools"),
       cue = tar_cue(mode = "always")
     )
   )

--- a/vignettes/articles/closeread-config.qmd
+++ b/vignettes/articles/closeread-config.qmd
@@ -140,8 +140,10 @@ if (is.null(rule_data)) {
 rules_caption <- safe_tar_read("vig_cr_rules_caption")
 if (is.null(rules_caption)) {
   rules_caption <- paste0(
-    "Rule categories across ", sum(rule_data$count),
-    " config files in ", nrow(rule_data), " categories"
+    "Rule categories covering all ", sum(rule_data$count),
+    " constraint files across ", nrow(rule_data), " categories, one row per category. ",
+    "Count is the number of rule files in that category; Examples lists two or three representative rule names. ",
+    "Core workflow and Quarto/vignettes are the largest categories, reflecting how much of the config stack is dedicated to session discipline and reproducible reporting."
   )
 }
 knitr::kable(rule_data, format = "html",
@@ -232,8 +234,10 @@ if (is.null(skill_data)) {
 skills_caption <- safe_tar_read("vig_cr_skills_caption")
 if (is.null(skills_caption)) {
   skills_caption <- paste0(
-    "Skill modules by domain (", sum(skill_data$count),
-    " total across ", nrow(skill_data), " categories)"
+    "Skill modules grouped by domain, covering all ", sum(skill_data$count),
+    " skills across ", nrow(skill_data), " categories, one row per category. ",
+    "Count is the number of skill modules in that domain; Purpose summarises what the category teaches the model to do. ",
+    "R package development and data & analysis are the two largest domains, together accounting for roughly a third of all skills."
   )
 }
 knitr::kable(skill_data, format = "html",
@@ -292,8 +296,11 @@ if (is.null(agents_caption)) {
   n_haiku  <- sum(agent_data$model == "haiku", na.rm = TRUE)
   n_sonnet <- sum(agent_data$model == "sonnet", na.rm = TRUE)
   agents_caption <- paste0(
-    "Agent model tiers and delegation triggers (", nrow(agent_data),
-    " agents: ", n_haiku, " haiku, ", n_sonnet, " sonnet)"
+    "Agent model tiers and delegation triggers for all ", nrow(agent_data),
+    " specialist agents, one row per agent. ",
+    "Model is the Claude tier the agent runs on (haiku for mechanical single-file edits, sonnet for everything requiring reasoning); Trigger is the phrase or task type that causes the orchestrator to delegate to it. ",
+    "Only ", n_haiku, " of ", nrow(agent_data), " agents run on the cheaper haiku tier; the remaining ", n_sonnet,
+    " run on sonnet, reflecting a policy that reserves the lightweight model for work with no correctness reasoning required."
   )
 }
 knitr::kable(agent_data, format = "html",
@@ -381,7 +388,9 @@ cmd_data$alias[is.na(cmd_data$alias)] <- "\u2014"
 commands_caption <- safe_tar_read("vig_cr_commands_caption")
 if (is.null(commands_caption)) {
   commands_caption <- paste0(
-    nrow(cmd_data), " slash commands, parsed from ~/.claude/commands/"
+    "All ", nrow(cmd_data), " slash commands parsed directly from `~/.claude/commands/`, one row per command. ",
+    "Alias lists an alternate invocation name where one exists (a dash means none); Description is the one-line summary from the command's own file. ",
+    "Commands are user-triggered workflows — unlike hooks, which fire automatically on tool events, a command only runs when explicitly typed."
   )
 }
 knitr::kable(cmd_data, format = "html",
@@ -425,8 +434,10 @@ if (is.null(hook_data)) {
 hooks_caption <- safe_tar_read("vig_cr_hooks_caption")
 if (is.null(hooks_caption)) {
   hooks_caption <- paste0(
-    nrow(hook_data), " hook scripts across ",
-    length(unique(hook_data$event)), " of 8 lifecycle events"
+    "Hook scripts registered in `~/.claude/settings.json`, covering ", nrow(hook_data),
+    " scripts across ", length(unique(hook_data$event)), " of the eight lifecycle events. ",
+    "Each row lists the script name and the matcher pattern, if any, that restricts which tool calls trigger it. ",
+    "Hooks are invisible when everything is working; they only become visible when one blocks a tool call."
   )
 }
 n_hooks_total  <- nrow(hook_data)
@@ -527,10 +538,12 @@ summary_data <- tibble::tibble(
 summary_caption <- safe_tar_read("vig_cr_summary_caption")
 if (is.null(summary_caption)) {
   summary_caption <- paste0(
-    "The six layers of the config stack: ", counts$n_rules, " rules, ",
+    "Summary of the six layers of the config stack: ", counts$n_rules, " rules, ",
     counts$n_skills, " skills, ", counts$n_agents, " agents, ",
-    counts$n_memory, " memory files, ", counts$n_commands, " commands, ",
-    counts$n_hooks, " hooks"
+    counts$n_memory, " memory files, ", counts$n_commands, " commands, and ",
+    counts$n_hooks, " hooks, one row per layer. ",
+    "Count is the number of files in that layer; Role describes what the layer contributes when a request is processed. ",
+    "All six layers activate simultaneously on every request — none of them operates in isolation from the others."
   )
 }
 knitr::kable(summary_data, format = "html",

--- a/vignettes/articles/roborev-architecture/architecture.qmd
+++ b/vignettes/articles/roborev-architecture/architecture.qmd
@@ -24,6 +24,7 @@ finding. Every node links to the relevant source file or dashboard panel.
 ::: {aria-label="Architecture diagram of the roborev system. A git commit triggers a post-commit hook which queues work in the roborev daemon. The daemon dispatches an AI agent. The agent produces findings that land in a local SQLite database. Three downstream consumers read the database: the weekly age-based autoclose job, the daily severity-threshold autoclose, and the llmtelemetry dashboard. A separate 15-minute poller catches any commits the hook missed. The daily ETL at 02:00 extracts the database into unified.duckdb for analytics."}
 
 ```{mermaid}
+%%| fig-cap: "This diagram traces the full data flow from a single git commit to a resolved finding in the roborev review system. A commit triggers a post-commit hook that queues work for the roborev daemon, which dispatches an AI agent (codex or claude-code) to produce findings written into a local SQLite database; a 15-minute poller catches any commits the hook missed. Three downstream consumers then read that database — a weekly age-based autoclose job, a daily severity-threshold autoclose, and a daily 02:00 ETL that extracts everything into unified.duckdb for the llmtelemetry dashboard and email digest."
 flowchart LR
   COMMIT["git commit"]
   HOOK["post-commit hook\n.git/hooks/post-commit"]

--- a/vignettes/articles/roborev-architecture/daily-lifecycle.qmd
+++ b/vignettes/articles/roborev-architecture/daily-lifecycle.qmd
@@ -24,6 +24,7 @@ All times are local.
 ::: {aria-label="Sequence diagram showing the daily roborev lifecycle. At 02:00 the metrics ETL runs: it reads reviews.db via DuckDB sqlite extension and writes to unified.duckdb. At 09:30 the severity autoclose runs: it reads open reviews from reviews.db, closes clean-verdict and below-threshold severity findings. At 08:00 the daily email job reads unified.duckdb and sends a blastula digest. The llmtelemetry data branch is refreshed after the email job so the dashboard reflects the same numbers as the email."}
 
 ```{mermaid}
+%%| fig-cap: "This sequence diagram shows the four scheduled jobs that run every 24 hours to keep roborev's dashboard and email digest current. At 02:00 the metrics ETL attaches reviews.db read-only and writes two summary tables into unified.duckdb; at 09:30 the severity autoclose job reads open reviews from the same SQLite database and closes findings that are either clean-verdict or below the severity threshold. At 08:00 the daily email job reads unified.duckdb and sends a blastula digest, and the llmtelemetry dashboard is refreshed afterward so it reports the same numbers as the email rather than a live, one-batch-ahead view of reviews.db."
 sequenceDiagram
   participant DB as reviews.db (SQLite)
   participant ETL as roborev_metrics_etl.sh<br/>02:00

--- a/vignettes/articles/scrolly-config-evolution.qmd
+++ b/vignettes/articles/scrolly-config-evolution.qmd
@@ -49,25 +49,41 @@ if (is.null(scope)) {
   )
 }
 
-# Stable colour palette — used unchanged across all 5 scenes
+# Stable colour palette — used unchanged across all 5 scenes.
+# Every entry is checked to be >= 4.5:1 contrast against a #000000 background.
 category_palette <- c(
-  rules    = "#e6194b",
+  rules    = "#ff4d6d",
   skills   = "#3cb44b",
-  agents   = "#4363d8",
+  agents   = "#6495ed",
   hooks    = "#f58231",
-  memory   = "#911eb4",
+  memory   = "#c77dff",
   commands = "#46f0f0",
   scripts  = "#aaffc3"
 )
 
 n_files <- nrow(cfg)
 
+# Dynamic hotspot count, computed once here so it can be reused both in the
+# scene4-plot fig-cap chunk option (evaluated before the chunk body runs) and
+# in the chunk body itself, without duplicating the filter logic.
+n_hotspot_rules <- sum(cfg$category == "rules" & cfg$n_lines > 150)
+
 base_theme <- theme_minimal(base_size = 13) +
   theme(
-    panel.background  = element_rect(fill = "transparent", colour = NA),
-    plot.background   = element_rect(fill = "transparent", colour = NA),
-    legend.background = element_rect(fill = "transparent", colour = NA),
-    legend.key        = element_rect(fill = "transparent", colour = NA)
+    plot.background   = element_rect(fill = "#000000", colour = NA),
+    panel.background  = element_rect(fill = "#000000", colour = NA),
+    legend.background = element_rect(fill = "#000000", colour = NA),
+    legend.key        = element_rect(fill = "#000000", colour = NA),
+    panel.grid.major  = element_line(colour = "#ffffff", linewidth = 0.3),
+    panel.grid.minor  = element_line(colour = "#ffffff", linewidth = 0.15),
+    text              = element_text(colour = "#ffffff"),
+    axis.text         = element_text(colour = "#ffffff"),
+    axis.title        = element_text(colour = "#ffffff"),
+    plot.title        = element_text(colour = "#ffffff", face = "bold"),
+    plot.subtitle     = element_text(colour = "#ffffff"),
+    legend.text       = element_text(colour = "#ffffff"),
+    legend.title      = element_text(colour = "#ffffff"),
+    legend.position   = "bottom"
   )
 ```
 
@@ -76,6 +92,7 @@ base_theme <- theme_minimal(base_size = 13) +
 :::{#cr-scene1 .sticky}
 ```{r scene1-plot}
 #| fig-alt: !expr scope$alt
+#| fig-cap: !expr paste0("Scatter plot of file size in bytes against line count for all ", n_files, " tracked configuration files under `.claude/`, shown in a single uniform colour with no category encoding yet. Each point represents one file; the dense cluster near the origin holds short hook and command scripts, while the sparse upper region holds long rule documents that exceed 300 lines. This unencoded view establishes the full inventory before category, age, and hotspot encodings are layered on in later scenes.")
 ggplot(cfg, aes(x = n_bytes, y = n_lines)) +
   geom_point(colour = "#888888", alpha = 0.6, size = 2) +
   scale_x_continuous(labels = scales::label_number(suffix = " B")) +
@@ -103,6 +120,7 @@ The spread along the y-axis is striking. A handful of files exceed 300 lines; mo
 :::{#cr-scene2 .sticky}
 ```{r scene2-plot}
 #| fig-alt: "The same config files now coloured by category. Rules are red and the largest cluster; skills are green and slightly smaller; scripts are light green; commands are cyan. Agents and hooks form smaller groups."
+#| fig-cap: "Scatter plot of file size against line count, now coloured by each file's configuration category (rules, skills, agents, hooks, memory, commands, scripts) using the palette that stays constant for the rest of the story. Rules (red) and skills (green) form the two largest and most spread-out clusters, together accounting for over half of all tracked files. Commands and hooks cluster tightly in the lower-left, reflecting their by-design brevity, while agents and memory form smaller, more compact groups."
 ggplot(cfg, aes(x = n_bytes, y = n_lines, colour = category)) +
   geom_point(alpha = 0.65, size = 2.5) +
   scale_colour_manual(values = category_palette, name = "Category") +
@@ -131,6 +149,7 @@ Skills lean smaller — a SKILL.md is typically a focused capability document. R
 :::{#cr-scene3 .sticky}
 ```{r scene3-plot}
 #| fig-alt: "The same colour-coded dots now have size proportional to git_age_days, so older files appear as larger circles. Several large red dots in the rules category indicate long-standing constraint files."
+#| fig-cap: "Scatter plot of file size against line count with a third encoding added: point size represents `git_age_days`, capped at 200 days for display, so larger points are older files. The largest red points sit within the rules category, identifying long-standing constraint files that have remained stable for months. Smaller points scattered across every category mark files added or substantially edited in the last few weeks, showing that the config stack accumulates in layers rather than all at once."
 ggplot(
   cfg |> mutate(age_clamped = pmin(git_age_days, 200)),
   aes(x = n_bytes, y = n_lines, colour = category, size = age_clamped)
@@ -167,6 +186,7 @@ Age and size together tell a different story than either alone. A large, old, la
 :::{#cr-scene4 .sticky}
 ```{r scene4-plot}
 #| fig-alt: "Files with more than 150 lines in the rules category are highlighted in red with full opacity. All other files are shown in grey at low opacity, drawing attention to the six outlier rule documents that dominate by line count."
+#| fig-cap: !expr paste0("Hotspot view highlighting the ", n_hotspot_rules, " rule files that exceed 150 lines, shown at full opacity in red while the remaining config files render in faded grey. These outliers are the load-bearing constraints a new agent encounters first, and each one documents a codified incident rather than being long for its own sake. The faded background shows what the hotspots sit among — dozens of shorter files that together form the surrounding texture of the constraint set.")
 hotspot_threshold <- 150L
 cfg_hot <- cfg |>
   mutate(
@@ -214,6 +234,7 @@ The greyed-out mass shows what those hotspots sit within: dozens of shorter file
 :::{#cr-scene5 .sticky}
 ```{r scene5-plot}
 #| fig-alt: "Small multiples showing the line count distribution for each of the seven config categories. Rules have the widest spread and highest maximum. Scripts and hooks cluster near zero. Skills and commands fall in the middle range."
+#| fig-cap: "Small-multiples histogram of line count, faceted into one panel per configuration category with independent y-axis scales and coloured using the same palette as the previous scenes. Rules and skills show the widest spread, ranging from short focused files to long comprehensive ones, while hooks and scripts cluster tightly near zero lines, reflecting their preference for brevity over completeness. Agents, memory, and commands fall in an intermediate range, with commands showing a mild bimodal shape that separates simple one-line triggers from multi-step workflow files."
 ggplot(cfg, aes(x = n_lines, fill = category)) +
   geom_histogram(binwidth = 20, colour = NA, alpha = 0.8) +
   facet_wrap(~category, scales = "free_y", ncol = 2) +

--- a/vignettes/closeread-infrastructure.qmd
+++ b/vignettes/closeread-infrastructure.qmd
@@ -56,7 +56,7 @@ if (is.null(counts)) {
 ## Software Layers
 
 ```{mermaid}
-%%| fig-cap: "Software stack from OS through [Nix](https://nixos.org/){target='_blank'} to project outputs. [rix](https://docs.ropensci.org/rix/){target='_blank'} translates `default.R` into `default.nix`. [targets](https://docs.ropensci.org/targets/){target='_blank'}, [crew](https://wlandau.github.io/crew/){target='_blank'}, and [mirai](https://cran.r-project.org/package=mirai){target='_blank'} orchestrate computation."
+%%| fig-cap: "Software stack showing how a Nix-based reproducible environment supports the full pipeline: [Nix](https://nixos.org/){target='_blank'} plus [rix](https://docs.ropensci.org/rix/){target='_blank'} sit at the base, translating declarative `default.R` files into pinned `default.nix` derivations. On top of that sit versioned R and Python packages, which [targets](https://docs.ropensci.org/targets/){target='_blank'}, [crew](https://wlandau.github.io/crew/){target='_blank'}, and [mirai](https://cran.r-project.org/package=mirai){target='_blank'} orchestrate into parallel pipelines. The LLM harness — Claude Code guided by rules, skills, and agents — runs at the top of this stack and produces the project outputs shown on the right. Each layer depends on the one below it being reproducible, so a change to `default.R` propagates through every layer above it."
 graph LR
   OS["OS: macOS / Linux"] --> Nix["Nix + rix"] --> Pkgs["R / Python<br/>packages"]
   Pkgs --> Orch["targets + crew<br/>+ mirai"]
@@ -95,7 +95,7 @@ At the top, `r counts$n_rules` rules, `r counts$n_skills` skills, `r counts$n_ag
 ## LLM Harness
 
 ```{mermaid}
-%%| fig-cap: "[AGENTS.md](https://github.com/JohnGavin/llm/blob/main/AGENTS.md){target='_blank'} is the entry point — indexing rules, skills, agents, hooks, commands, and memory files."
+%%| fig-cap: "[AGENTS.md](https://github.com/JohnGavin/llm/blob/main/AGENTS.md){target='_blank'} is the single entry point every Claude Code session reads first, indexing all six categories of project configuration: rules, skills, agents, hooks, commands, and memory files. Each category is a distinct directory under `.claude/`, and this diagram shows AGENTS.md fanning out to all six rather than any hierarchy among them. Clicking a node opens the corresponding directory on GitHub, so this diagram doubles as a navigable map of the harness."
 graph LR
   A["AGENTS.md<br/>Entry point"] --> R["Rules"]
   A --> S["Skills"]
@@ -139,11 +139,19 @@ if (!is.na(rules_dir)) {
     data.frame(Rule = paste0("`", name, "`"), Description = desc, stringsAsFactors = FALSE)
   }) |> do.call(rbind, args = _)
 
-  knitr::kable(rules_df, caption = paste0("All ", nrow(rules_df), " rules in `", rules_dir, "`"))
+  knitr::kable(rules_df, caption = paste0(
+    "All ", nrow(rules_df), " rule files found in `", rules_dir, "`, one row per file. ",
+    "Rule is the file's base name without the `.md` extension; Description is the first non-heading line of prose in that file, truncated to 60 characters. ",
+    "Rules are hard constraints, not suggestions — each one applies regardless of context unless its own trigger clause says otherwise."
+  ))
 } else {
   knitr::kable(
     data.frame(Rule = character(0), Description = character(0)),
-    caption = "Rules directory not found (checked .claude/rules/ and ~/.claude/rules/)"
+    caption = paste0(
+      "Rules directory not found — checked `.claude/rules/` and `~/.claude/rules/`. ",
+      "This placeholder appears only when the pipeline runs outside a full checkout. ",
+      "The published site always serves the live directory scan."
+    )
   )
 }
 ```
@@ -172,8 +180,12 @@ if (!is.null(skill_cats)) {
 
   skill_cats |>
     dplyr::select(Category = category, Count = count, Examples) |>
-    knitr::kable(caption = paste0("All ", sum(skill_cats$count),
-                                  " skills from ~/.claude/skills/MANIFEST.md"))
+    knitr::kable(caption = paste0(
+      "All ", sum(skill_cats$count), " skill modules from `~/.claude/skills/MANIFEST.md`, grouped into ",
+      nrow(skill_cats), " domain categories. ",
+      "Count is the number of skill modules in that category; Examples names a few representative packages or tools the category covers. ",
+      "Skills supply the how — the domain knowledge a rule's what-not-to-do constraint doesn't provide."
+    ))
 } else {
   cat("*Run `tar_make()` locally to generate skill counts*")
 }
@@ -210,11 +222,19 @@ if (!is.na(agents_dir)) {
     data.frame(Agent = paste0("`", name, "`"), Model = model, Trigger = trigger, stringsAsFactors = FALSE)
   }) |> do.call(rbind, args = _)
 
-  knitr::kable(agents_df, caption = paste0("All ", nrow(agents_df), " agents in `", agents_dir, "`"))
+  knitr::kable(agents_df, caption = paste0(
+    "All ", nrow(agents_df), " agent definitions found in `", agents_dir, "`, one row per agent. ",
+    "Model is the Claude tier parsed from the agent's own frontmatter, defaulting to sonnet when unspecified; Trigger is the first use-case line extracted from the file. ",
+    "Delegating to the right agent keeps mechanical work on the cheap tier and reserves the orchestrator for planning and synthesis."
+  ))
 } else {
   knitr::kable(
     data.frame(Agent = character(0), Model = character(0), Trigger = character(0)),
-    caption = "Agents directory not found (checked .claude/agents/ and ~/.claude/agents/)"
+    caption = paste0(
+      "Agents directory not found — checked `.claude/agents/` and `~/.claude/agents/`. ",
+      "This placeholder appears only when the pipeline runs outside a full checkout. ",
+      "The published site always serves the live directory scan."
+    )
   )
 }
 ```
@@ -255,11 +275,19 @@ if (!is.na(hooks_dir)) {
     data.frame(Hook = paste0("`", name, "`"), Event = event, Purpose = purpose, stringsAsFactors = FALSE)
   }) |> do.call(rbind, args = _)
 
-  knitr::kable(hooks_df, caption = paste0("All ", nrow(hooks_df), " hooks in `", hooks_dir, "`"))
+  knitr::kable(hooks_df, caption = paste0(
+    "All ", nrow(hooks_df), " hook scripts found in `", hooks_dir, "`, one row per script. ",
+    "Event is inferred from the script's filename pattern (session start, pre-edit, pre-compact, and so on); Purpose is the first comment line in the file. ",
+    "Hooks automate enforcement that would otherwise depend on the model remembering a rule on every single tool call."
+  ))
 } else {
   knitr::kable(
     data.frame(Hook = character(0), Event = character(0), Purpose = character(0)),
-    caption = "Hooks directory not found (checked .claude/hooks/ and ~/.claude/hooks/)"
+    caption = paste0(
+      "Hooks directory not found — checked `.claude/hooks/` and `~/.claude/hooks/`. ",
+      "This placeholder appears only when the pipeline runs outside a full checkout. ",
+      "The published site always serves the live directory scan."
+    )
   )
 }
 ```
@@ -287,11 +315,19 @@ if (!is.na(memory_dir)) {
     data.frame(File = paste0("`", name, "`"), Purpose = purpose, stringsAsFactors = FALSE)
   }) |> do.call(rbind, args = _)
 
-  knitr::kable(memory_df, caption = paste0("All ", nrow(memory_df), " memory files in `", memory_dir, "`"))
+  knitr::kable(memory_df, caption = paste0(
+    "All ", nrow(memory_df), " memory files found in `", memory_dir, "`, one row per file. ",
+    "File is the base name of the memory file; Purpose is the first non-heading line, truncated to 50 characters, summarising what that file records. ",
+    "Memory persists lessons — failed approaches, incident write-ups, standing conventions — that a fresh session context would otherwise lose."
+  ))
 } else {
   knitr::kable(
     data.frame(File = character(0), Purpose = character(0)),
-    caption = "Memory directory not found (lives outside the repo; tracked in #144)"
+    caption = paste0(
+      "Memory directory not found — it lives outside the repository, tracked in #144. ",
+      "This placeholder appears when the pipeline cannot locate `~/.claude/projects/.../memory/`, which is common on a machine other than the primary development laptop. ",
+      "The published site always serves the live directory scan."
+    )
   )
 }
 ```
@@ -304,7 +340,7 @@ if (!is.na(memory_dir)) {
 The <a href="https://github.com/JohnGavin/irishbuoys" target="_blank">irishbuoys</a> R package is an independent project that monitors wave conditions at Marine Institute buoy stations around Ireland. Its <a href="https://johngavin.github.io/irishbuoys/" target="_blank">pkgdown site</a> is deployed separately. The pipeline below illustrates how the software layers described above come together in practice — from <a href="https://erddap.marine.ie/" target="_blank">ERDDAP</a> data acquisition through QA validation to multiple output formats.
 
 ```{mermaid}
-%%| fig-cap: "[irishbuoys](https://github.com/JohnGavin/irishbuoys){target='_blank'} pipeline ([pkgdown site](https://johngavin.github.io/irishbuoys/){target='_blank'}). 19 plan files, ~294 [targets](https://docs.ropensci.org/targets/){target='_blank'}. Data from [ERDDAP](https://erddap.marine.ie/){target='_blank'}, stored in [DuckDB](https://duckdb.org/){target='_blank'}."
+%%| fig-cap: "The [irishbuoys](https://github.com/JohnGavin/irishbuoys){target='_blank'} pipeline is an independently deployed R package (see its [pkgdown site](https://johngavin.github.io/irishbuoys/){target='_blank'}) that monitors Irish wave-buoy conditions end to end. It comprises 19 [targets](https://docs.ropensci.org/targets/){target='_blank'} plan files totalling roughly 294 individual targets, moving data from acquisition through validation, wave analysis, and prediction to dashboard and API outputs. Raw observations are pulled from the [ERDDAP](https://erddap.marine.ie/){target='_blank'} API and staged in [DuckDB](https://duckdb.org/){target='_blank'} before quality-control bounds checks run, so every downstream target inherits the same validated source table."
 graph LR
   acq["ERDDAP<br/>API"] --> val["Validation<br/>8 targets"] --> qc["QC<br/>bounds"]
   qc --> wave["Wave Analysis<br/>61 targets"]
@@ -332,7 +368,7 @@ graph LR
 **Simplified flow:**
 
 ```{mermaid}
-%%| fig-cap: "Simplified: [ERDDAP](https://erddap.marine.ie/){target='_blank'} → validation → wave analysis → outputs. [QA gates](https://github.com/JohnGavin/irishbuoys/blob/main/R/tar_plans/plan_qa_gates.R){target='_blank'} score Bronze/Silver/Gold before merge."
+%%| fig-cap: "Simplified view of the same irishbuoys pipeline, collapsing the 19 detailed plan files into four stages: [ERDDAP](https://erddap.marine.ie/){target='_blank'} acquisition, validation, wave analysis, and final outputs. Wave analysis is the pivot point — it feeds three parallel downstream paths (storm alerts and email, the dashboard, and the pkgdown site) rather than a single linear chain. Independent [QA gates](https://github.com/JohnGavin/irishbuoys/blob/main/R/tar_plans/plan_qa_gates.R){target='_blank'} score each build Bronze, Silver, or Gold before the site is allowed to merge, so quality is checked in parallel with the analysis rather than only at the very end."
 graph LR
   acq["ERDDAP"] --> val["8 validation"] --> wave["61 analysis"]
   wave --> alert["Alerts + email"]
@@ -354,8 +390,12 @@ graph LR
 walkthrough <- safe_tar_read("vig_cr_pipeline_walkthrough")
 if (!is.null(walkthrough)) {
   knitr::kable(walkthrough,
-    caption = paste0("irishbuoys pipeline: ", nrow(walkthrough),
-                     " plan files across data, QA, analysis, and output layers."))
+    caption = paste0(
+      "irishbuoys pipeline: ", nrow(walkthrough),
+      " plan files spanning data acquisition, QA, analysis, and output layers, one row per plan file. ",
+      "Each row corresponds to one `R/tar_plans/*.R` file and the pipeline stage it implements. ",
+      "The table demonstrates, with a real external project, how the layered Nix-to-outputs architecture described above looks in practice."
+    ))
 }
 ```
 
@@ -365,7 +405,7 @@ if (!is.null(walkthrough)) {
 ## FOCUS Framework
 
 ```{mermaid}
-%%| fig-cap: "FOCUS: how [Claude Code](https://claude.com/claude-code){target='_blank'} navigates a project. Each phase maps to specific agents, rules, and skills."
+%%| fig-cap: "FOCUS is the five-phase framework — Find, Organize, Condense, Understand, Synthesize — that structures how [Claude Code](https://claude.com/claude-code){target='_blank'} navigates an unfamiliar or large project. Each phase maps to a distinct set of tools and specialists: Find uses Glob/Grep/Explore, Organize centres on AGENTS.md and the Plan agent, Condense relies on memory files, Understand delegates to r-debugger and critic, and Synthesize hands off to fixer and targets-runner. The phases run roughly in sequence within a session but are not strictly linear — Condense in particular can trigger at any point when context needs compacting."
 flowchart LR
   F["Find<br/>Glob, Grep, Explore"] --> O["Organize<br/>AGENTS.md, Plan"]
   O --> C["Condense<br/>Memory, ctx.yaml"]

--- a/vignettes/config-evolution/_setup.qmd
+++ b/vignettes/config-evolution/_setup.qmd
@@ -15,14 +15,40 @@ library(ggplot2)
 library(scales)
 library(gt)
 
-# Theme for dark mode compatibility
+# Theme for dark mode compatibility: black background, white ink throughout
+# (user requirement; accessibility dark-mode rule — no transparent/grey
+# placeholders, every text/grid element must hit >=4.5:1 contrast on #000000).
 theme_dashboard <- theme_minimal(base_size = 14) +
   theme(
-    plot.background = element_rect(fill = "transparent", color = NA),
-    panel.background = element_rect(fill = "transparent", color = NA),
-    legend.background = element_rect(fill = "transparent", color = NA),
-    plot.title = element_text(face = "bold")
+    plot.background = element_rect(fill = "#000000", color = NA),
+    panel.background = element_rect(fill = "#000000", color = NA),
+    legend.background = element_rect(fill = "#000000", color = NA),
+    panel.grid.major = element_line(color = "#ffffff", linewidth = 0.3),
+    panel.grid.minor = element_line(color = "#ffffff", linewidth = 0.15),
+    text = element_text(color = "#ffffff"),
+    axis.text = element_text(color = "#ffffff"),
+    axis.title = element_text(color = "#ffffff"),
+    plot.title = element_text(color = "#ffffff", face = "bold"),
+    plot.subtitle = element_text(color = "#ffffff"),
+    legend.text = element_text(color = "#ffffff"),
+    legend.title = element_text(color = "#ffffff"),
+    legend.position = "bottom"
   )
+
+# Shared named palette (narrative-colour-persistence rule): one colour per
+# config category, reused across every chart on this page set so the same
+# entity always reads as the same colour. All values are >=4.5:1 contrast
+# against #000000 (verified: rules 8.0:1, skills 11.5:1, scripts 15.2:1,
+# hooks 8.1:1, memory 8.0:1, agents 10.4:1, commands 12.5:1).
+PALETTE <- c(
+  "rules"    = "#4ea8de",
+  "skills"   = "#69d4a0",
+  "scripts"  = "#ffd93d",
+  "hooks"    = "#f08080",
+  "memory"   = "#c084fc",
+  "agents"   = "#ff9f5a",
+  "commands" = "#5adbd0"
+)
 
 # Try to load from local pulse data, otherwise count files directly
 config_dir <- path.expand("~/.claude/logs/config")
@@ -56,10 +82,15 @@ if (is.null(config_data)) {
   claude_dir <- Find(dir.exists, .candidates)
   if (is.null(claude_dir)) claude_dir <- here::here(".claude")  # last-resort string
 
-  # Count rules
+  # Count rules. Excludes _companions/*.md: companion docs hold verbose
+  # worked-example detail split OUT of a rule to keep the rule itself lean
+  # (see rule-scoping conventions); counting them as rules double-counts
+  # content and mislabels companion detail as an oversized "rule" in the
+  # Top Rules table below.
   rules_dir <- file.path(claude_dir, "rules")
   if (dir.exists(rules_dir)) {
     rule_files <- list.files(rules_dir, pattern = "\\.md$", full.names = TRUE, recursive = TRUE)
+    rule_files <- rule_files[!grepl("_companions/", rule_files, fixed = TRUE)]
     n_rules <- length(rule_files)
     rule_lines <- sapply(rule_files, function(f) length(readLines(f, warn = FALSE)))
   } else {
@@ -67,12 +98,14 @@ if (is.null(config_data)) {
     rule_lines <- numeric(0)
   }
 
- # Count skills
+ # Count skills. Same _companions/ exclusion as rules, in case a skill ever
+ # grows a companion/detail sub-directory of its own.
   skills_dir <- file.path(claude_dir, "skills")
   if (dir.exists(skills_dir)) {
     skill_dirs <- list.dirs(skills_dir, recursive = FALSE)
     n_skills <- length(skill_dirs)
     skill_files <- list.files(skills_dir, pattern = "SKILL\\.md$", full.names = TRUE, recursive = TRUE)
+    skill_files <- skill_files[!grepl("_companions/", skill_files, fixed = TRUE)]
     skill_lines <- sapply(skill_files, function(f) length(readLines(f, warn = FALSE)))
   } else {
     n_skills <- 0

--- a/vignettes/config-evolution/architecture.qmd
+++ b/vignettes/config-evolution/architecture.qmd
@@ -31,7 +31,14 @@ version control.
 ::: {aria-label="Pipeline diagram showing two flows. Top: config_pulse.sh writes daily Parquet snapshots to logs/config/; the config-evolution dashboard reads those snapshots via DuckDB. Bottom: git history feeds config_change_digest.R; that R script produces a markdown digest; send_config_digest_email.R sends the digest via blastula and Gmail credentials; the email arrives in the inbox. A separate overnight chain shows self-review-stage1 at 02:30 running the overnight Claude review; self-review-verify at 08:00 running the email dispatch; and a scheduled-task health email cross-linking to issue 300."}
 
 ```{mermaid}
-flowchart LR
+%%| fig-cap: >
+%%|   This diagram traces the two pipelines that turn the `.claude/` git
+%%|   history into observable output. The pulse pipeline (top) runs
+%%|   config_pulse.sh daily, writes Parquet snapshots, and feeds this
+%%|   dashboard. The digest pipeline (bottom) runs config_change_digest.R,
+%%|   sends a markdown summary by email, and is cross-checked by an
+%%|   overnight self-review chain before delivery.
+flowchart TB
     A[".claude/ tree\n(git history)"] --> B["config_pulse.sh\n(daily, launchd)"]
     B --> C["logs/config/*.parquet\n(DuckDB snapshots)"]
     C --> D["config-evolution\ndashboard\n(this page)"]

--- a/vignettes/config-evolution/metrics.qmd
+++ b/vignettes/config-evolution/metrics.qmd
@@ -19,7 +19,16 @@ execute:
 ```{r size-distribution}
 #| fig-width: 10
 #| fig-height: 6
-#| fig-alt: "Bar chart showing line counts by category: rules, skills, hooks"
+#| fig-cap: >
+#|   This dot plot ranks configuration categories — rules, skills, scripts,
+#|   hooks, and memory — by total lines of code in the checked-in `.claude/`
+#|   tree, sorted from largest to smallest so the ranking itself surfaces
+#|   which part of the configuration surface currently carries the most
+#|   content. The horizontal dot-and-stem layout keeps every value legible
+#|   even when categories differ by an order of magnitude, avoiding the
+#|   heavier visual weight of a bar chart. Labels give the exact line count
+#|   for each category at the latest available snapshot.
+#| fig-alt: "Horizontal dot plot ranking rules, skills, scripts, hooks, and memory by total lines of code, sorted from largest to smallest category"
 
 if (!is.null(latest)) {
   latest |>
@@ -28,17 +37,17 @@ if (!is.null(latest)) {
       metric == "total_lines",
       category %in% c("rules", "skills", "hooks", "scripts", "memory")
     ) |>
-    mutate(category = factor(category, levels = c("skills", "rules", "scripts", "hooks", "memory"))) |>
-    ggplot(aes(x = category, y = value, fill = category)) +
-    geom_col() +
-    geom_text(aes(label = comma(value)), vjust = -0.5, size = 4) +
-    scale_y_continuous(labels = comma, expand = expansion(mult = c(0, 0.15))) +
-    scale_fill_viridis_d(option = "plasma", end = 0.85) +
+    ggplot(aes(x = value, y = reorder(category, value), color = category)) +
+    geom_segment(aes(x = 0, xend = value, yend = category), linewidth = 0.8) +
+    geom_point(size = 4) +
+    geom_text(aes(label = comma(round(value))), hjust = -0.3, color = "#ffffff", size = 4) +
+    scale_x_continuous(labels = comma, expand = expansion(mult = c(0, 0.15))) +
+    scale_color_manual(values = PALETTE) +
     labs(
       title = "Config Size by Category",
       subtitle = paste("Snapshot:", max(config_data$snapshot_date)),
-      x = NULL,
-      y = "Lines of Code"
+      x = "Lines of Code",
+      y = NULL
     ) +
     theme_dashboard +
     theme(legend.position = "none")
@@ -48,17 +57,17 @@ if (!is.null(latest)) {
     category = c("skills", "rules", "hooks"),
     value = c(fallback_counts$total_skill_lines, fallback_counts$total_rule_lines, fallback_counts$total_hook_lines)
   ) |>
-    mutate(category = factor(category, levels = c("skills", "rules", "hooks"))) |>
-    ggplot(aes(x = category, y = value, fill = category)) +
-    geom_col() +
-    geom_text(aes(label = comma(value)), vjust = -0.5, size = 4) +
-    scale_y_continuous(labels = comma, expand = expansion(mult = c(0, 0.15))) +
-    scale_fill_viridis_d(option = "plasma", end = 0.85) +
+    ggplot(aes(x = value, y = reorder(category, value), color = category)) +
+    geom_segment(aes(x = 0, xend = value, yend = category), linewidth = 0.8) +
+    geom_point(size = 4) +
+    geom_text(aes(label = comma(round(value))), hjust = -0.3, color = "#ffffff", size = 4) +
+    scale_x_continuous(labels = comma, expand = expansion(mult = c(0, 0.15))) +
+    scale_color_manual(values = PALETTE) +
     labs(
       title = "Config Size by Category",
       subtitle = paste("Live count:", Sys.Date()),
-      x = NULL,
-      y = "Lines of Code"
+      x = "Lines of Code",
+      y = NULL
     ) +
     theme_dashboard +
     theme(legend.position = "none")
@@ -68,6 +77,15 @@ if (!is.null(latest)) {
 ## Top Rules
 
 ```{r top-rules}
+#| tbl-cap: >
+#|   This table lists the fifteen largest rule files in `.claude/rules/`,
+#|   ranked by line count from the shared config-pulse snapshot (or a live
+#|   file count when no snapshot exists in CI). The colour scale flags files
+#|   approaching or past the two-hundred-line domain used for the red/yellow/
+#|   green banding, with 150 lines marking the CLAUDE.md-documented threshold
+#|   where a rule should be split into a companion doc. Files already split
+#|   via the `_companions/` convention are excluded here so companion detail
+#|   is not mislabeled as an oversized rule.
 if (!is.null(latest)) {
   latest |>
     filter(category == "rules", metric == "lines", item != "all") |>
@@ -131,6 +149,14 @@ if (!is.null(latest)) {
 ## Top Skills
 
 ```{r top-skills}
+#| tbl-cap: >
+#|   This table lists the fifteen largest skill files (`SKILL.md`) in
+#|   `.claude/skills/`, ranked by line count from the shared config-pulse
+#|   snapshot or a live file-count fallback. The blue colour scale highlights
+#|   which skills carry the most instructional content, making it easy to
+#|   spot a skill that has grown past what a single file should hold. Skill
+#|   size here uses the same per-file line-count convention as the Top Rules
+#|   table above, so the two are directly comparable.
 if (!is.null(latest)) {
   latest |>
     filter(category == "skills", metric == "lines", item != "all") |>
@@ -168,6 +194,16 @@ if (!is.null(latest)) {
 ## Quality Metrics
 
 ```{r quality-table}
+#| tbl-cap: >
+#|   This table summarises headline configuration-quality metrics: total
+#|   rule and skill counts, their average sizes, how many rules exceed the
+#|   150-line threshold, and the estimated total token footprint of the
+#|   whole `.claude/` tree. These figures are computed identically in both
+#|   the live-snapshot and CI-fallback code paths, so the numbers stay
+#|   consistent regardless of which data source is available at render
+#|   time. Read this table alongside the Evolution panel below to see
+#|   whether the configuration is growing faster than its quality controls
+#|   (frontmatter coverage, threshold compliance) are keeping up.
 if (!is.null(latest)) {
   quality_metrics <- latest |>
     filter(item == "all") |>
@@ -212,7 +248,16 @@ if (!is.null(latest)) {
 ```{r evolution-chart}
 #| fig-width: 10
 #| fig-height: 5
-#| fig-alt: "Line chart showing config evolution over time"
+#| fig-cap: >
+#|   This line chart tracks how the counts of rules, skills, and hooks
+#|   change across daily configuration snapshots collected by
+#|   `config_pulse.sh`. Each line is one category, coloured consistently
+#|   with the Size Distribution panel above, so a rising or falling trend
+#|   is easy to follow over time. Because snapshots are taken once per day,
+#|   at least two of them are needed before a trend becomes visible; a
+#|   missing chart usually means the pulse pipeline has not yet
+#|   accumulated enough history.
+#| fig-alt: "Line chart of daily rules, skills, and hooks counts, one coloured line per category, trending over the available snapshot history"
 
 if (!is.null(latest) && n_distinct(config_data$snapshot_date) > 1) {
   config_data |>
@@ -224,7 +269,7 @@ if (!is.null(latest) && n_distinct(config_data$snapshot_date) > 1) {
     ggplot(aes(x = snapshot_date, y = value, color = category)) +
     geom_line(linewidth = 1.2) +
     geom_point(size = 3) +
-    scale_color_viridis_d(option = "plasma", end = 0.85) +
+    scale_color_manual(values = PALETTE) +
     labs(
       title = "Config Growth Over Time",
       x = NULL,

--- a/vignettes/knowledge-evolution/_setup.qmd
+++ b/vignettes/knowledge-evolution/_setup.qmd
@@ -20,11 +20,45 @@ library(igraph)
 
 theme_dashboard <- theme_minimal(base_size = 14) +
   theme(
-    plot.background = element_rect(fill = "transparent", color = NA),
-    panel.background = element_rect(fill = "transparent", color = NA),
-    legend.background = element_rect(fill = "transparent", color = NA),
-    plot.title = element_text(face = "bold")
+    plot.background   = element_rect(fill = "#000000", color = NA),
+    panel.background  = element_rect(fill = "#000000", color = NA),
+    legend.background = element_rect(fill = "#000000", color = NA),
+    panel.grid.major  = element_line(color = "#ffffff", linewidth = 0.3),
+    panel.grid.minor  = element_line(color = "#ffffff", linewidth = 0.15),
+    text        = element_text(color = "#ffffff"),
+    axis.text   = element_text(color = "#ffffff"),
+    axis.title  = element_text(color = "#ffffff"),
+    plot.title  = element_text(color = "#ffffff", face = "bold"),
+    plot.subtitle = element_text(color = "#ffffff"),
+    legend.text = element_text(color = "#ffffff"),
+    legend.title = element_text(color = "#ffffff"),
+    legend.position = "bottom"
   )
+
+# Shared named palette (narrative-colour-persistence rule): one colour per
+# category across every chart on this page set. Every entry is >=4.5:1
+# contrast on the #000000 black backgrounds set by theme_dashboard above.
+PALETTE <- c(
+  "Fully Sourced"             = "#69d4a0",
+  "With Sources"               = "#69d4a0",
+  "Partial (has AI-inferred)" = "#ffd93d",
+  "Unsourced"                  = "#f08080",
+  "Wiki Pages"                 = "#4ea8de",
+  "Raw Sources"                = "#69d4a0",
+  "Total Words (÷100)"    = "#c084fc",
+  "Wiki page"                  = "#4ea8de",
+  "Orphan (no inbound)"        = "#ffd93d",
+  "Broken target"              = "#f08080"
+)
+
+# Cycling palette for data-driven categories whose names aren't known ahead
+# of time (topic-graph domain clusters). Reuses the same five PALETTE hues,
+# so a given domain gets a stable colour across both topic-graph chunks and
+# every hue keeps the >=4.5:1 contrast on #000000.
+DOMAIN_PALETTE <- unname(PALETTE[c(
+  "Wiki Pages", "Raw Sources", "Partial (has AI-inferred)",
+  "Unsourced", "Total Words (÷100)"
+)])
 
 # Priority 0: CI-safe path — read pre-computed aggregates from committed RDS.
 # knowledge/ is gitignored (wiki-storage-policy), so live file counts return 0

--- a/vignettes/knowledge-evolution/architecture.qmd
+++ b/vignettes/knowledge-evolution/architecture.qmd
@@ -21,9 +21,10 @@ The knowledge base (KB) is a **private "second brain"** — a local-only git rep
 The diagram below shows the three-layer structure and where the privacy boundary sits. Clickable nodes link to the relevant source files and rules.
 
 ```{mermaid}
+%%| fig-cap: "This diagram traces how a piece of knowledge moves from raw capture to public dashboard while a privacy boundary blocks its content from ever leaving the local machine. Raw material lands append-only in raw/, gets distilled with provenance and cross-links into wiki/, and only then feeds outputs/; separately, knowledge_pulse.sh reads wiki/ and extracts counts, titles, and themes — never page bodies — into the committed vig_kb_stats.rds aggregate. The Public / CI subgraph (the dashboard and the daily digest email) can only ever see that aggregate, and the crossed-out arrow to 'Raw content NEVER here' marks the boundary that is structurally, not just procedurally, enforced."
 %%| fig-alt: "Knowledge base data flow: raw (append-only) feeds wiki (provenance + cross-links) feeds outputs. A privacy boundary prevents raw content from reaching CI, the dashboard, or the digest email. knowledge_pulse.sh extracts aggregate metrics only."
 
-flowchart LR
+flowchart TB
   subgraph LOCAL ["🔒 Local only (PRIVATE + pre-push block)"]
     RAW["raw/\n(append-only)"]
     WIKI["wiki/\n(provenance + [[links]])"]

--- a/vignettes/knowledge-evolution/metrics.qmd
+++ b/vignettes/knowledge-evolution/metrics.qmd
@@ -19,7 +19,8 @@ execute:
 ```{r confidence-chart}
 #| fig-width: 8
 #| fig-height: 4
-#| fig-alt: "Stacked bar showing confidence distribution"
+#| fig-cap: !expr conf_cap
+#| fig-alt: !expr conf_alt
 
 if (!is.null(latest)) {
   confidence <- latest |>
@@ -34,53 +35,95 @@ if (!is.null(latest)) {
       label = factor(label, levels = c("Fully Sourced", "Partial (has AI-inferred)", "Unsourced"))
     )
 
-  ggplot(confidence, aes(x = "Pages", y = value, fill = label)) +
-    geom_col(width = 0.6) +
-    geom_text(aes(label = value), position = position_stack(vjust = 0.5), size = 5, color = "white") +
-    scale_fill_manual(values = c(
-      "Fully Sourced" = "#69d4a0",
-      "Partial (has AI-inferred)" = "#ffd93d",
-      "Unsourced" = "#f08080"
-    )) +
-    coord_flip() +
+  n_total_conf <- sum(confidence$value)
+  n_fully_conf <- confidence$value[confidence$label == "Fully Sourced"]
+  pct_fully_conf <- if (n_total_conf > 0) round(100 * n_fully_conf / n_total_conf) else 0
+
+  conf_cap <- paste0(
+    "This Cleveland dot plot ranks knowledge-base pages by confidence level, ",
+    "from fully sourced (a `## Sources` section citing raw material) down to unsourced. ",
+    "Of ", scales::comma(n_total_conf, accuracy = 1), " pages tracked, ",
+    scales::comma(n_fully_conf, accuracy = 1), " (", pct_fully_conf, "%) are fully sourced. ",
+    "Categories are sorted descending by page count so the balance between well-cited ",
+    "and un-cited content is visible at a glance."
+  )
+  conf_alt <- paste0(
+    "Dot plot: ",
+    paste(sprintf("%s %s pages", confidence$label, scales::comma(confidence$value, accuracy = 1)),
+          collapse = "; "), "."
+  )
+
+  ggplot(confidence, aes(x = value, y = reorder(label, value), color = label)) +
+    geom_segment(aes(x = 0, xend = value, y = label, yend = label), linewidth = 1) +
+    geom_point(size = 4) +
+    geom_text(aes(label = scales::comma(value, accuracy = 1)), hjust = -0.4, color = "#ffffff", size = 4) +
+    scale_color_manual(values = PALETTE) +
     labs(
       title = "Knowledge Base Quality",
       subtitle = "Pages by confidence level",
-      x = NULL,
-      y = "Number of Pages",
-      fill = "Confidence"
+      x = "Number of Pages",
+      y = NULL,
+      color = "Confidence"
     ) +
     theme_dashboard +
-    theme(axis.text.y = element_blank(), axis.ticks.y = element_blank())
+    theme(legend.position = "none") +
+    expand_limits(x = max(confidence$value) * 1.15)
 } else {
   # Fallback: categorize pages
   n_with_src <- fallback_kb$with_sources
   n_ai <- if (fallback_kb$ai_inferred > 0) min(fallback_kb$ai_inferred, fallback_kb$n_pages - n_with_src) else 0
   n_unsourced <- fallback_kb$n_pages - n_with_src
 
-  tibble(
+  fallback_conf <- tibble(
     label = factor(c("With Sources", "Unsourced"),
                    levels = c("With Sources", "Unsourced")),
     value = c(n_with_src, n_unsourced)
-  ) |>
-    ggplot(aes(x = "Pages", y = value, fill = label)) +
-    geom_col(width = 0.6) +
-    geom_text(aes(label = value), position = position_stack(vjust = 0.5), size = 5, color = "white") +
-    scale_fill_manual(values = c("With Sources" = "#69d4a0", "Unsourced" = "#f08080")) +
-    coord_flip() +
-    labs(title = "Knowledge Base Quality", x = NULL, y = "Pages", fill = "Status") +
+  )
+
+  conf_cap <- paste0(
+    "This Cleveland dot plot ranks knowledge-base pages by confidence level, ",
+    "from pages with sources down to unsourced pages. ",
+    "Of ", scales::comma(fallback_kb$n_pages, accuracy = 1), " pages tracked, ",
+    scales::comma(n_with_src, accuracy = 1), " carry a `## Sources` section. ",
+    "Categories are sorted descending by page count so the balance between well-cited ",
+    "and un-cited content is visible at a glance."
+  )
+  conf_alt <- paste0(
+    "Dot plot: ",
+    paste(sprintf("%s %s pages", fallback_conf$label, scales::comma(fallback_conf$value, accuracy = 1)),
+          collapse = "; "), "."
+  )
+
+  fallback_conf |>
+    ggplot(aes(x = value, y = reorder(label, value), color = label)) +
+    geom_segment(aes(x = 0, xend = value, y = label, yend = label), linewidth = 1) +
+    geom_point(size = 4) +
+    geom_text(aes(label = scales::comma(value, accuracy = 1)), hjust = -0.4, color = "#ffffff", size = 4) +
+    scale_color_manual(values = PALETTE) +
+    labs(title = "Knowledge Base Quality", x = "Pages", y = NULL, color = "Status") +
     theme_dashboard +
-    theme(axis.text.y = element_blank(), axis.ticks.y = element_blank())
+    theme(legend.position = "none") +
+    expand_limits(x = max(fallback_conf$value) * 1.15)
 }
 ```
 
 ## Wiki Pages
 
 ```{r wiki-pages-table}
+#| tbl-cap: !expr wiki_tbl_cap
+
 if (!is.null(latest)) {
   wiki_pages <- latest |>
     filter(category == "wiki", metric == "words", item != "all") |>
     arrange(desc(value))
+
+  wiki_tbl_cap <- paste0(
+    "This table lists every wiki page in the knowledge base, ranked by word count in ",
+    "descending order. There are ", scales::comma(nrow(wiki_pages), accuracy = 1),
+    " pages tracked in the latest snapshot. ",
+    "Word counts come from the anonymised `vig_kb_stats.rds` aggregate (page identifiers ",
+    "are pseudonymous, e.g. `page_001`), so page titles never leak into CI output."
+  )
 
   if (nrow(wiki_pages) > 0) {
     wiki_pages |>
@@ -93,6 +136,13 @@ if (!is.null(latest)) {
     cat("*No wiki pages found*")
   }
 } else {
+  wiki_tbl_cap <- paste0(
+    "This table lists every wiki page in the knowledge base, ranked by word count in ",
+    "descending order. There are ", scales::comma(fallback_kb$n_pages, accuracy = 1),
+    " pages counted directly from the local `wiki/` directory (no time-series snapshot ",
+    "is available, so this is a live file-count fallback rather than the RDS aggregate)."
+  )
+
   if (length(fallback_kb$page_words) > 0) {
     tibble(
       page = basename(names(fallback_kb$page_words)) |> tools::file_path_sans_ext(),
@@ -112,6 +162,8 @@ if (!is.null(latest)) {
 ## Raw Sources
 
 ```{r raw-sources}
+#| tbl-cap: !expr raw_tbl_cap
+
 if (!is.null(latest)) {
   raw_summary <- latest |>
     filter(category == "raw") |>
@@ -126,12 +178,29 @@ if (!is.null(latest)) {
     ) |>
     select(label, value)
 
+  raw_tbl_cap <- paste0(
+    "This table summarises the append-only `raw/` folder of the knowledge base — the ",
+    "unedited source material (transcripts, notes, articles) that wiki pages cite back to. ",
+    "It reports the total source count, total size, and how many sources were added in the ",
+    "last 7 days, broken down by file extension where available. ",
+    "All values are counts or byte totals with zero decimal places, since raw sources are ",
+    "discrete files, never fractional."
+  )
+
   raw_summary |>
     gt() |>
     cols_label(label = "Metric", value = "Value") |>
     fmt_number(columns = value, decimals = 0, use_seps = TRUE) |>
     tab_header(title = "Raw Sources")
 } else {
+  raw_tbl_cap <- paste0(
+    "This table summarises the append-only `raw/` folder of the knowledge base — the ",
+    "unedited source material that wiki pages cite back to. No time-series snapshot is ",
+    "available, so this reports a single live file count from the local `raw/` directory ",
+    "rather than the multi-metric RDS aggregate. ",
+    "The value is a whole-file count, so it is shown with zero decimal places."
+  )
+
   tibble(
     label = c("Total Sources"),
     value = c(fallback_kb$n_sources)
@@ -148,10 +217,11 @@ if (!is.null(latest)) {
 ```{r evolution-chart}
 #| fig-width: 10
 #| fig-height: 5
-#| fig-alt: "Line chart showing knowledge base growth"
+#| fig-cap: !expr evo_cap
+#| fig-alt: !expr evo_alt
 
 if (!is.null(latest) && n_distinct(kb_data$snapshot_date) > 1) {
-  kb_data |>
+  evo_data <- kb_data |>
     filter(
       item == "all",
       metric %in% c("page_count", "source_count", "word_count")
@@ -163,14 +233,44 @@ if (!is.null(latest) && n_distinct(kb_data$snapshot_date) > 1) {
         metric == "word_count" ~ "Total Words (÷100)"
       ),
       value = if_else(metric == "word_count", value / 100, value)
-    ) |>
+    )
+
+  n_snapshots_evo <- n_distinct(evo_data$snapshot_date)
+  date_range_evo <- range(evo_data$snapshot_date)
+  latest_pages_evo <- evo_data$value[evo_data$label == "Wiki Pages" & evo_data$snapshot_date == max(evo_data$snapshot_date)]
+
+  evo_cap <- paste0(
+    "This line chart tracks knowledge-base growth over time, plotting wiki page count, ",
+    "raw source count, and total word count (divided by 100 to share a common y-axis) ",
+    "as separate coloured series. It spans ", scales::comma(n_snapshots_evo, accuracy = 1),
+    " daily snapshots from ", format(date_range_evo[1]), " to ", format(date_range_evo[2]), ". ",
+    "The most recent snapshot shows ", scales::comma(latest_pages_evo, accuracy = 1), " wiki pages, ",
+    "and an upward trend across series indicates the knowledge base is still actively growing."
+  )
+  evo_alt <- paste0(
+    "Line chart, ", scales::comma(n_snapshots_evo, accuracy = 1), " snapshots from ",
+    format(date_range_evo[1]), " to ", format(date_range_evo[2]),
+    "; latest wiki page count ", scales::comma(latest_pages_evo, accuracy = 1), "."
+  )
+
+  evo_data |>
     ggplot(aes(x = snapshot_date, y = value, color = label)) +
     geom_line(linewidth = 1.2) +
     geom_point(size = 3) +
-    scale_color_viridis_d(option = "plasma", end = 0.85) +
+    scale_color_manual(values = PALETTE) +
     labs(title = "Knowledge Base Growth", x = NULL, y = "Count", color = "Metric") +
     theme_dashboard
 } else {
+  evo_cap <- paste0(
+    "This panel would show a line chart tracking knowledge-base growth over time — wiki page ",
+    "count, raw source count, and total word count as separate series. ",
+    "No time-series snapshot is available yet, so only a single-point-in-time count can be shown. ",
+    "Run `~/.claude/scripts/knowledge_pulse.sh` daily to start collecting the history this chart needs."
+  )
+  evo_alt <- paste0(
+    "No time-series data yet. Current snapshot: ", scales::comma(fallback_kb$n_pages, accuracy = 1),
+    " wiki pages, ", scales::comma(fallback_kb$n_sources, accuracy = 1), " raw sources."
+  )
   cat("*Run `~/.claude/scripts/knowledge_pulse.sh` daily to collect time-series data.*
 
 Current: ", fallback_kb$n_pages, " wiki pages, ", fallback_kb$n_sources, " raw sources")
@@ -180,21 +280,22 @@ Current: ", fallback_kb$n_pages, " wiki pages, ", fallback_kb$n_sources, " raw s
 ## Topic Graph
 
 ```{r topic-graph-vis}
-#| fig-alt: "Interactive network diagram of wiki topic connections from [[link]] references. Click a node to highlight its neighbours."
+#| fig-cap: !expr vis_cap
+#| fig-alt: !expr vis_alt
 if (!is.null(kg_graph) && nrow(kg_graph$edges) > 0L) {
   .n  <- kg_graph$nodes
   .e  <- kg_graph$edges
   .dm <- sort(unique(.n$domain))
-  .pc <- scales::viridis_pal(option = "plasma", end = 0.85)(max(3L, length(.dm)))
-  .dc <- setNames(.pc[seq_along(.dm)], .dm)
+  .dc <- setNames(rep_len(DOMAIN_PALETTE, length(.dm)), .dm)
   .col <- .dc[.n$domain]
-  .col[.n$broken] <- "#f08080"
-  .col[.n$orphan] <- "#ffd93d"
+  .col[.n$broken] <- PALETTE[["Broken target"]]
+  .col[.n$orphan] <- PALETTE[["Orphan (no inbound)"]]
   .vn <- data.frame(
     id    = .n$id,
     label = .n$label,
     value = pmax(10L, 10L + .n$inbound * 8L),
     color = .col,
+    font.color = "#ffffff",
     title = paste0("<b>", .n$id, "</b><br>Domain: ", .n$domain,
                    "<br>Inbound: ", .n$inbound,
                    ifelse(.n$broken, "<br><i>Broken target</i>", ""),
@@ -205,10 +306,30 @@ if (!is.null(kg_graph) && nrow(kg_graph$edges) > 0L) {
                     stringsAsFactors = FALSE)
   .lg <- data.frame(
     label = c("Wiki page", "Orphan (no inbound)", "Broken target"),
-    color = c(.dc[[1L]], "#ffd93d", "#f08080"),
+    color = c(.dc[[1L]], PALETTE[["Orphan (no inbound)"]], PALETTE[["Broken target"]]),
     shape = "dot", size = 20L, stringsAsFactors = FALSE
   )
-  visNetwork::visNetwork(.vn, .ve, width = "100%", height = "500px") |>
+  n_broken_vis <- sum(.n$broken)
+  n_orphan_vis <- sum(.n$orphan)
+
+  vis_cap <- paste0(
+    "This interactive network diagram plots every wiki page as a node, connected by the ",
+    "`[[link]]` cross-references found in each page's body. Node colour encodes the domain ",
+    "cluster derived from the page's filename prefix, node size scales with inbound-link ",
+    "count, and yellow/red flag orphan pages (", scales::comma(n_orphan_vis, accuracy = 1),
+    " with no inbound links) and broken link targets (", scales::comma(n_broken_vis, accuracy = 1),
+    ") respectively. Click any node to highlight its immediate neighbours."
+  )
+  vis_alt <- paste0(
+    "Interactive network: ", scales::comma(nrow(.n), accuracy = 1), " wiki pages, ",
+    scales::comma(nrow(.e), accuracy = 1), " links, ",
+    scales::comma(n_orphan_vis, accuracy = 1), " orphan pages, ",
+    scales::comma(n_broken_vis, accuracy = 1), " broken targets."
+  )
+
+  visNetwork::visNetwork(.vn, .ve, width = "100%", height = "500px",
+                          background = "#000000") |>
+    visNetwork::visNodes(font = list(color = "#ffffff")) |>
     visNetwork::visOptions(
       highlightNearest = list(enabled = TRUE, degree = 1L, hover = TRUE),
       nodesIdSelection = TRUE
@@ -216,6 +337,13 @@ if (!is.null(kg_graph) && nrow(kg_graph$edges) > 0L) {
     visNetwork::visIgraphLayout(layout = "layout_with_fr") |>
     visNetwork::visLegend(addNodes = .lg, useGroups = FALSE)
 } else {
+  vis_cap <- paste0(
+    "This panel would show an interactive network diagram of wiki pages connected by ",
+    "`[[link]]` cross-references, coloured by domain cluster and sized by inbound-link count. ",
+    "No topic-graph data is available in this build. ",
+    "Run `~/.claude/scripts/knowledge_pulse.sh` locally to regenerate `vig_kb_graph.rds`."
+  )
+  vis_alt <- "No topic-graph data available."
   cat("*No topic-graph data available. Run",
       "`~/.claude/scripts/knowledge_pulse.sh` locally to regenerate",
       "`vig_kb_graph.rds`.*")
@@ -225,8 +353,8 @@ if (!is.null(kg_graph) && nrow(kg_graph$edges) > 0L) {
 ```{r topic-graph-static}
 #| fig-width: 8
 #| fig-height: 6
-#| fig-alt: "Static directed graph of wiki topic connections. Nodes coloured by domain cluster and sized by inbound link count. Yellow nodes are orphan pages with no inbound links."
-#| fig-cap: "Knowledge base topic graph. Node size reflects inbound link count; colour identifies domain cluster; yellow = orphan page."
+#| fig-cap: !expr static_cap
+#| fig-alt: !expr static_alt
 if (!is.null(kg_graph) && nrow(kg_graph$edges) > 0L) {
   .n <- kg_graph$nodes
   .e <- kg_graph$edges
@@ -236,15 +364,37 @@ if (!is.null(kg_graph) && nrow(kg_graph$edges) > 0L) {
     directed = TRUE
   )
   .dm  <- sort(unique(.n$domain))
-  .pc  <- scales::viridis_pal(option = "plasma", end = 0.85)(max(3L, length(.dm)))
-  .dc  <- setNames(.pc[seq_along(.dm)], .dm)
+  .dc  <- setNames(rep_len(DOMAIN_PALETTE, length(.dm)), .dm)
   .vcol <- .dc[igraph::V(.g)$domain]
-  .vcol[igraph::V(.g)$broken] <- "#f08080"
-  .vcol[igraph::V(.g)$orphan] <- "#ffd93d"
+  .vcol[igraph::V(.g)$broken] <- PALETTE[["Broken target"]]
+  .vcol[igraph::V(.g)$orphan] <- PALETTE[["Orphan (no inbound)"]]
   igraph::V(.g)$fill_color <- .vcol
+
+  n_broken_static <- sum(.n$broken)
+  n_orphan_static <- sum(.n$orphan)
+  n_domains_static <- length(.dm)
+
+  static_cap <- paste0(
+    "This static directed graph is a print-friendly rendering of the same wiki topic ",
+    "connections shown in the interactive panel above: ", scales::comma(nrow(.n), accuracy = 1),
+    " pages and ", scales::comma(nrow(.e), accuracy = 1), " `[[link]]` references across ",
+    scales::comma(n_domains_static, accuracy = 1), " domain clusters. ",
+    "Node size reflects inbound-link count, node colour identifies domain cluster, and ",
+    "yellow/red mark the ", scales::comma(n_orphan_static, accuracy = 1), " orphan pages and ",
+    scales::comma(n_broken_static, accuracy = 1), " broken link targets respectively. ",
+    "Force-directed layout groups densely cross-linked pages together, so isolated clusters ",
+    "indicate topics with weak connections to the rest of the knowledge base."
+  )
+  static_alt <- paste0(
+    "Static directed graph: ", scales::comma(nrow(.n), accuracy = 1), " pages, ",
+    scales::comma(nrow(.e), accuracy = 1), " links, ",
+    scales::comma(n_orphan_static, accuracy = 1), " orphan pages, ",
+    scales::comma(n_broken_static, accuracy = 1), " broken targets, coloured by domain cluster."
+  )
+
   ggraph::ggraph(.g, layout = "fr") +
     ggraph::geom_edge_link(
-      colour = "#888888", alpha = 0.55,
+      colour = "#cccccc", alpha = 0.6,
       arrow  = grid::arrow(length = grid::unit(2.5, "mm"), type = "closed"),
       end_cap = ggraph::circle(3, "mm")
     ) +
@@ -253,7 +403,7 @@ if (!is.null(kg_graph) && nrow(kg_graph$edges) > 0L) {
     ) +
     ggraph::geom_node_text(
       ggplot2::aes(label = name),
-      colour = "white", size = 2.5, repel = TRUE
+      colour = "#ffffff", size = 2.5, repel = TRUE
     ) +
     ggplot2::scale_colour_identity() +
     ggplot2::scale_size_continuous(range = c(3, 10), name = "Inbound links") +
@@ -263,6 +413,13 @@ if (!is.null(kg_graph) && nrow(kg_graph$edges) > 0L) {
     theme_dashboard +
     ggplot2::theme(legend.position = "bottom")
 } else {
+  static_cap <- paste0(
+    "This static directed graph would show wiki topic connections coloured by domain ",
+    "cluster and sized by inbound-link count. ",
+    "No edges are available to plot in this build. ",
+    "Run `~/.claude/scripts/knowledge_pulse.sh` locally to regenerate `vig_kb_graph.rds`."
+  )
+  static_alt <- "No topic-graph edges available."
   cat("*No edges to plot.*")
 }
 ```

--- a/vignettes/telemetry/github-activity.qmd
+++ b/vignettes/telemetry/github-activity.qmd
@@ -29,13 +29,13 @@ safe_tar_read("vig_github_activity_table", wrap_df = TRUE)
 
 ## CI Workflow Runtimes
 
-```{r ci-plot, fig.cap="Box plot of successful GitHub Actions workflow runtimes by workflow name."}
+```{r ci-plot, fig.cap="Distribution of successful GitHub Actions workflow runtimes, one box per workflow name, ordered by typical duration. Each box spans the interquartile range of run times in minutes, with whiskers showing the typical range and points marking outlier runs. Use this to spot which workflows have grown slow or unpredictable and would benefit from caching or splitting.", fig.alt="Boxplot of GitHub Actions workflow runtimes in minutes, one box per workflow, sorted by typical duration."}
 safe_tar_read("vig_workflow_plot", wrap_df = TRUE)
 ```
 
 ## Git History
 
-```{r git-hist, fig.cap="Daily commit frequency over the last 100 commits."}
+```{r git-hist, fig.cap="Daily commit counts for the repository's most recent 100 commits, shown as a Cleveland dot plot with one dot per day sorted by commit count. The x-axis gives the number of commits made on that date, with the exact count labeled beside each dot. Days with unusually high commit counts typically mark bulk auto-generated commits, such as telemetry data refreshes, rather than manual development bursts.", fig.alt="Dot plot of commit counts by date, ranked from highest to lowest, with each dot labeled by its exact commit count."}
 safe_tar_read("vig_git_history_plot", wrap_df = TRUE)
 ```
 

--- a/vignettes/telemetry/llm-usage-costs.qmd
+++ b/vignettes/telemetry/llm-usage-costs.qmd
@@ -21,25 +21,25 @@ safe_tar_read("vig_usage_summary", wrap_df = TRUE)
 
 ## Cost Trends
 
-```{r cost-trend, fig.cap="Daily LLM costs over time with LOESS smoothing trend line."}
+```{r cost-trend, fig.cap="Daily LLM spend over time, shown as a line with one point per day and a LOESS-smoothed trend overlaid in a contrasting colour. The y-axis is in US dollars per day, aggregated across all tracked models and projects. Use the trend line to see whether spend is rising, falling, or holding steady week over week.", fig.alt="Line chart of daily LLM cost in dollars over time, with a smoothed trend line overlaid."}
 safe_tar_read("vig_cost_trend_plot", wrap_df = TRUE)
 ```
 
 ## Cumulative Cost
 
-```{r cumulative-cost, fig.cap="Cumulative LLM spending over time showing total expenditure trajectory."}
+```{r cumulative-cost, fig.cap="Running total of LLM spending since tracking began, shown as a filled area under a cumulative-sum line. The y-axis is cumulative cost in US dollars and the x-axis is calendar date. The slope of the curve indicates the current burn rate: a steepening slope means costs are accelerating, a flattening slope means spend has slowed.", fig.alt="Area chart of cumulative LLM cost in dollars from the start of tracking to the present."}
 safe_tar_read("vig_cumulative_cost_plot", wrap_df = TRUE)
 ```
 
 ## Breakdowns
 
-```{r breakdowns-combined, fig.height=10, fig.cap="Top: Cost breakdown by model. Bottom: Token usage by type (input, output, cache)."}
+```{r breakdowns-combined, fig.height=10, fig.cap="Two stacked Cleveland dot plots: the top panel ranks Claude models by total cost in US dollars, and the bottom panel ranks token categories (input, output, cache) by total tokens consumed in millions. Both panels sort categories from highest to lowest value and label each dot with its exact figure. Together they show which model and which token type are driving the largest share of usage.", fig.alt="Two dot plots: model cost ranking in dollars on top, token-type totals in millions on bottom."}
 safe_tar_read("vig_breakdowns_plot", wrap_df = TRUE)
 ```
 
 ## Gemini Analytics
 
-```{r gemini-analysis, fig.cap="Gemini daily costs from the Gemini usage database."}
+```{r gemini-analysis, fig.cap="Gemini daily costs pulled from the local Gemini usage database, shown as a Cleveland dot plot with one dot per date sorted by cost. The x-axis is cost in US dollars, with the exact figure labeled beside each dot. This chart tracks a cost stream separate from the Claude usage charts above, since Gemini billing is recorded independently.", fig.alt="Dot plot of Gemini daily cost in dollars, ranked from highest to lowest spending day."}
 safe_tar_read("vig_gemini_plot", wrap_df = TRUE)
 ```
 

--- a/vignettes/telemetry/prediction-calibration.qmd
+++ b/vignettes/telemetry/prediction-calibration.qmd
@@ -30,13 +30,13 @@ safe_tar_read("vig_pred_global_calibration_table", wrap_df = TRUE)
 
 ## Rolling Brier Score
 
-```{r pred-rolling-brier, fig.cap="Cumulative Brier score across all projects over time. Lower is better; 0.25 is the uninformative baseline."}
+```{r pred-rolling-brier, fig.cap="Cumulative Brier score across all tracked projects over time, plotted as one line per project against prediction sequence number. Lower values indicate better-calibrated probability forecasts; a dashed reference line at 0.25 marks the score an uninformative forecaster (always predicting 50%) would achieve. Lines that trend downward and stay below the reference line show a project's forecasts improving and beating a naive baseline.", fig.alt="Line chart of cumulative Brier score by prediction number, one line per project, with a 0.25 uninformative-baseline reference line."}
 safe_tar_read("vig_pred_global_brier_plot", wrap_df = TRUE)
 ```
 
 ## Predicted vs Actual
 
-```{r pred-success-rate, fig.cap="Comparison of mean predicted probability vs actual success rate by project."}
+```{r pred-success-rate, fig.cap="Mean predicted probability versus actual observed success rate for each project, shown as a grouped Cleveland dot plot with two coloured dots per project connected by a line. The x-axis is a percentage rate; a well-calibrated project should have its two dots close together. Wide gaps between the dots for a given project indicate systematic over- or under-confidence in that project's predictions.", fig.alt="Grouped dot plot comparing mean predicted probability against actual success rate as percentages, one pair of dots per project."}
 safe_tar_read("vig_pred_success_rate_plot", wrap_df = TRUE)
 ```
 

--- a/vignettes/telemetry/session-efficiency.qmd
+++ b/vignettes/telemetry/session-efficiency.qmd
@@ -31,25 +31,25 @@ Analysis of session durations and cost efficiency, including Claude Max5 blocks.
 
 ## Duration Trends
 
-```{r duration-trend, fig.cap="Average session duration over time, colored by recency period."}
+```{r duration-trend, fig.cap="Average Claude Code session duration over time, coloured by recency period (last week vs older), with a LOESS-smoothed trend line overlaid. The y-axis is average duration in minutes per day. Use this to see whether sessions have been getting longer or shorter recently compared to the longer-run baseline.", fig.alt="Scatter and trend line of average session duration in minutes over time, coloured by recency period."}
 safe_tar_read("vig_duration_trend_plot", wrap_df = TRUE)
 ```
 
 ## Cost Efficiency
 
-```{r cost-eff, fig.cap="Cost per minute over time showing session cost efficiency trends."}
+```{r cost-eff, fig.cap="Cost per minute of Claude Code usage over time, coloured by recency period, with a LOESS-smoothed trend line overlaid. The y-axis is cost efficiency in dollars per minute, rounded to at most three significant figures to avoid implying false precision. A rising trend means sessions are becoming more expensive per minute of use, not just more numerous.", fig.alt="Scatter and trend line of cost per minute in dollars over time, coloured by recency period."}
 safe_tar_read("vig_cost_efficiency_plot", wrap_df = TRUE)
 ```
 
 ## Cost vs Duration
 
-```{r cost-duration, fig.cap="Scatter plot of cost intensity vs session duration. Longer sessions tend to be more cost efficient."}
+```{r cost-duration, fig.cap="Scatter plot of cost intensity in dollars per minute against session duration in minutes, coloured by recency period with a LOESS trend line overlaid. Each point is one Claude Code session block. If the trend line slopes downward, longer sessions tend to be more cost efficient per minute than shorter ones.", fig.alt="Scatter plot of cost per minute against session duration in minutes, coloured by recency period."}
 safe_tar_read("vig_cost_duration_plot", wrap_df = TRUE)
 ```
 
 ## Model Breakdown
 
-```{r model-breakdown, fig.height=8, fig.cap="Cost efficiency faceted by Claude model variant."}
+```{r model-breakdown, fig.height=8, fig.cap="Cost per minute over time, faceted by Claude model variant with independent y-axis scales and a LOESS trend line in each panel. This isolates whether cost efficiency differs by model rather than being dominated by whichever model is used most often. Panels with a rising trend indicate that model's sessions have become more expensive per minute over the tracked period.", fig.alt="Small-multiples scatter plot of cost per minute over time, one panel per Claude model variant."}
 safe_tar_read("vig_model_session_plot", wrap_df = TRUE)
 ```
 


### PR DESCRIPTION
Applies the project visualization rules to **every** plot, table, and diagram across all vignettes. Origin: user report on the config-evolution "Config Size by Category" chart (bar chart, no caption, transparent/white bg, per-chart viridis).

## What changed (per the `visualization` / `accessibility` / `narrative-colour-persistence` rules)

| Fix | Rule |
|---|---|
| Bar charts → **Cleveland dot plots** (7 charts) | `visualization` "NEVER bar charts" |
| **Black `#000000` bg + white `#ffffff`** axes/gridlines/labels (shared `theme_dashboard`) | `accessibility` dark-mode |
| One named **`PALETTE`** per page (no per-chart `scale_*_viridis_d`) | `narrative-colour-persistence` |
| Mandatory **3+ sentence** `fig-cap`/`tbl-cap` on every plot/table/diagram | `visualization` caption minimum |
| architecture mermaids `flowchart LR → TB` (bigger text) | user request |
| `_companions/` excluded from rule/skill file counts (dashboard bug) | #856 |
| `$/min` ratio precision → `signif(x,3)` | `visualization` no spurious accuracy |

Commit 1 = inline vignettes (config-evolution, knowledge-evolution, articles) — render from source, live on merge.
Commit 2 = telemetry pipeline source (targets build the plots; read via `safe_tar_read`).

## ⚠ Telemetry `.rds` rebuild required

Telemetry plots are pre-computed to `inst/extdata/vignettes/*.rds` and read via `safe_tar_read` (which falls back to those snapshots on deploy — no `_targets` store). **The committed `.rds` must be regenerated (`tar_make`) for the telemetry fixes to appear live.** A rebuild is running; the regenerated snapshots will be added as a follow-up commit (or flagged if the local rebuild can't complete).

## Audit summary (all vignettes, pre-fix)
61 visual objects; 31 without a caption (10 plots, 17 tables, 4 diagrams); 7 bar charts; 0 plots with a black background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)