### PR TITLE
fix(tests): repair the 5 pre-existing test failures on main

### DIFF
--- a/tests/testthat/_snaps/cmonitor-integration.md
+++ b/tests/testthat/_snaps/cmonitor-integration.md
@@ -3,5 +3,14 @@
     Code
       head(sanitized_output, 10)
     Output
-      [1] "Setup complete\\nTerminal wrapper: /Users/USER/.config/positron/nix-terminal-wrapper.sh\\nRSTUDIO_TERM_EXEC set to execute new shell with Nix environment.\\nAnalyzing usage data to determine cost limits..."
+       [1] "Analyzing usage data to determine cost limits..."       
+       [2] "P90 session limit calculated: N,NNN tokens"             
+       [3] "╭────────────────────── Summary ──────────────────────╮"
+       [4] "│ │"                                                    
+       [5] "│  📊 Daily Usage Summary - YYYY-MM-DD to YYYY-MM-DD │" 
+       [6] "│ │"                                                    
+       [7] "│  Total Tokens: N,NNN │"                               
+       [8] "│  Total Cost: $N,NNN.NN │"                             
+       [9] "│  Entries: N,NNN │"                                    
+      [10] "│ │"                                                    
 

--- a/tests/testthat/test-cmonitor-integration.R
+++ b/tests/testthat/test-cmonitor-integration.R
@@ -53,6 +53,25 @@ test_that("cmonitor execution inside nix-shell produces expected output", {
   
   # Capture the output for the snapshot
   output_content <- readLines(output_file)
+
+  # Positron terminal sessions wrap nix-shell invocations through
+  # ~/.config/positron/nix-terminal-wrapper.sh, which prints a
+  # "Setup complete" / "Terminal wrapper: ..." / "RSTUDIO_TERM_EXEC set to
+  # execute new shell with Nix environment." preamble before handing off to
+  # the real command. Plain nix-shell (e.g. this test run under CI or a
+  # bare terminal) has no such preamble, so a snapshot recorded inside
+  # Positron does not match one recorded outside it (llm#874). Depending on
+  # which shell runs the wrapper's `echo`, the preamble lines arrive either
+  # as real newlines or as a single line with literal two-character "\\n"
+  # sequences embedded -- normalise both forms to real lines before
+  # filtering, so the snapshot is independent of the terminal that produced
+  # the raw output.
+  output_content <- unlist(strsplit(output_content, "\\n", fixed = TRUE))
+  positron_banner_pattern <- paste0(
+    "^(Setup complete|Terminal wrapper:.*|",
+    "RSTUDIO_TERM_EXEC set to execute new shell with Nix environment\\.)$"
+  )
+  output_content <- output_content[!grepl(positron_banner_pattern, output_content, perl = TRUE)]
   
   # We expect some output, even if it fails (stderr is captured)
   expect_true(length(output_content) > 0)
@@ -71,6 +90,23 @@ test_that("cmonitor execution inside nix-shell produces expected output", {
   sanitized_output <- gsub("\033\\[[0-9;]*m", "", sanitized_output)
   # Filter out nix download/unpacking lines that depend on cache state
   sanitized_output <- sanitized_output[!grepl("^(unpacking |copying path |these \\d+ paths|  /nix/store/)", sanitized_output)]
+  # Token counts, session limits, and running dollar costs (e.g.
+  # "607,208 tokens", "5,514,144,157", "$5,123.38") are LIVE
+  # ccusage/cmonitor values that grow continuously and differ on every run
+  # -- the same instability class as the Positron banner above, just from
+  # data instead of environment. Mask them so the snapshot tracks output
+  # *structure* (per the original intent: "Snapshot the type of output ...
+  # to track changes"), not the moving-target values. Dollar-cost figures
+  # are masked FIRST because they carry a decimal-cents suffix that the
+  # comma-integer mask below does not touch.
+  sanitized_output <- gsub("\\$[0-9,]+\\.[0-9]{2}", "$N,NNN.NN", sanitized_output)
+  sanitized_output <- gsub("[0-9]{1,3}(,[0-9]{3})+", "N,NNN", sanitized_output)
+  # Box-drawn table padding (e.g. the Summary panel) was column-aligned for
+  # the original digit count of the masked numbers above; after masking,
+  # the right border no longer lines up. Collapse runs of 2+ spaces before
+  # a box-drawing vertical border so the snapshot does not depend on how
+  # many digits the pre-masked number happened to have.
+  sanitized_output <- gsub(" {2,}\u2502", " \u2502", sanitized_output)
 
   expect_snapshot(head(sanitized_output, 10))
   

--- a/tests/testthat/test-roborev-etl-lifecycle.R
+++ b/tests/testthat/test-roborev-etl-lifecycle.R
@@ -7,16 +7,19 @@
 #   3. Idempotence: running twice yields identical results
 #   4. No silent NULLs: all closed=1 reviews have non-NA closed_at + close_reason
 #
-# Strategy: source only lines 350-585 of the ETL script (the pure function
-# block — SEVERITY constants + parse_max_severity + derive_close_reason +
+# Strategy: source only the pure-function block (SEVERITY constants +
+# parse_max_severity + build_daily_metrics + derive_close_reason +
 # build_review_lifecycle).  These lines have no I/O side effects.
+#
+# The block boundaries are found DYNAMICALLY (grep anchor + brace-depth walk)
+# rather than hardcoded line numbers, because the ETL script grows over time
+# and fixed offsets silently drift out from under the test (llm#874: this
+# test broke when unrelated commits added ~150 lines above the sourced
+# block). See test-roborev-fix-commit-link.R for the same pattern.
 
 library(testthat)
 
 # ── Load ETL function block ─────────────────────────────────────────────────
-
-.etl_fn_start <- 358L   # SEVERITY_PATTERN <- line (first assignment, no leading comment)
-.etl_fn_end   <- 605L   # closing } of build_review_lifecycle
 
 etl_script <- file.path(pkgload::pkg_path(),
                          ".claude", "scripts", "roborev_metrics_etl.R")
@@ -24,7 +27,23 @@ etl_script <- file.path(pkgload::pkg_path(),
 skip_if_not(file.exists(etl_script), "ETL script not found at expected path")
 
 all_lines <- readLines(etl_script)
-fn_block  <- all_lines[.etl_fn_start:.etl_fn_end]
+
+start_line <- grep("^SEVERITY_PATTERN <- ", all_lines)[[1L]]
+
+fn_line <- grep("^build_review_lifecycle <- function", all_lines)[[1L]]
+depth   <- 0L
+end_line <- fn_line
+for (li in fn_line:length(all_lines)) {
+  opens  <- nchar(gsub("[^{]", "", all_lines[[li]]))
+  closes <- nchar(gsub("[^}]", "", all_lines[[li]]))
+  depth  <- depth + opens - closes
+  if (li > fn_line && depth == 0L) {
+    end_line <- li
+    break
+  }
+}
+
+fn_block <- all_lines[start_line:end_line]
 eval(parse(text = paste(fn_block, collapse = "\n")), envir = globalenv())
 
 # ── DuckDB / SQLite fixture ─────────────────────────────────────────────────

--- a/tests/testthat/test-roborev-fix-commit-link.R
+++ b/tests/testthat/test-roborev-fix-commit-link.R
@@ -160,10 +160,10 @@ test_that("find_fix_commit: commit with 'roborev #<id>' in message → commit_re
   system2("git", args = c("-C", tmp_repo, "add", "file.txt"))
   system2("git", args = c(
     "-C", tmp_repo,
-    "commit", "-m", "fix: address roborev review #1234 finding in R/foo.R",
+    "commit", "-m", shQuote("fix: address roborev review #1234 finding in R/foo.R"),
     "--date", "2026-05-27T17:30:00+00:00",
     "--no-gpg-sign"
-  ))
+  ), env = c("GIT_COMMITTER_DATE=2026-05-27T17:30:00+00:00"))
 
   # Get the commit SHA
   sha_raw <- system2("git", args = c("-C", tmp_repo, "log", "--format=%H", "-1"),
@@ -202,10 +202,10 @@ test_that("find_fix_commit: commit within 6h before closure → manual (time-pro
   system2("git", args = c("-C", tmp_repo, "add", "fix.R"))
   system2("git", args = c(
     "-C", tmp_repo,
-    "commit", "-m", "refactor: general cleanup",
+    "commit", "-m", shQuote("refactor: general cleanup"),
     "--date", "2026-05-27T15:00:00+00:00",
     "--no-gpg-sign"
-  ))
+  ), env = c("GIT_COMMITTER_DATE=2026-05-27T15:00:00+00:00"))
 
   sha_raw <- system2("git", args = c("-C", tmp_repo, "log", "--format=%H", "-1"),
                      stdout = TRUE)
@@ -242,10 +242,10 @@ test_that("find_fix_commit: no commits in window → unknown", {
   system2("git", args = c("-C", tmp_repo, "add", "old.R"))
   system2("git", args = c(
     "-C", tmp_repo,
-    "commit", "-m", "chore: old unrelated commit",
+    "commit", "-m", shQuote("chore: old unrelated commit"),
     "--date", "2026-05-27T10:00:00+00:00",
     "--no-gpg-sign"
-  ))
+  ), env = c("GIT_COMMITTER_DATE=2026-05-27T10:00:00+00:00"))
 
   # closed_at = 18:00; only commit is at 10:00 → 8h gap, outside window
   closed_at <- as.POSIXct("2026-05-27 18:00:00", tz = "UTC")

--- a/tests/testthat/test-roborev-lineage.R
+++ b/tests/testthat/test-roborev-lineage.R
@@ -10,29 +10,45 @@
 #   4. Idempotence: re-running build_finding_lineage produces identical rows.
 #
 # Strategy: source only the two pure-function blocks from the ETL script
-# (build_finding_lineage + coalesce_int, lines ~1032-1215).
+# (log_msg + build_finding_lineage + coalesce_int).
 # These blocks have no I/O side effects and depend only on:
 #   - a DBI connection pointing at an in-memory SQLite fixture
-#   - the log_msg helper (stubbed below)
+#   - the log_msg helper (sourced from the script, not stubbed)
 #   - since_date / repo_clause (plain strings)
+#
+# Block boundaries are found DYNAMICALLY (grep anchor + brace-depth walk)
+# rather than hardcoded line numbers, because the ETL script grows over time
+# and fixed offsets silently drift out from under the test (llm#874: this
+# test broke when unrelated commits added ~450 lines above the sourced
+# block). See test-roborev-fix-commit-link.R for the same pattern.
 
 library(testthat)
 library(DBI)
 library(duckdb)
 
-# ── Source the lineage function block ─────────────────────────────────────
+# Source the lineage function block
 #
 # Two separate eval blocks:
-#   Block 1: lines 100-108  — log_msg helper (required by build_finding_lineage)
-#   Block 2: lines 1032-end — build_finding_lineage + coalesce_int
+#   Block 1: log_msg helper (required by build_finding_lineage)
+#   Block 2: build_finding_lineage + coalesce_int
 #
-# We source log_msg from the script rather than stubbing it, so the dependency
-# is explicit and the stub doesn't drift if the signature changes.
+# log_msg is sourced from the script rather than stubbed, so the dependency
+# is explicit and the stub does not drift if the signature changes.
 
-.log_msg_start  <- 100L   # log_msg <- function(...)
-.log_msg_end    <- 108L   # closing } of log_msg
-.etl_fn_start   <- 1032L  # "# ── Build roborev_finding_lineage"
-.etl_fn_end     <- 1215L  # closing } of coalesce_int
+.brace_walk_end <- function(lines, fn_start_line) {
+  depth <- 0L
+  end_line <- fn_start_line
+  for (li in fn_start_line:length(lines)) {
+    opens  <- nchar(gsub("[^{]", "", lines[[li]]))
+    closes <- nchar(gsub("[^}]", "", lines[[li]]))
+    depth  <- depth + opens - closes
+    if (li > fn_start_line && depth == 0L) {
+      end_line <- li
+      break
+    }
+  }
+  end_line
+}
 
 etl_script <- file.path(pkgload::pkg_path(),
                          ".claude", "scripts", "roborev_metrics_etl.R")
@@ -41,9 +57,16 @@ skip_if_not(file.exists(etl_script), "ETL script not found at expected path")
 
 all_lines <- readLines(etl_script)
 
-# log_file is referenced inside log_msg — provide a tempfile so it doesn't
+# log_file is referenced inside log_msg -- provide a tempfile so it does not
 # try to write to ~/.claude/logs/ during tests.
 log_file <- tempfile(fileext = ".log")
+
+.log_msg_start <- grep("^log_msg <- function", all_lines)[[1L]]
+.log_msg_end   <- .brace_walk_end(all_lines, .log_msg_start)
+
+.etl_fn_start  <- grep("^# .*Build roborev_finding_lineage", all_lines)[[1L]]
+.coalesce_fn_start <- grep("^coalesce_int <- function", all_lines)[[1L]]
+.etl_fn_end    <- .brace_walk_end(all_lines, .coalesce_fn_start)
 
 eval(parse(text = paste(all_lines[.log_msg_start:.log_msg_end], collapse = "\n")),
      envir = globalenv())


### PR DESCRIPTION
Fixes the 5 failures that were failing on a clean `main` checkout, unrelated to
any recent work:

```
test-cmonitor-integration.R:75   snapshot drift
test-roborev-etl-lifecycle.R:28  error outside test_that()
test-roborev-fix-commit-link.R   x2 find_fix_commit errors
test-roborev-lineage.R:50        error outside test_that()
```

The cmonitor snapshot was **environment-dependent**: recorded inside a Positron
terminal, it carried a `Terminal wrapper: ...` preamble absent under plain
`nix-shell`, so it failed for whoever ran it in the other environment. The fix
sanitises that preamble before snapshotting rather than re-recording — which
would only have flipped which environment fails.

## Verification

`testthat::test_local()` over **74 test blocks completes with ZERO failures**,
down from 5. Diff confined to the 5 target files (+113/−26).

## ⚠ Provenance — please read before reviewing

This work came from a dispatched `r-debugger` agent that was **terminated
mid-run by a monthly-spend-limit API error** before it could commit or report.
The changes were left uncommitted in its worktree.

I verified the **outcome** independently — full suite green, diff scoped to the
intended files — and committed them on that basis. But the agent never delivered
its per-failure root-cause narrative, so **the reasoning behind the four roborev
fixes is not documented anywhere**.

Review the diff on its merits rather than trusting a rationale that was never
written down. In particular check that none of the four roborev fixes
blanket-skips a test that was catching a real defect — that was an explicit
constraint in the dispatch, but I cannot confirm it was honoured without the
agent's reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)