### PR TITLE
feat(qa): qa_rds_freshness gate — fail when a vig_ target outruns its snapshot (#860)

### DIFF
--- a/R/tar_plans/plan_qa_gates.R
+++ b/R/tar_plans/plan_qa_gates.R
@@ -390,8 +390,82 @@ check_build_info_blocks <- function(vignettes_dir = "docs/articles",
   invisible(html_files)
 }
 
+#' Check committed vig_*.rds snapshots are not older than their targets
+#'
+#' The telemetry vignettes read via `safe_tar_read()`, which falls back to the
+#' committed `inst/extdata/vignettes/vig_*.rds` snapshots when there is no
+#' `_targets` store (i.e. on deploy). A pipeline-source fix therefore stays
+#' invisible on the deployed site until the snapshots are re-exported.
+#'
+#' That is exactly what happened in #859/#860: the plots were fixed in source,
+#' merged, and CI went green, but the deployed vignettes kept rendering the old
+#' snapshots for weeks because nothing compared the two.
+#'
+#' This gate compares each `vig_` target's last build time in `tar_meta()`
+#' against its snapshot's mtime and fails when the target is newer.
+#'
+#' @param store targets store to read metadata from.
+#' @param snapshot_dir Directory holding the committed `.rds` snapshots.
+#' @param tolerance_sec Grace period; a snapshot written moments before the
+#'   target's recorded build time is not stale in any meaningful sense.
+#' @return Invisibly, a tibble of target/snapshot times.
+#' @keywords internal
+check_rds_freshness <- function(store = targets::tar_config_get("store"),
+                                 snapshot_dir = "inst/extdata/vignettes",
+                                 tolerance_sec = 60) {
+  if (!dir.exists(store)) {
+    cli::cli_alert_info("No targets store at {.path {store}} — skipping snapshot-freshness gate.")
+    return(invisible(NULL))
+  }
+  if (!dir.exists(snapshot_dir)) {
+    cli::cli_alert_info("No snapshot dir at {.path {snapshot_dir}} — skipping snapshot-freshness gate.")
+    return(invisible(NULL))
+  }
+
+  meta <- targets::tar_meta(store = store)
+  meta <- meta[grepl("^vig_", meta$name) & !is.na(meta$time), c("name", "time")]
+  if (nrow(meta) == 0) {
+    cli::cli_alert_info("No built vig_* targets in {.path {store}} — skipping snapshot-freshness gate.")
+    return(invisible(NULL))
+  }
+
+  meta$rds <- file.path(snapshot_dir, paste0(meta$name, ".rds"))
+  meta$rds_mtime <- file.mtime(meta$rds)
+
+  missing <- meta$name[is.na(meta$rds_mtime)]
+  stale <- meta$name[
+    !is.na(meta$rds_mtime) &
+      as.numeric(difftime(meta$time, meta$rds_mtime, units = "secs")) > tolerance_sec
+  ]
+
+  if (length(missing) || length(stale)) {
+    cli::cli_abort(c(
+      "x" = "Committed vig_*.rds snapshots are out of date with the pipeline.",
+      "i" = if (length(stale)) {
+        "Target newer than snapshot ({length(stale)}): {paste(stale, collapse = ', ')}"
+      },
+      "i" = if (length(missing)) {
+        "Built target with no snapshot ({length(missing)}): {paste(missing, collapse = ', ')}"
+      },
+      "i" = "The deployed vignettes read these snapshots, not the pipeline.",
+      "i" = "Fix: Rscript data-raw/export_vignette_snapshots.R"
+    ))
+  }
+
+  cli::cli_alert_success(
+    "All {nrow(meta)} vig_* snapshot{?s} at least as new as their target{?s}."
+  )
+  invisible(meta)
+}
+
 plan_qa_gates <- function() {
   list(
+    targets::tar_target(
+      qa_rds_freshness,
+      check_rds_freshness(),
+      packages = c("cli"),
+      cue = targets::tar_cue(mode = "always")
+    ),
     targets::tar_target(
       qa_html_no_errors,
       scan_html_for_errors(),

--- a/tests/testthat/test-qa-rds-freshness.R
+++ b/tests/testthat/test-qa-rds-freshness.R
@@ -1,0 +1,110 @@
+## Guard against the #859/#860 failure mode: pipeline source fixed and merged,
+## CI green, but the deployed vignettes keep rendering stale committed
+## vig_*.rds snapshots because nothing compared target build time to snapshot
+## mtime.
+
+# R/tar_plans/ is a subdirectory of R/, so it is NOT collated into the package
+# namespace — only tar_source() loads it. Source it directly, as
+# test-plan-qa-gates.R does.
+source(file.path(pkgload::pkg_path(), "R", "tar_plans", "plan_qa_gates.R"))
+
+# Build a fake targets store whose tar_meta() reports `built_at` for `targets`,
+# alongside a snapshot dir whose .rds files carry `snapshot_at` mtimes.
+local_fixture <- function(targets, built_at, snapshot_at, env = parent.frame()) {
+  store <- withr::local_tempdir(.local_envir = env)
+  snaps <- withr::local_tempdir(.local_envir = env)
+
+  for (i in seq_along(targets)) {
+    if (is.na(snapshot_at[i])) next
+    f <- file.path(snaps, paste0(targets[i], ".rds"))
+    saveRDS(list(x = 1), f)
+    Sys.setFileTime(f, snapshot_at[i])
+  }
+
+  meta <- data.frame(name = targets, time = built_at, stringsAsFactors = FALSE)
+  # .local_envir = env is load-bearing: without it the mock unwinds when this
+  # helper returns, the real tar_meta() runs against an empty store, and every
+  # test passes for the wrong reason.
+  local_mocked_bindings(
+    tar_meta = function(...) meta, .package = "targets", .env = env
+  )
+
+  list(store = store, snaps = snaps)
+}
+
+test_that("passes when every snapshot is newer than its target", {
+  now <- Sys.time()
+  fx <- local_fixture(
+    targets     = c("vig_a", "vig_b"),
+    built_at    = c(now - 3600, now - 3600),
+    snapshot_at = c(now, now)
+  )
+
+  expect_no_error(
+    check_rds_freshness(store = fx$store, snapshot_dir = fx$snaps)
+  )
+})
+
+test_that("aborts when a target is newer than its snapshot (the #860 case)", {
+  now <- Sys.time()
+  fx <- local_fixture(
+    targets     = c("vig_fresh", "vig_stale"),
+    built_at    = c(now - 3600, now),
+    snapshot_at = c(now, now - 86400)   # vig_stale's snapshot is a day old
+  )
+
+  expect_error(
+    check_rds_freshness(store = fx$store, snapshot_dir = fx$snaps),
+    regexp = "vig_stale"
+  )
+})
+
+test_that("aborts when a built target has no committed snapshot", {
+  now <- Sys.time()
+  fx <- local_fixture(
+    targets     = c("vig_a", "vig_orphan"),
+    built_at    = c(now, now),
+    snapshot_at = c(now, NA)            # vig_orphan never exported
+  )
+
+  expect_error(
+    check_rds_freshness(store = fx$store, snapshot_dir = fx$snaps),
+    regexp = "vig_orphan"
+  )
+})
+
+test_that("tolerance absorbs sub-minute export lag", {
+  now <- Sys.time()
+  # Snapshot written 5s before the target's recorded build time — an artifact
+  # of export ordering, not staleness.
+  fx <- local_fixture(
+    targets     = "vig_a",
+    built_at    = now,
+    snapshot_at = now - 5
+  )
+
+  expect_no_error(
+    check_rds_freshness(store = fx$store, snapshot_dir = fx$snaps, tolerance_sec = 60)
+  )
+})
+
+test_that("skips quietly when there is no store or no snapshot dir", {
+  # On a fresh clone with no _targets store the gate must not fail the build.
+  expect_null(check_rds_freshness(store = tempfile(), snapshot_dir = tempfile()))
+})
+
+test_that("ignores non-vig_ targets", {
+  now <- Sys.time()
+  store <- withr::local_tempdir()
+  snaps <- withr::local_tempdir()
+  meta <- data.frame(
+    name = c("pred_all_raw", "pkgdown_site"),
+    time = c(now, now),
+    stringsAsFactors = FALSE
+  )
+  local_mocked_bindings(tar_meta = function(...) meta, .package = "targets")
+  dir.create(file.path(store, "meta"), recursive = TRUE, showWarnings = FALSE)
+
+  # Neither is a vig_ target, so there is nothing to compare and no abort.
+  expect_no_error(check_rds_freshness(store = store, snapshot_dir = snaps))
+})


### PR DESCRIPTION
Closes #860 — the last open piece.

#868 and #869 fixed the current instance of stale telemetry snapshots. Nothing
yet *detected* the next one. This adds that.

## The failure mode

Vignettes read via `safe_tar_read()`, which falls back to the committed
`inst/extdata/vignettes/vig_*.rds` snapshots when there is no `_targets` store —
i.e. on deploy. So a pipeline-source fix stays invisible on the deployed site
until the snapshots are re-exported.

In #859 the plots were fixed, merged, and CI went green while the deployed
vignettes kept rendering the old snapshots, because nothing compared target
build time to snapshot mtime.

## The gate

`check_rds_freshness()` compares each `vig_` target's `tar_meta()` time against
its `.rds` mtime and aborts when the target is newer, or when a built target has
no snapshot at all. Registered as `qa_rds_freshness` with
`tar_cue(mode = "always")` so it cannot be skipped as up-to-date. Fills the
`qa_rds_sync` slot the `qa-targets-pipeline` rule already specifies.

**Fails open by design** — no store, no snapshot dir, or no built `vig_` targets
each skip with a message rather than abort, so a fresh clone or a docs-only
build does not break.

## Verification — real repo state, both directions

```
after tar_make(), snapshots from git:
  x Committed vig_*.rds snapshots are out of date with the pipeline.
  i Target newer than snapshot (55): vig_pipeline_summary, vig_daily_data, ...

after Rscript data-raw/export_vignette_snapshots.R:
  v All 56 vig_* snapshots at least as new as their targets.
```

6 unit tests: pass, stale-target, missing-snapshot, tolerance, skip-when-absent,
ignore-non-vig.

One note on the tests worth flagging for review: the fixture passes
`.env = env` to `local_mocked_bindings`. Without it the mock unwinds when the
helper returns, the real `tar_meta()` runs against an empty store, and every
test passes for the wrong reason. That was caught during development — the
first green run was a false green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)