### PR TITLE
feat(launchd): wire launchd_run_record.sh into 23 plists so health report shows real run counts (llm#300)

### DIFF
--- a/.claude/launchd/com.claude.branch-gc.plist
+++ b/.claude/launchd/com.claude.branch-gc.plist
@@ -23,6 +23,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.branch-gc</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/branch_gc.sh</string>
         <string>--apply</string>
     </array>

--- a/.claude/launchd/com.claude.codex-overnight-learning.plist
+++ b/.claude/launchd/com.claude.codex-overnight-learning.plist
@@ -6,6 +6,10 @@
     <string>com.claude.codex-overnight-learning</string>
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.codex-overnight-learning</string>
+        <string>--</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/codex_overnight_learning.py</string>
     </array>
     <key>StartCalendarInterval</key>

--- a/.claude/launchd/com.claude.config-digest-email.plist
+++ b/.claude/launchd/com.claude.config-digest-email.plist
@@ -30,6 +30,10 @@
 
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.config-digest-email</string>
+        <string>--</string>
         <string>/Users/johngavin/.local/bin/with-secrets</string>
         <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/bin/config_digest_cron.sh</string>

--- a/.claude/launchd/com.claude.cron-catchup.plist
+++ b/.claude/launchd/com.claude.cron-catchup.plist
@@ -9,6 +9,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.cron-catchup</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/cron_catchup.sh</string>
     </array>
 

--- a/.claude/launchd/com.claude.kb-digest-email.plist
+++ b/.claude/launchd/com.claude.kb-digest-email.plist
@@ -34,6 +34,10 @@
 
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.kb-digest-email</string>
+        <string>--</string>
         <string>/Users/johngavin/.local/bin/with-secrets</string>
         <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/bin/kb_digest_daily_cron.sh</string>

--- a/.claude/launchd/com.claude.launchd-health-weekly.plist
+++ b/.claude/launchd/com.claude.launchd-health-weekly.plist
@@ -14,6 +14,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.launchd-health-weekly</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/bin/launchd_health_weekly_cron.sh</string>
     </array>
 

--- a/.claude/launchd/com.claude.overnight-self-review-email.plist
+++ b/.claude/launchd/com.claude.overnight-self-review-email.plist
@@ -37,6 +37,10 @@
 
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.overnight-self-review-email</string>
+        <string>--</string>
         <string>/Users/johngavin/.local/bin/with-secrets</string>
         <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/bws_launcher.sh</string>

--- a/.claude/launchd/com.claude.pr-status-pulse.plist
+++ b/.claude/launchd/com.claude.pr-status-pulse.plist
@@ -6,6 +6,10 @@
     <string>com.claude.pr-status-pulse</string>
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.pr-status-pulse</string>
+        <string>--</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/pr_status_pulse.sh</string>
     </array>
     <key>StartCalendarInterval</key>

--- a/.claude/launchd/com.claude.roborev-agent-health.plist
+++ b/.claude/launchd/com.claude.roborev-agent-health.plist
@@ -6,6 +6,10 @@
     <string>com.claude.roborev-agent-health</string>
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.roborev-agent-health</string>
+        <string>--</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_agent_health.sh</string>
         <string>--apply</string>
     </array>

--- a/.claude/launchd/com.claude.roborev-autoclose.plist
+++ b/.claude/launchd/com.claude.roborev-autoclose.plist
@@ -7,6 +7,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.roborev-autoclose</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_weekly_chain.sh</string>
     </array>
     <!-- ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 roborev

--- a/.claude/launchd/com.claude.roborev-bridge.plist
+++ b/.claude/launchd/com.claude.roborev-bridge.plist
@@ -32,6 +32,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.roborev-bridge</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_bridge_to_unified.sh</string>
     </array>
 

--- a/.claude/launchd/com.claude.roborev-daily-backlog.plist
+++ b/.claude/launchd/com.claude.roborev-daily-backlog.plist
@@ -32,6 +32,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.roborev-daily-backlog</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_daily_backlog_aggregator.sh</string>
     </array>
 

--- a/.claude/launchd/com.claude.roborev-daily-email.plist
+++ b/.claude/launchd/com.claude.roborev-daily-email.plist
@@ -31,6 +31,10 @@
 
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.roborev-daily-email</string>
+        <string>--</string>
         <string>/Users/johngavin/.local/bin/with-secrets</string>
         <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/bin/roborev_daily_cron.sh</string>

--- a/.claude/launchd/com.claude.roborev-metrics-etl.plist
+++ b/.claude/launchd/com.claude.roborev-metrics-etl.plist
@@ -26,6 +26,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.roborev-metrics-etl</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/.claude/scripts/roborev_metrics_etl.sh</string>
         <string>--apply</string>
     </array>

--- a/.claude/launchd/com.claude.roborev-poll-merges.plist
+++ b/.claude/launchd/com.claude.roborev-poll-merges.plist
@@ -6,6 +6,10 @@
     <string>com.claude.roborev-poll-merges</string>
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.roborev-poll-merges</string>
+        <string>--</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_poll_merges.sh</string>
         <string>--apply</string>
     </array>

--- a/.claude/launchd/com.claude.roborev-project-backlog.plist
+++ b/.claude/launchd/com.claude.roborev-project-backlog.plist
@@ -6,6 +6,10 @@
     <string>com.claude.roborev-project-backlog</string>
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.roborev-project-backlog</string>
+        <string>--</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_project_backlog.sh</string>
         <string>--repo</string>
         <string>llm</string>

--- a/.claude/launchd/com.claude.roborev-severity-autoclose.plist
+++ b/.claude/launchd/com.claude.roborev-severity-autoclose.plist
@@ -6,6 +6,10 @@
     <string>com.claude.roborev-severity-autoclose</string>
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.roborev-severity-autoclose</string>
+        <string>--</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_severity_autoclose.sh</string>
         <string>--apply</string>
         <string>--threshold</string>

--- a/.claude/launchd/com.claude.roborev-weekly-rollup-email.plist
+++ b/.claude/launchd/com.claude.roborev-weekly-rollup-email.plist
@@ -33,6 +33,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.roborev-weekly-rollup-email</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/bin/roborev_weekly_rollup_cron.sh</string>
     </array>
 

--- a/.claude/launchd/com.claude.self-review-stage1.plist
+++ b/.claude/launchd/com.claude.self-review-stage1.plist
@@ -15,6 +15,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.self-review-stage1</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/self_review_stage1.sh</string>
         <string>--write</string>
     </array>

--- a/.claude/launchd/com.claude.self-review-verify.plist
+++ b/.claude/launchd/com.claude.self-review-verify.plist
@@ -19,6 +19,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.self-review-verify</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/self_review_verify.sh</string>
     </array>
 

--- a/.claude/launchd/com.claude.unified-duckdb-backup.plist
+++ b/.claude/launchd/com.claude.unified-duckdb-backup.plist
@@ -40,6 +40,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.unified-duckdb-backup</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/.claude/scripts/unified_duckdb_backup.sh</string>
         <string>--apply</string>
         <string>--prune</string>

--- a/.claude/launchd/com.claude.wiki-health-pulse.plist
+++ b/.claude/launchd/com.claude.wiki-health-pulse.plist
@@ -6,6 +6,10 @@
     <string>com.claude.wiki-health-pulse</string>
     <key>ProgramArguments</key>
     <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.wiki-health-pulse</string>
+        <string>--</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/wiki_health_check.sh</string>
         <string>/Users/johngavin/docs_gh/llm/knowledge/wiki</string>
     </array>

--- a/.claude/launchd/com.claude.worktree-gc.plist
+++ b/.claude/launchd/com.claude.worktree-gc.plist
@@ -23,6 +23,10 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.worktree-gc</string>
+        <string>--</string>
+        <string>/bin/bash</string>
         <string>/Users/johngavin/docs_gh/llm/.claude/scripts/worktree_gc.sh</string>
         <string>--apply</string>
     </array>


### PR DESCRIPTION
## What

Prepends `[/bin/bash, bin/launchd_run_record.sh, <label>, --]` to `ProgramArguments` of every tracked `com.claude.*.plist`, so each launchd run records `started_at / finished_at / exit_code / peak_rss` into `~/.claude/logs/launchd_runs.duckdb` — the ledger the weekly health report reads for "Runs (7d)".

**Why:** that ledger is currently empty (0 plists wrapped the recorder), so the report shows "—" for every job even though all 25 jobs run fine (last-exit-status 0). This is the llm#300 instrumentation gap.

## Scope

- **23 tracked plists** wrapped, all `plutil -lint` OK; 2 deprecated skipped.
- Wrapper **verified working** standalone (runs the wrapped command + writes a ledger row).

## ⚠ Remaining steps (NOT in this PR — deliberately)

1. **Live deploy + reload.** Live plists are *copies* (not symlinks), so each needs `cp` to `~/Library/LaunchAgents` + `launchctl bootout`/`bootstrap`. The installer (`bin/launchd_run_record_install.sh`) is deliberately read-only ("do not apply automatically"). Recommend a **staged** rollout: deploy+reload one job, `launchctl kickstart` it, confirm a ledger row appears and the job still works, then roll out the rest with `.bak` rollback.
2. **2 untracked live jobs** — `com.claude.config-pulse` and `com.claude.knowledge-pulse` have no plist in `.claude/launchd/`, so they can't be wired via this PR. Bring their plists into the repo first (separate task), then wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)