### PR TITLE
fix(launchd): recorder resolves duckdb by absolute path (works under launchd) — llm#300

### DIFF
--- a/bin/launchd_run_record.sh
+++ b/bin/launchd_run_record.sh
@@ -44,6 +44,15 @@ LEDGER="${LAUNCHD_LEDGER:-$HOME/.claude/logs/launchd_runs.duckdb}"
 LOG_DIR="$(dirname "$LEDGER")"
 TIMELOG="$(mktemp /tmp/launchd_time.XXXXXX)"
 DUCKDB_BIN="${DUCKDB_BIN:-duckdb}"
+# launchd jobs run with a minimal PATH (no Homebrew/nix dirs), so `duckdb` on PATH
+# resolves interactively but NOT under launchd — the recorder would silently no-op
+# ("duckdb not found — metrics not recorded"). Fall back to common absolute install
+# locations so metrics still record for scheduled jobs (llm#300).
+if ! command -v "$DUCKDB_BIN" &>/dev/null; then
+  for _duckdb_cand in /opt/homebrew/bin/duckdb /usr/local/bin/duckdb; do
+    if [ -x "$_duckdb_cand" ]; then DUCKDB_BIN="$_duckdb_cand"; break; fi
+  done
+fi
 
 # ── Ensure ledger + schema exist ───────────────────────────────────────────────
 


### PR DESCRIPTION
Follow-up to #862, caught during the staged rollout pilot.

**Bug:** `launchd_run_record.sh` finds `duckdb` via PATH only. launchd jobs run with a minimal PATH (no `/opt/homebrew/bin`), so the recorder printed "duckdb not found in PATH — metrics not recorded" and no-oped — the ledger stayed empty even after wiring the plists. The pilot job (`pr-status-pulse`) ran fine but recorded 0 rows; its `.err` showed the not-found message.

**Fix:** fall back to `/opt/homebrew/bin/duckdb` → `/usr/local/bin/duckdb` when `duckdb` isn't on PATH.

**Verified:** `env PATH=/usr/bin:/bin bash launchd_run_record.sh com.claude.fixtest -- /bin/echo hi` now writes a `runs` row (confirmed via duckdb query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)