### PR TITLE
docs(memory): ast-grep lesson 8 — R rules need -c sgconfig.yml, and 3 adjacent traps

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -35,6 +35,9 @@ One hook line per topic; full detail lives in the linked file. Keep under ~140 l
 ## Session Conventions
 - Commit with gert (not bash git); append CHANGELOG.md at /bye; CURRENT_WORK.md is ephemeral
 
+## ast-grep Lessons (see feedback_ast-grep-lessons.md)
+- R is a CUSTOM grammar: always `-c ~/.config/ast-grep/sgconfig.yml`, else a valid rule errors as "Cannot parse rule / SgLang"; binary is nix-shell-only; rules live laptop-local at `~/.config/ast-grep/rules/` so merging ≠ deploying; bare `$$$` can silently never match — prove a rule fires before trusting it
+
 ## Safe Deletion (see feedback_safe-deletion.md)
 - NEVER delete untracked >1MB without size/age/diff/user-approval (origin: 522MB worktree loss 2026-03-27)
 

--- a/.claude/memory/feedback_ast-grep-lessons.md
+++ b/.claude/memory/feedback_ast-grep-lessons.md
@@ -21,3 +21,50 @@ type: feedback
 7. **Periodic code sweeps are necessary.** Rules only prevent NEW violations. Old code predating the rule persists until someone sweeps. `/check` now includes ast-grep sweep.
 
 **How to apply:** Run `/check` which includes ast-grep sweep. When reporting counts, use --json. When justifying a violation, cite the documented exception or fix it.
+
+---
+
+## 8. R rules need `-c sgconfig.yml` — a bare `--rule` invocation LOOKS broken (2026-08-02)
+
+R is a **custom grammar** registered in `~/.config/ast-grep/sgconfig.yml`, not a built-in
+language. Scanning a rule standalone bypasses that registration and fails at parse time
+with an error that reads like the rule file itself is malformed:
+
+```
+Error: Cannot parse rule .../r-no-system2-getenv-splice.yml
+╰▻ Fail to parse yaml as RuleConfig
+╰▻ data did not match any variant of untagged enum SgLang at line 28 column 1
+```
+
+`line 28` is the `language: r` line. The rule is fine; ast-grep simply does not know
+what `r` is without the config.
+
+```bash
+# WRONG — reads as "your rule is broken"
+ast-grep scan --rule ~/.config/ast-grep/rules/<rule>.yml target.R
+
+# RIGHT
+ast-grep scan -c ~/.config/ast-grep/sgconfig.yml --rule ~/.config/ast-grep/rules/<rule>.yml target.R
+```
+
+`ast-grep` is provided by the nix shell — not on the bare PATH, and neither is `sg`.
+Run it via `nix-shell /Users/johngavin/docs_gh/llm/default.nix --run "ast-grep ..."`.
+
+**Why this cost time:** I read the parse error as evidence that a just-merged rule was
+defective and nearly reverted it. The rule was correct. Diagnose "invalid rule" errors by
+first re-running WITH `-c` before doubting the rule.
+
+**Second trap, same session:** rules live ONLY at `~/.config/ast-grep/rules/` — laptop-local,
+not git-backed. A rule merged into `.claude/ast-grep-rules/` in the repo is **not active**
+until copied across. Merging is not deploying. See [[deploy-gap-stale-main-checkout]].
+
+**Third trap:** bare `$$$` multi-metavars degrade to literal R extract-operator tokens in
+some syntactic positions under this grammar, so a pattern like
+`system2($$$, env = c($$$, Sys.getenv($$$), $$$), $$$)` parses but never matches anything.
+Verify with `--debug-query=pattern`; prefer composite `has`/`field`/`stopBy: end` rules over
+multi-`$$$` patterns. A lint that never fires is worse than no lint — always prove it fires
+on a bad fixture AND stays silent on a good one before trusting it.
+
+**How to apply:** always `-c sgconfig.yml`; always run inside the nix shell; always copy new
+rules to `~/.config/ast-grep/rules/` after merge; always prove a new rule fires before
+claiming coverage.


### PR DESCRIPTION
Documents a lesson learnt while activating the `r-no-system2-getenv-splice` rule from #874. It was not recorded anywhere — `grep -rl sgconfig .claude/memory .claude/rules` returned nothing.

## The trap

A bare standalone invocation fails with an error that reads like the **rule file** is malformed:

```
Error: Cannot parse rule .../r-no-system2-getenv-splice.yml
╰▻ Fail to parse yaml as RuleConfig
╰▻ data did not match any variant of untagged enum SgLang at line 28 column 1
```

Line 28 is `language: r`. The rule is fine — R is a **custom grammar** registered in `~/.config/ast-grep/sgconfig.yml`, and `--rule` alone bypasses that registration.

```bash
# WRONG — reads as "your rule is broken"
ast-grep scan --rule ~/.config/ast-grep/rules/<rule>.yml target.R

# RIGHT
ast-grep scan -c ~/.config/ast-grep/sgconfig.yml --rule ~/.config/ast-grep/rules/<rule>.yml target.R
```

I read this error as evidence that a just-merged rule was defective and nearly reverted a correct rule. That is the cost this entry is meant to prevent.

## Three adjacent traps, same session

- **The binary is nix-shell-only.** Neither `ast-grep` nor `sg` is on the bare PATH.
- **Rules live only at `~/.config/ast-grep/rules/`** — laptop-local, not git-backed. A rule merged into `.claude/ast-grep-rules/` is **inert until copied across**. Merging is not deploying.
- **Bare `$$$` metavars can silently never match.** They degrade to literal R extract-operator tokens in some syntactic positions, so a pattern parses yet matches nothing. Verify with `--debug-query=pattern`; prefer composite `has`/`field`/`stopBy: end`. A lint that never fires is worse than no lint.

## Also

`MEMORY.md` had **no index entry for `feedback_ast-grep-lessons.md` at all** — added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)