### PR TITLE
lint(ast-grep): catch system2(env=c(Sys.getenv(),...)) splice defect

### DIFF
--- a/.claude/ast-grep-rules/r-no-system2-getenv-splice.yml
+++ b/.claude/ast-grep-rules/r-no-system2-getenv-splice.yml
@@ -1,0 +1,51 @@
+# r-no-system2-getenv-splice.yml
+#
+# NOT YET REGISTERED: the 8 existing ast-grep rules for this project live at
+# ~/.config/ast-grep/rules/ (laptop-local, manually installed, NOT git-backed
+# -- see CLAUDE.md "Code Quality (ast-grep + jarl)"). There is no in-repo
+# mirror of that directory, so this rule cannot be auto-discovered by
+# r_code_check.sh / `/check` until it is copied there:
+#
+#   cp .claude/ast-grep-rules/r-no-system2-getenv-splice.yml \
+#     ~/.config/ast-grep/rules/r-no-system2-getenv-splice.yml
+#
+# This file is kept in-repo so the rule is reviewable and version-controlled;
+# the orchestrator (or a human) must perform the one-time copy above outside
+# this worktree's sandbox.
+#
+# Rationale: system2() renders its `env` argument as `env NAME=VAL ... cmd`.
+# The `env` command already inherits the parent environment, so splicing all
+# of Sys.getenv() in produces an enormous command line whose quoting mangles
+# the invocation -- the child then produces no usable output and downstream
+# assertions silently test an empty string. Correct form: env = env_vars
+# (just the overrides).
+#
+# This exact defect has been fixed THREE times now:
+#   - tests/testthat/test-kb-digest.R              (llm#848 / PR #851)
+#   - tests/testthat/test-overnight-self-review-email.R (llm#871 / PR #873)
+#   - tests/testthat/test-roborev-daily-email.R     (found + fixed by this rule's
+#     own verification sweep, dispatch 4dd486d1)
+id: r-no-system2-getenv-splice
+language: r
+rule:
+  pattern: system2($$$)
+  has:
+    kind: argument
+    stopBy: end
+    all:
+      - has:
+          field: name
+          regex: ^env$
+      - has:
+          field: value
+          pattern: c($$$)
+          has:
+            pattern: Sys.getenv($$$)
+            stopBy: end
+message: |
+  system2(env = c(Sys.getenv(), ...)) mangles the child invocation.
+  env already inherits the parent environment -- splicing all of
+  Sys.getenv() in produces a command line whose quoting corrupts the call,
+  and the child silently produces no usable output.
+severity: error
+note: "Fix: env = env_vars (overrides only, e.g. c(\"FOO=bar\")). See llm#848, llm#871."

--- a/tests/testthat/test-roborev-daily-email.R
+++ b/tests/testthat/test-roborev-daily-email.R
@@ -253,11 +253,18 @@ test_that("publish_roborev_data.sh DRYRUN=1 exits 0 with expected log lines", {
   fake_json <- file.path(dir, "2026-05-28.json")
   writeLines('{"report_date":"2026-05-28"}', fake_json)
 
+  # NOTE: env = <overrides only>, NOT c(Sys.getenv(), ...) -- system2()
+  # renders `env` as `env NAME=VAL ... cmd`, and `env` already inherits the
+  # parent environment, so splicing all of Sys.getenv() in produces a vast
+  # command line whose quoting mangles the invocation. Same defect fixed in
+  # test-kb-digest.R (llm#848) and test-overnight-self-review-email.R (llm#871).
+  env_vars <- c(
+    "DRYRUN=1",
+    paste0("ROBOREV_DAILY_DIR=", dir)
+  )
   out <- system2("bash", args = publish_script,
                  stdout = TRUE, stderr = TRUE,
-                 env = c(Sys.getenv(),
-                   "DRYRUN=1",
-                   paste0("ROBOREV_DAILY_DIR=", dir)))
+                 env = env_vars)
   combined <- paste(out, collapse = "\n")
 
   expect_true(grepl("DRYRUN", combined), info = "DRYRUN log line not emitted")


### PR DESCRIPTION
## Summary

- Adds an ast-grep rule catching the recurring `system2(env = c(Sys.getenv(), ...))` defect: `env` already inherits the parent environment, so splicing `Sys.getenv()` into it produces an enormous command line whose quoting mangles the child invocation and silently yields no usable output.
- This exact defect has been fixed **three** times now:
  - `tests/testthat/test-kb-digest.R` — llm#848 / PR #851
  - `tests/testthat/test-overnight-self-review-email.R` — llm#871 / PR #873
  - `tests/testthat/test-roborev-daily-email.R` — **found and fixed by this rule's own verification sweep** (dispatch `4dd486d1`), confirming the task's prediction that a third occurrence was likely.

## Rule location — IMPORTANT, needs orchestrator action

The project's 8 existing ast-grep rules live at `~/.config/ast-grep/rules/` — laptop-local, **manually installed, NOT git-backed** (per `CLAUDE.md` "Code Quality (ast-grep + jarl)"). There is no in-repo mirror of that directory today, so `r_code_check.sh` / `/check` will **not** auto-discover this new rule.

This PR adds the rule at `.claude/ast-grep-rules/r-no-system2-getenv-splice.yml` so it is reviewable and version-controlled. My worktree scope forbids writing outside the worktree, so someone with access to `~/.config/ast-grep/rules/` must run:

```bash
cp .claude/ast-grep-rules/r-no-system2-getenv-splice.yml \
  ~/.config/ast-grep/rules/r-no-system2-getenv-splice.yml
```

after this merges, to make the rule live for `/check` and `r_code_check.sh`.

## Verification transcript

**Fires on the bad pattern** (`env = c(Sys.getenv(), "FOO=bar")`):

```
error[r-no-system2-getenv-splice]: system2(env = c(Sys.getenv(), ...)) mangles the child invocation.
env already inherits the parent environment -- splicing all of
Sys.getenv() in produces a command line whose quoting corrupts the call,
and the child silently produces no usable output.

  ┌─ .../verify_bad.R:1:8
  │
1 │   out <- system2("Rscript", args = email_script,
  │ ╭────────^
2 │ │                 stdout = TRUE, stderr = TRUE,
3 │ │                 env = c(Sys.getenv(), "FOO=bar"))
  │ │                 --------------------------------
  │ ╰─────────────────────────────────────────────────^
  │
  = Fix: env = env_vars (overrides only, e.g. c("FOO=bar")). See llm#848, llm#871.

Error: 1 error(s) found in code.
```

Confirmed to fire regardless of argument order: `env` first, middle, or last positional argument to `system2()`, and with `Sys.getenv()` first, middle, or last element inside `c(...)`.

**Silent on the corrected form** (`env = env_vars`):

```
$ ast-grep scan -c sgconfig.yml -r r-no-system2-getenv-splice.yml verify_good.R
(no output, exit 0)
```

**Silent on legitimate `env = c(...)` usage without `Sys.getenv()`** (no false positive):

```
$ ast-grep scan ... good_env_c_no_getenv.R   # env = c("FOO=bar", "BAZ=qux")
(no output, exit 0)
```

**Silent on `Sys.getenv()` used in an unrelated argument** (e.g. `args = c(Sys.getenv("HOME"), ...)`) — this was an initial false positive in a first draft of the rule (a loose `has: pattern: c($$$) has: pattern: Sys.getenv($$$)` search anywhere inside the call), fixed by constraining the match to the `env=` named argument specifically via `field: name` / `field: value`:

```
$ ast-grep scan ... edge_getenv_in_args_not_env.R   # args = c(Sys.getenv("HOME"), "--flag")
(no output, exit 0)
```

**Zero hits across the repo** after fixing the third occurrence:

```
$ ast-grep scan -c sgconfig.yml -r r-no-system2-getenv-splice.yml <worktree-root>
(no output, exit 0)
```

Before the fix, this same repo-wide scan found exactly one hit: `tests/testthat/test-roborev-daily-email.R:256` (`env = c(Sys.getenv(), "DRYRUN=1", paste0("ROBOREV_DAILY_DIR=", dir))`), fixed in this PR using the same `env_vars <- c(...)` pattern as the other two prior fixes.

## Test plan

- [x] `parse()` on the edited test file succeeds
- [x] `devtools::test(filter = "roborev-daily-email")` — 39 passed, 0 failed, 4 skipped (same 4 skips as before my change, due to a pre-existing unrelated `testthat::test_path()` resolution quirk when locating `bin/*.sh` fixtures — not introduced by this change; flagging for a separate issue if worth chasing)
- [x] ast-grep rule verified against 5 bad-pattern variants (fires) + 3 good/edge fixtures (silent)
- [x] Full-repo ast-grep scan confirms zero remaining hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
