### PR TITLE
feat(launchd): per-job named launchers — Login Items show descriptive names, not 'bash'

### DIFF
--- a/.claude/launchd/com.claude.branch-gc.plist
+++ b/.claude/launchd/com.claude.branch-gc.plist
@@ -22,13 +22,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.branch-gc</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/branch_gc.sh</string>
-        <string>--apply</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/branch-gc</string>
     </array>
 
     <!-- Daily 09:08 (after worktree-gc at 09:00) -->

--- a/.claude/launchd/com.claude.codex-overnight-learning.plist
+++ b/.claude/launchd/com.claude.codex-overnight-learning.plist
@@ -6,11 +6,7 @@
     <string>com.claude.codex-overnight-learning</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.codex-overnight-learning</string>
-        <string>--</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/codex_overnight_learning.py</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/codex-overnight-learning</string>
     </array>
     <key>StartCalendarInterval</key>
     <dict>

--- a/.claude/launchd/com.claude.config-digest-email.plist
+++ b/.claude/launchd/com.claude.config-digest-email.plist
@@ -30,13 +30,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.config-digest-email</string>
-        <string>--</string>
-        <string>/Users/johngavin/.local/bin/with-secrets</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/config_digest_cron.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/config-digest-email</string>
     </array>
 
     <!-- Daily at 08:05 local time (5 min after roborev daily email slot) -->

--- a/.claude/launchd/com.claude.config-pulse.plist
+++ b/.claude/launchd/com.claude.config-pulse.plist
@@ -6,14 +6,7 @@
     <string>com.claude.config-pulse</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.config-pulse</string>
-        <string>--</string>
-        <string>/nix/var/nix/profiles/default/bin/nix-shell</string>
-        <string>/Users/johngavin/docs_gh/llm/default.nix</string>
-        <string>--run</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/config_pulse.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/config-pulse</string>
     </array>
     <key>StartCalendarInterval</key>
     <dict>

--- a/.claude/launchd/com.claude.cron-catchup.plist
+++ b/.claude/launchd/com.claude.cron-catchup.plist
@@ -8,12 +8,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.cron-catchup</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/cron_catchup.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/cron-catchup</string>
     </array>
 
     <key>StartInterval</key>

--- a/.claude/launchd/com.claude.kb-digest-email.plist
+++ b/.claude/launchd/com.claude.kb-digest-email.plist
@@ -34,13 +34,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.kb-digest-email</string>
-        <string>--</string>
-        <string>/Users/johngavin/.local/bin/with-secrets</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/kb_digest_daily_cron.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/kb-digest-email</string>
     </array>
 
     <!-- Daily at 08:05 local time (5-min offset from roborev-daily-email) -->

--- a/.claude/launchd/com.claude.knowledge-pulse.plist
+++ b/.claude/launchd/com.claude.knowledge-pulse.plist
@@ -6,14 +6,7 @@
     <string>com.claude.knowledge-pulse</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.knowledge-pulse</string>
-        <string>--</string>
-        <string>/nix/var/nix/profiles/default/bin/nix-shell</string>
-        <string>/Users/johngavin/docs_gh/llm/default.nix</string>
-        <string>--run</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/knowledge_pulse.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/knowledge-pulse</string>
     </array>
     <key>StartCalendarInterval</key>
     <dict>

--- a/.claude/launchd/com.claude.launchd-health-weekly.plist
+++ b/.claude/launchd/com.claude.launchd-health-weekly.plist
@@ -13,12 +13,7 @@
          (see the writer script's Step 1b retry-logic comment). -->
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.launchd-health-weekly</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_health_weekly_cron.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/launchd-health-weekly</string>
     </array>
 
     <!-- Daily; Hour 8; Minute 0 -->

--- a/.claude/launchd/com.claude.overnight-self-review-email.plist
+++ b/.claude/launchd/com.claude.overnight-self-review-email.plist
@@ -37,14 +37,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.overnight-self-review-email</string>
-        <string>--</string>
-        <string>/Users/johngavin/.local/bin/with-secrets</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/bws_launcher.sh</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/overnight_self_review_email_cron.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/overnight-self-review-email</string>
     </array>
 
     <!-- Daily at 06:30 local time (after self-review-stage1 at 02:30) -->

--- a/.claude/launchd/com.claude.pr-status-pulse.plist
+++ b/.claude/launchd/com.claude.pr-status-pulse.plist
@@ -6,11 +6,7 @@
     <string>com.claude.pr-status-pulse</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.pr-status-pulse</string>
-        <string>--</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/pr_status_pulse.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/pr-status-pulse</string>
     </array>
     <key>StartCalendarInterval</key>
     <array>

--- a/.claude/launchd/com.claude.roborev-agent-health.plist
+++ b/.claude/launchd/com.claude.roborev-agent-health.plist
@@ -6,12 +6,7 @@
     <string>com.claude.roborev-agent-health</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.roborev-agent-health</string>
-        <string>--</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_agent_health.sh</string>
-        <string>--apply</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/roborev-agent-health</string>
     </array>
     <!-- ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 roborev
          primary shim (#386) intercepts all roborev invocations from agent-health. -->

--- a/.claude/launchd/com.claude.roborev-autoclose.plist
+++ b/.claude/launchd/com.claude.roborev-autoclose.plist
@@ -6,12 +6,7 @@
     <string>com.claude.roborev-autoclose</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.roborev-autoclose</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_weekly_chain.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/roborev-autoclose</string>
     </array>
     <!-- ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 roborev
          primary shim (#386) intercepts all roborev invocations from autoclose. -->

--- a/.claude/launchd/com.claude.roborev-bridge.plist
+++ b/.claude/launchd/com.claude.roborev-bridge.plist
@@ -31,12 +31,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.roborev-bridge</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_bridge_to_unified.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/roborev-bridge</string>
     </array>
 
     <!-- Daily at 06:00 local time (30 min before 06:30 overnight digest) -->

--- a/.claude/launchd/com.claude.roborev-daily-backlog.plist
+++ b/.claude/launchd/com.claude.roborev-daily-backlog.plist
@@ -31,12 +31,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.roborev-daily-backlog</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_daily_backlog_aggregator.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/roborev-daily-backlog</string>
     </array>
 
     <!-- PATH must include ~/.local/bin (roborev shim — #386) and /usr/local/bin

--- a/.claude/launchd/com.claude.roborev-daily-email.plist
+++ b/.claude/launchd/com.claude.roborev-daily-email.plist
@@ -31,13 +31,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.roborev-daily-email</string>
-        <string>--</string>
-        <string>/Users/johngavin/.local/bin/with-secrets</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/roborev_daily_cron.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/roborev-daily-email</string>
     </array>
 
     <!-- Daily at 08:00 local time (after 02:00 metrics-etl job) -->

--- a/.claude/launchd/com.claude.roborev-metrics-etl.plist
+++ b/.claude/launchd/com.claude.roborev-metrics-etl.plist
@@ -25,13 +25,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.roborev-metrics-etl</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/.claude/scripts/roborev_metrics_etl.sh</string>
-        <string>--apply</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/roborev-metrics-etl</string>
     </array>
 
     <!-- Daily at 02:00 local time -->

--- a/.claude/launchd/com.claude.roborev-poll-merges.plist
+++ b/.claude/launchd/com.claude.roborev-poll-merges.plist
@@ -6,12 +6,7 @@
     <string>com.claude.roborev-poll-merges</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.roborev-poll-merges</string>
-        <string>--</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_poll_merges.sh</string>
-        <string>--apply</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/roborev-poll-merges</string>
     </array>
     <!-- Business-hours safety-net poller (Phase 1.7, #217):
          Fires thrice per weekday at 09:00, 13:00, 17:00 — 3 runs/day × 5 days = 15/week.

--- a/.claude/launchd/com.claude.roborev-project-backlog.plist
+++ b/.claude/launchd/com.claude.roborev-project-backlog.plist
@@ -6,14 +6,7 @@
     <string>com.claude.roborev-project-backlog</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.roborev-project-backlog</string>
-        <string>--</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_project_backlog.sh</string>
-        <string>--repo</string>
-        <string>llm</string>
-        <string>--apply</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/roborev-project-backlog</string>
     </array>
     <!-- ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 roborev
          primary shim (#386) intercepts all roborev invocations from project-backlog. -->

--- a/.claude/launchd/com.claude.roborev-severity-autoclose.plist
+++ b/.claude/launchd/com.claude.roborev-severity-autoclose.plist
@@ -6,14 +6,7 @@
     <string>com.claude.roborev-severity-autoclose</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.roborev-severity-autoclose</string>
-        <string>--</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_severity_autoclose.sh</string>
-        <string>--apply</string>
-        <string>--threshold</string>
-        <string>medium</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/roborev-severity-autoclose</string>
     </array>
     <!-- ~/.local/bin/ MUST precede /usr/local/bin/ so the Phase-1.6 roborev
          primary shim (#386) intercepts all roborev invocations from severity-autoclose. -->

--- a/.claude/launchd/com.claude.roborev-weekly-rollup-email.plist
+++ b/.claude/launchd/com.claude.roborev-weekly-rollup-email.plist
@@ -32,12 +32,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.roborev-weekly-rollup-email</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/roborev_weekly_rollup_cron.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/roborev-weekly-rollup-email</string>
     </array>
 
     <!-- Sunday at 09:15 local time (Weekday 0 = Sunday) -->

--- a/.claude/launchd/com.claude.self-review-stage1.plist
+++ b/.claude/launchd/com.claude.self-review-stage1.plist
@@ -14,13 +14,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.self-review-stage1</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/self_review_stage1.sh</string>
-        <string>--write</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/self-review-stage1</string>
     </array>
 
     <!-- 02:30 daily: after roborev-metrics-etl (~02:00), before backup (~03:00) -->

--- a/.claude/launchd/com.claude.self-review-verify.plist
+++ b/.claude/launchd/com.claude.self-review-verify.plist
@@ -18,12 +18,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.self-review-verify</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/self_review_verify.sh</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/self-review-verify</string>
     </array>
 
     <!-- 08:00 daily: after 02:30 stage1 run and ~03:00 backup -->

--- a/.claude/launchd/com.claude.unified-duckdb-backup.plist
+++ b/.claude/launchd/com.claude.unified-duckdb-backup.plist
@@ -39,14 +39,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.unified-duckdb-backup</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/.claude/scripts/unified_duckdb_backup.sh</string>
-        <string>--apply</string>
-        <string>--prune</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/unified-duckdb-backup</string>
     </array>
 
     <!-- Daily at 03:00 local time (one hour after roborev ETL at 02:00) -->

--- a/.claude/launchd/com.claude.wiki-health-pulse.plist
+++ b/.claude/launchd/com.claude.wiki-health-pulse.plist
@@ -6,12 +6,7 @@
     <string>com.claude.wiki-health-pulse</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.wiki-health-pulse</string>
-        <string>--</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/wiki_health_check.sh</string>
-        <string>/Users/johngavin/docs_gh/llm/knowledge/wiki</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/wiki-health-pulse</string>
     </array>
     <key>StartCalendarInterval</key>
     <dict>

--- a/.claude/launchd/com.claude.worktree-gc.plist
+++ b/.claude/launchd/com.claude.worktree-gc.plist
@@ -22,13 +22,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh</string>
-        <string>com.claude.worktree-gc</string>
-        <string>--</string>
-        <string>/bin/bash</string>
-        <string>/Users/johngavin/docs_gh/llm/.claude/scripts/worktree_gc.sh</string>
-        <string>--apply</string>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/worktree-gc</string>
     </array>
 
     <!-- Fix: launchd's default PATH (/usr/bin:/bin:/usr/sbin:/sbin) omits gh   -->

--- a/bin/launchd-recorders/branch-gc
+++ b/bin/launchd-recorders/branch-gc
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.branch-gc" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/.claude/scripts/branch_gc.sh" "--apply"

--- a/bin/launchd-recorders/codex-overnight-learning
+++ b/bin/launchd-recorders/codex-overnight-learning
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.codex-overnight-learning" -- "/Users/johngavin/docs_gh/llm/.claude/scripts/codex_overnight_learning.py"

--- a/bin/launchd-recorders/config-digest-email
+++ b/bin/launchd-recorders/config-digest-email
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.config-digest-email" -- "/Users/johngavin/.local/bin/with-secrets" "/bin/bash" "/Users/johngavin/docs_gh/llm/bin/config_digest_cron.sh"

--- a/bin/launchd-recorders/config-pulse
+++ b/bin/launchd-recorders/config-pulse
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.config-pulse" -- "/nix/var/nix/profiles/default/bin/nix-shell" "/Users/johngavin/docs_gh/llm/default.nix" "--run" "/Users/johngavin/docs_gh/llm/.claude/scripts/config_pulse.sh"

--- a/bin/launchd-recorders/cron-catchup
+++ b/bin/launchd-recorders/cron-catchup
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.cron-catchup" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/.claude/scripts/cron_catchup.sh"

--- a/bin/launchd-recorders/kb-digest-email
+++ b/bin/launchd-recorders/kb-digest-email
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.kb-digest-email" -- "/Users/johngavin/.local/bin/with-secrets" "/bin/bash" "/Users/johngavin/docs_gh/llm/bin/kb_digest_daily_cron.sh"

--- a/bin/launchd-recorders/knowledge-pulse
+++ b/bin/launchd-recorders/knowledge-pulse
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.knowledge-pulse" -- "/nix/var/nix/profiles/default/bin/nix-shell" "/Users/johngavin/docs_gh/llm/default.nix" "--run" "/Users/johngavin/docs_gh/llm/.claude/scripts/knowledge_pulse.sh"

--- a/bin/launchd-recorders/launchd-health-weekly
+++ b/bin/launchd-recorders/launchd-health-weekly
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.launchd-health-weekly" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/bin/launchd_health_weekly_cron.sh"

--- a/bin/launchd-recorders/overnight-self-review-email
+++ b/bin/launchd-recorders/overnight-self-review-email
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.overnight-self-review-email" -- "/Users/johngavin/.local/bin/with-secrets" "/bin/bash" "/Users/johngavin/docs_gh/llm/.claude/scripts/bws_launcher.sh" "/Users/johngavin/docs_gh/llm/bin/overnight_self_review_email_cron.sh"

--- a/bin/launchd-recorders/pr-status-pulse
+++ b/bin/launchd-recorders/pr-status-pulse
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.pr-status-pulse" -- "/Users/johngavin/docs_gh/llm/.claude/scripts/pr_status_pulse.sh"

--- a/bin/launchd-recorders/roborev-agent-health
+++ b/bin/launchd-recorders/roborev-agent-health
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-agent-health" -- "/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_agent_health.sh" "--apply"

--- a/bin/launchd-recorders/roborev-autoclose
+++ b/bin/launchd-recorders/roborev-autoclose
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-autoclose" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_weekly_chain.sh"

--- a/bin/launchd-recorders/roborev-bridge
+++ b/bin/launchd-recorders/roborev-bridge
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-bridge" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_bridge_to_unified.sh"

--- a/bin/launchd-recorders/roborev-daily-backlog
+++ b/bin/launchd-recorders/roborev-daily-backlog
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-daily-backlog" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_daily_backlog_aggregator.sh"

--- a/bin/launchd-recorders/roborev-daily-email
+++ b/bin/launchd-recorders/roborev-daily-email
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-daily-email" -- "/Users/johngavin/.local/bin/with-secrets" "/bin/bash" "/Users/johngavin/docs_gh/llm/bin/roborev_daily_cron.sh"

--- a/bin/launchd-recorders/roborev-metrics-etl
+++ b/bin/launchd-recorders/roborev-metrics-etl
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-metrics-etl" -- "/bin/bash" "/Users/johngavin/.claude/scripts/roborev_metrics_etl.sh" "--apply"

--- a/bin/launchd-recorders/roborev-poll-merges
+++ b/bin/launchd-recorders/roborev-poll-merges
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-poll-merges" -- "/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_poll_merges.sh" "--apply"

--- a/bin/launchd-recorders/roborev-project-backlog
+++ b/bin/launchd-recorders/roborev-project-backlog
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-project-backlog" -- "/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_project_backlog.sh" "--repo" "llm" "--apply"

--- a/bin/launchd-recorders/roborev-severity-autoclose
+++ b/bin/launchd-recorders/roborev-severity-autoclose
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-severity-autoclose" -- "/Users/johngavin/docs_gh/llm/.claude/scripts/roborev_severity_autoclose.sh" "--apply" "--threshold" "medium"

--- a/bin/launchd-recorders/roborev-weekly-rollup-email
+++ b/bin/launchd-recorders/roborev-weekly-rollup-email
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-weekly-rollup-email" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/bin/roborev_weekly_rollup_cron.sh"

--- a/bin/launchd-recorders/self-review-stage1
+++ b/bin/launchd-recorders/self-review-stage1
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.self-review-stage1" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/.claude/scripts/self_review_stage1.sh" "--write"

--- a/bin/launchd-recorders/self-review-verify
+++ b/bin/launchd-recorders/self-review-verify
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.self-review-verify" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/.claude/scripts/self_review_verify.sh"

--- a/bin/launchd-recorders/unified-duckdb-backup
+++ b/bin/launchd-recorders/unified-duckdb-backup
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.unified-duckdb-backup" -- "/bin/bash" "/Users/johngavin/.claude/scripts/unified_duckdb_backup.sh" "--apply" "--prune"

--- a/bin/launchd-recorders/wiki-health-pulse
+++ b/bin/launchd-recorders/wiki-health-pulse
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.wiki-health-pulse" -- "/Users/johngavin/docs_gh/llm/.claude/scripts/wiki_health_check.sh" "/Users/johngavin/docs_gh/llm/knowledge/wiki"

--- a/bin/launchd-recorders/worktree-gc
+++ b/bin/launchd-recorders/worktree-gc
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.worktree-gc" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/.claude/scripts/worktree_gc.sh" "--apply"


### PR DESCRIPTION
## Why

macOS "Login Items & Extensions" labels each background item by the **basename of `ProgramArguments[0]`** (confirmed via `sfltool dumpbtm` — the item `Name` = the executable's basename). After #862 wrapped all 25 launchd jobs in `/bin/bash launchd_run_record.sh …`, every one shows as **"bash"**, making the list unreadable.

## What

Each plist's `ProgramArguments` is now a single-element array pointing at a per-job launcher `bin/launchd-recorders/<name>` (name = label minus `com.claude.`). Each launcher `exec`s the recorder + the job's original command:

```bash
#!/bin/bash
exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.roborev-bridge" -- "/bin/bash" ".../roborev_bridge_to_unified.sh"
```

Result: the items show **`roborev-bridge`, `config-pulse`, `kb-digest-email`, …** instead of 25× "bash". Run-count telemetry (llm#300) is preserved (the recorder still wraps every job).

## Verified

- On `pr-status-pulse`: `sfltool dumpbtm` Name changed `bash` → `pr-status-pulse`.
- All 25 launchers `bash -n` OK; all 25 plists `plutil -lint` OK.
- Embedded command tokens match the prior `ProgramArguments` byte-for-byte (nix-shell jobs incl.).

Deploy (cp to `~/Library/LaunchAgents` + reload) happens after merge, from the main-checkout launcher paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)