### PR TITLE
docs(rules): measure the baseline before blaming the recent change

### DIFF
--- a/.claude/rules/credential-management.md
+++ b/.claude/rules/credential-management.md
@@ -57,6 +57,7 @@ httr2::req_auth_bearer_token(req, Sys.getenv("API_TOKEN"))
 | API key in committed `.R` file | Visible to anyone with repo access | `.Renviron` + `.gitignore` |
 | Credentials in `_quarto.yml` | Committed to version control | Environment variable |
 | `.Renviron` not in `.gitignore` | Credentials committed with project | Add `.Renviron` to `.gitignore` |
+| `echo "${VAR:+yes}${VAR:-no}"` as an is-it-set check | **Prints the secret.** When `VAR` is set, `:+` yields `yes` and `:-` yields the *value* | `[ -n "${VAR:-}" ] && echo set \|\| echo unset` |
 | Credentials in Docker image layers | Persist in image history | Multi-stage build or runtime env vars |
 
 ### Pre-commit Check

--- a/.claude/rules/systematic-debugging.md
+++ b/.claude/rules/systematic-debugging.md
@@ -49,6 +49,37 @@ Test hypothesis WITHOUT changing source:
 | "Command not found" in nix | Not in nix-shell | `Sys.getenv("IN_NIX_SHELL")`, enter shell |
 | CI fails, local passes | Dirty local env or version mismatch | Re-run `source("default.R")`, reboot shell |
 
+## Measure the Baseline Before Claiming a Regression
+
+**A recent change is visible. The baseline is not. So the recent change gets blamed.**
+
+Before asserting that a change caused a problem, measure the same quantity
+**without** the change. Usually one command.
+
+| Symptom | Wrong first move | Right first move |
+|---|---|---|
+| CI job slow after your PR | "My PR slowed it down" | Time the same step on the last run before your PR |
+| Check fails right after your merge | "My merge broke it" | Read the failure; check whether it fails on the parent commit too |
+| Data looks stale | "The refresh broke" | Confirm a refresh ever existed and when it last ran |
+| Test fails on your branch | "I broke it" | Run it on `main` — it may be a known baseline failure |
+
+**A step that passes is not a step that is fine.** In the 2026-08-01 incident a
+CI install step had taken ~51 minutes for months. Nobody had looked, because it
+had always *succeeded*. It was only questioned when a PR touched it — and then
+wrongly blamed on that PR.
+
+Timing evidence is usually one API call:
+
+```bash
+gh run view <run-id> --json jobs \
+  --jq '.jobs[] | "\(.name): \(.startedAt) -> \(.completedAt)"'
+```
+
+Correlation in time is not evidence of causation. A merge that *triggers* a
+scheduled check is not the cause of what that check finds.
+
+See `knowledge/wiki/lessons-learned-false-attribution.md` for three worked cases.
+
 ## Never Accept Unverified Justifications
 
 **Red flags:** "expected", "normal", "probably fine", "should be okay"

--- a/.claude/rules/verification-before-completion.md
+++ b/.claude/rules/verification-before-completion.md
@@ -61,6 +61,28 @@ done
 
 All articles must show 0 for nulls, errors, #> (except intentional #> in code examples).
 
+## One Change Per Verification Run
+
+When verifying fix A, do not fold in change B "while we're here". A single
+green result then proves them **jointly**, with no way to attribute the
+outcome.
+
+If a second change is already available and tempting to bundle:
+
+| | |
+|---|---|
+| **Keep** the slower/older run as a control | It isolates what fix A did |
+| **Then** apply change B and re-run | The delta is attributable to B |
+
+Worked case (2026-08-01): a slow CI run verifying a dependency fix was left to
+finish rather than cancelled in favour of a combined run. That control proved
+(a) the dependency fix reached the previously-failing step, and (b) the
+*separate* repo change produced an 11× speedup. Bundled, a fast green run
+would have proved neither individually.
+
+This is `single-change-experiment` discipline applied to verification runs, not
+just modelling experiments.
+
 ## Before Any Commit
 
 ```r

--- a/.claude/skills/ci-workflows-github-actions/SKILL.md
+++ b/.claude/skills/ci-workflows-github-actions/SKILL.md
@@ -124,6 +124,58 @@ See [workflow-templates.md](references/workflow-templates.md) for YAML examples 
 4. **Artifact upload on failure** -- Debug failed checks easily
 5. **Native R for web tools** -- bslib/pkgdown don't work in Nix
 6. **Test r-universe locally** -- Catch issues before deployment
+7. **Never hardcode `repos=` on Linux CI** -- see below; measured 11x penalty
+
+## R Package Install: Use RSPM Binaries, Not CRAN Source
+
+`r-lib/actions/setup-r@v2` exports `RSPM`, the Posit Package Manager binary
+repo matching the runner's Ubuntu release:
+
+```
+RSPM: https://packagemanager.posit.co/cran/__linux__/noble/latest
+```
+
+Passing an explicit `repos=` **discards it**, and `cloud.r-project.org` serves
+**source tarballs only** for Linux. Every package then compiles from scratch on
+every job.
+
+```r
+# WRONG on Linux CI -- forces source builds
+install.packages(pkgs, repos = "https://cloud.r-project.org")
+
+# RIGHT -- binaries in CI, graceful fallback elsewhere
+repos <- Sys.getenv("RSPM", unset = "")
+if (!nzchar(repos)) repos <- "https://cloud.r-project.org"
+install.packages(pkgs, repos = repos)
+```
+
+Measured on `JohnGavin/historical` 2026-08-01, one matrix job installing 20
+packages including `duckdb`, `arrow`, `duckplyr`, `ggplot2`:
+
+| repo | install step |
+|---|---|
+| `cloud.r-project.org` (source) | **51m 37s** |
+| `RSPM` (binaries) | **~4m 30s** |
+
+Audit every R workflow for a hardcoded `repos=`. The symptom is a slow job that
+**passes**, so it is easy to never look at.
+
+### Derive the package list from DESCRIPTION
+
+A hand-written install list beside a `DESCRIPTION` is a twin that will drift.
+Adding one Import to `DESCRIPTION` and not the workflow broke a scheduled job
+on the same repo:
+
+```
+Error in load_imports(path) : The package "digest" is required.
+```
+
+```r
+dcf <- read.dcf("packages/<pkg>/DESCRIPTION", fields = "Imports")
+imports <- trimws(sub("\\(.*\\)", "", strsplit(dcf[1L, 1L], ",")[[1]]))
+need <- setdiff(unique(c(script_only_deps, imports)),
+                rownames(installed.packages(priority = "base")))
+```
 
 ## GitHub Pages Deployment Gotcha
 


### PR DESCRIPTION
Propagates lessons from a 2026-08-01 session on `JohnGavin/historical` where I made **three wrong causal calls**, each blaming the newest and most visible change for a pre-existing condition.

| # | Symptom | What I claimed | What it was |
|---|---|---|---|
| 1 | Link audit failed right after two merges | "The timestamps are damning — my merges broke it" | Kaggle bot-block returning **404**; the merges only *triggered* the scheduled check |
| 2 | CI install ran 38 min on a PR that rewrote that step | "Treat that PR as suspect" | The step had **always** taken ~51 min |
| 3 | Two datasets 103 days stale | "The refresh broke" | **No refresh ever existed** |

All three dissolved under one cheap measurement of the prior state.

## Changes

**`systematic-debugging`** — new section, *Measure the Baseline Before Claiming a Regression*. Symptom → wrong-first-move → right-first-move table, the `gh run view` timing one-liner, and the observation that matters most: **a step that passes is never timed**, so its cost stays invisible until someone touches it — and then gets blamed on them.

**`verification-before-completion`** — new section, *One Change Per Verification Run*. Keeping a slow control run rather than bundling a second change is what made the 11× speedup attributable. Applies `single-change-experiment` discipline to verification runs, not just modelling experiments.

**`credential-management`** — forbidden pattern: `${VAR:+yes}${VAR:-no}` prints the secret when `VAR` is set. I did exactly this to a FRED key during the session.

**`ci-workflows-github-actions` skill** — RSPM vs `cloud.r-project.org`, with measurements:

| repo | install step |
|---|---|
| `cloud.r-project.org` (source) | **51m 37s** |
| `RSPM` (binaries) | **~4m 30s** |

`setup-r` exports `RSPM`; hardcoding `repos=` discards it, and cloud serves source-only tarballs on Linux. **Every R project using `r-lib/actions` should be audited for a hardcoded `repos=`.** Plus: derive the install list from `DESCRIPTION` rather than maintaining a twin — that drift broke a scheduled job on the same repo.

## Why rules and not just a wiki page

The wiki page is the narrative; the rules are what actually fire in a future session. Each addition extends an **existing** rule rather than adding a new one, per `press-release-first` and the subtractive-first principle — the Chesterton check found a natural home for all four.

Full narrative with evidence: `knowledge/wiki/lessons-learned-false-attribution.md` (local-only hub, committed separately as `833828a`).

## Verification

Rules and skill are prose; no executable content changed. The skill-size pre-push check passed. All measurements are quoted from real CI runs — 30691340071, 30702998804, 30705524744 — and reproduced in the PR bodies of JohnGavin/historical#613, #618, #620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)