### PR TITLE
fix(tests): repair test-overnight-self-review-email.R — 5 defects, none of it ran (#871)

### DIFF
--- a/.claude/launchd/com.claude.overnight-self-review-email.plist
+++ b/.claude/launchd/com.claude.overnight-self-review-email.plist
@@ -24,8 +24,10 @@
        Machine account: claude-cron  Project: claude-llm-creds
        Secrets: GMAIL_USERNAME, GMAIL_APP_PASSWORD, REPORT_RECIPIENT
        Token in macOS Keychain (service=claude-cron, account=bws).
-       bws_launcher.sh retrieves token + calls `bws run --` so secrets
-       are injected as env vars and never written to disk.
+       bws_launcher.sh retrieves the token and invokes the `bws run`
+       subcommand so secrets are injected as env vars, never written to
+       disk. (The literal double-hyphen separator is omitted here: XML
+       comments may not contain it, and xmllint rejects the file.)
        Falls back to ~/.claude/env/overnight_self_review.env if bws unavailable.
 
      Tracked in llm#491, llm#559, llm#615.

--- a/tests/testthat/test-overnight-self-review-email.R
+++ b/tests/testthat/test-overnight-self-review-email.R
@@ -29,11 +29,16 @@ library(testthat)
     package  = "llm",
     mustWork = FALSE
   )
-  # Fallback: dev-time source tree
+  # Fallback: dev-time source tree.
+  # pkgload::pkg_path() resolves the package root regardless of the working
+  # directory; dirname(dirname(test_path())) did not — under test_local()
+  # test_path() errors with "Can't find 'tests/testthat'", so this fallback
+  # never produced a usable path and every test here failed to locate the
+  # script. See #871.
   if (!nzchar(s) || !file.exists(s)) {
     s <- normalizePath(
       file.path(
-        dirname(dirname(testthat::test_path())),
+        pkgload::pkg_path(),
         ".claude", "scripts", "send_overnight_self_review_email.R"
       ),
       mustWork = FALSE
@@ -44,7 +49,7 @@ library(testthat)
 
 .plist_path <- normalizePath(
   file.path(
-    dirname(dirname(testthat::test_path())),
+    pkgload::pkg_path(),
     ".claude", "launchd", "com.claude.overnight-self-review-email.plist"
   ),
   mustWork = FALSE
@@ -67,12 +72,18 @@ run_dry_run <- function(db_path = .real_db, extra_env = character(0)) {
     "REPORT_RECIPIENT=",
     extra_env
   )
+  # env = env_vars, NOT c(Sys.getenv(), env_vars) — same defect #848/#851 fixed
+  # in test-kb-digest.R. system2() renders `env` as `env NAME=VAL ... cmd`, and
+  # `env` already inherits the parent environment, so splicing all of
+  # Sys.getenv() in only produces a vast command line whose quoting mangles the
+  # invocation. The script then produced no usable output and the QA-marker and
+  # source-table assertions failed against an empty string. See #871.
   system2(
     "Rscript",
     args   = .email_script,
     stdout = TRUE,
     stderr = TRUE,
-    env    = c(Sys.getenv(), env_vars)
+    env    = env_vars
   )
 }
 
@@ -92,8 +103,11 @@ test_that("dry-run output is non-empty when DB present", {
 
   out      <- run_dry_run()
   combined <- paste(out, collapse = "\n")
+  # expect_gt() has no `info` argument (signature is object/expected/label/
+  # expected.label) — passing one raised "unused argument" instead of asserting,
+  # so this check never actually ran. Context goes in `label`. See #871.
   expect_gt(nchar(combined), 200L,
-            info = "dry-run output is too short — likely an early error")
+            label = "dry-run output length (short output usually means an early error)")
 })
 
 test_that("dry-run output contains required QA markers", {
@@ -122,9 +136,13 @@ test_that("dry-run output contains at least 4 collapsible <details> blocks", {
   out      <- run_dry_run()
   combined <- paste(out, collapse = "\n")
 
-  n_details <- length(gregexpr("<details", combined)[[1]])
-  expect_gte(n_details, 4L,
-             info = paste("Expected ≥4 <details> blocks, found:", n_details))
+  # gregexpr() returns -1 for "no match", and length(-1) is 1 — so the old
+  # `length(gregexpr(...)[[1]])` reported 1 block when there were none. Count
+  # actual match positions instead. See #871.
+  n_details <- sum(gregexpr("<details", combined)[[1]] > 0)
+  # Same as above: expect_gte() takes no `info`. testthat already reports the
+  # actual value, so `label` only needs to name the quantity. See #871.
+  expect_gte(n_details, 4L, label = "number of <details> blocks")
 })
 
 test_that("dry-run output contains all 4 source table names in Section 2", {


### PR DESCRIPTION
Closes #871.

The file errored at its first comparison expectation, so almost nothing in it
had executed since #497 (2026-06-04). Fixing the reported symptom exposed four
more defects behind it — which is exactly why #871 was worth doing rather than
deferring.

## What was wrong

| # | Defect | Effect |
|---|---|---|
| 1 | `expect_gt()` / `expect_gte()` passed `info =`, which they don't accept | Raised "unused argument" instead of asserting — the checks never ran |
| 2 | Script path via `dirname(dirname(testthat::test_path()))` | `test_path()` aborts under `test_local()`; the fallback never yielded a usable path, so every test failed to find the script |
| 3 | `n_details <- length(gregexpr(...)[[1]])` | `gregexpr()` returns `-1` on no-match and `length(-1)` is 1 — **zero** `<details>` blocks counted as one |
| 4 | `system2(env = c(Sys.getenv(), env_vars))` | The **same defect #848/#851 just fixed in `test-kb-digest.R`**, recurring here. Script produced no usable output; QA-marker and source-table assertions ran against an empty string |
| 5 | `com.claude.overnight-self-review-email.plist` is invalid XML | A comment contained a literal double-hyphen, which XML forbids |

`expect_true(..., info =)` elsewhere in the file is valid and left alone.

### On #5 — a real artifact defect, not a test artifact

`plutil` and launchd tolerate it (the job is loaded, program path correct), but
`xmllint` rejects the file — which is what the test asserts, correctly. The
comment is reworded; the plist now passes **both** `xmllint --noout` and
`plutil -lint`.

Note #4 is the second occurrence of the same `system2` env pattern in this
repo's tests. Might be worth an ast-grep rule to stop a third.

## Verification

- `test_local(filter="overnight-self-review-email")` → **exit 0, no failures**
- Full suite leaves 5 failures, **all reproduced on a clean `main` checkout** and untouched by this change:
  - `test-cmonitor-integration` — snapshot recorded in a Positron terminal; the wrapper banner is absent under plain `nix-shell`
  - 4 × `roborev-*` errors (`roborev-etl-lifecycle`, `roborev-fix-commit-link` ×2, `roborev-lineage`)

Those 5 are pre-existing and out of scope here; worth their own issue if you
want the suite fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)