### PR TITLE
feat(launchd): version-control + wire config-pulse & knowledge-pulse plists (llm#300)

### DIFF
--- a/.claude/launchd/com.claude.config-pulse.plist
+++ b/.claude/launchd/com.claude.config-pulse.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.config-pulse</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.config-pulse</string>
+        <string>--</string>
+        <string>/nix/var/nix/profiles/default/bin/nix-shell</string>
+        <string>/Users/johngavin/docs_gh/llm/default.nix</string>
+        <string>--run</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/config_pulse.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/config_pulse.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/config_pulse.err</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/.claude/launchd/com.claude.knowledge-pulse.plist
+++ b/.claude/launchd/com.claude.knowledge-pulse.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude.knowledge-pulse</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
+        <string>com.claude.knowledge-pulse</string>
+        <string>--</string>
+        <string>/nix/var/nix/profiles/default/bin/nix-shell</string>
+        <string>/Users/johngavin/docs_gh/llm/default.nix</string>
+        <string>--run</string>
+        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/knowledge_pulse.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>5</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/knowledge_pulse.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/knowledge_pulse.err</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>


### PR DESCRIPTION
Completes the #862 recorder rollout for the two remaining jobs.

`config-pulse` and `knowledge-pulse` were live-only (their plists existed in `~/Library/LaunchAgents` but not in `.claude/launchd/`), so they couldn't be wrapped from the repo and stayed at "—" in the health report.

- Brought both plists into version control (copied verbatim from the live copies — clean, no secrets).
- Wrapped `ProgramArguments` with `launchd_run_record.sh` (same transform as the other 23).
- Both `plutil -lint` OK.

Deploy + reload + live-verify follows on merge (same staged procedure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)