### PR TITLE
fix(vignettes): repair Quarto Publish build broken by #859 (tbl-cap !expr timing)

### DIFF
--- a/vignettes/knowledge-evolution/metrics.qmd
+++ b/vignettes/knowledge-evolution/metrics.qmd
@@ -110,7 +110,12 @@ if (!is.null(latest)) {
 ## Wiki Pages
 
 ```{r wiki-pages-table}
-#| tbl-cap: !expr wiki_tbl_cap
+#| tbl-cap: >
+#|   Every wiki page in the knowledge base, ranked by word count in descending order.
+#|   Word counts come from the anonymised `vig_kb_stats.rds` aggregate, so page
+#|   identifiers are pseudonymous (e.g. `page_001`) and titles never leak into CI
+#|   output. The longest pages are the most-developed topics; the shortest are
+#|   typically stubs still awaiting promotion.
 
 if (!is.null(latest)) {
   wiki_pages <- latest |>
@@ -162,7 +167,13 @@ if (!is.null(latest)) {
 ## Raw Sources
 
 ```{r raw-sources}
-#| tbl-cap: !expr raw_tbl_cap
+#| tbl-cap: >
+#|   Summary of the append-only `raw/` folder of the knowledge base — the unedited
+#|   source material (transcripts, notes, articles) that wiki pages cite back to. It
+#|   reports the total source count, total size, and how many sources were added in
+#|   the last 7 days, broken down by file extension where available. All values are
+#|   counts or byte totals with zero decimal places, since raw sources are discrete
+#|   files, never fractional.
 
 if (!is.null(latest)) {
   raw_summary <- latest |>


### PR DESCRIPTION
## Hotfix — main deploy is broken

Quarto Publish run [30703030524](https://github.com/JohnGavin/llm/actions/runs/30703030524) (on `main` @ `909cec5`, the #859 merge) failed:

```
Error in eval(x, envir = envir) : object 'wiki_tbl_cap' not found
Quitting from metrics.qmd [wiki-pages-table]
```

**Cause:** #859 set `#| tbl-cap: !expr wiki_tbl_cap` / `raw_tbl_cap` on the two knowledge-evolution table chunks, but `tbl-cap` options are evaluated **before** the chunk body — so the vars (assigned in the body) don't exist yet. (`fig-cap: !expr` is evaluated **after** the body, so the four dynamic figure captions are fine; `scrolly`'s `n_files`/`n_hotspot_rules` are defined in an earlier chunk, also fine.)

**Fix:** the two table captions → static 3-sentence block captions (matching config-evolution's `#| tbl-cap: >` pattern). No hardcoded data values, so no stale-number risk.

**Verified:** rendered `knowledge-evolution/metrics.qmd` locally — no R error, `metrics.html` produced. (The only remaining post-render warning is the single-page link-check false alarm: sibling pages aren't built when rendering one page in isolation; they exist in the full-site render.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)