### PR TITLE
docs(rules): portable-build-artifacts — committed artifacts must not depend on the checkout that built them

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -134,5 +134,11 @@ One hook line per topic; full detail lives in the linked file. Keep under ~140 l
 ## Deploy Gap: Merged ≠ Live (see deploy-gap-stale-main-checkout.md)
 - A merged fix that "isn't live" = local main checkout behind origin/main; cron `--ff-only` auto-pull jams on dirty tree (uncommitted memory edits), swallows the error, runs stale. Check `git -C ~/docs_gh/llm rev-list --count HEAD..origin/main`; also `launchctl print` before trusting "N cron jobs failed" (#510 reopened 2026-07-11)
 
+## Portable Build Artifacts (see portable-build-artifacts.md)
+- A committed artifact must not depend on the checkout that built it: (1) absolute paths serialised inside objects (DT html_dependency) — repair on READ, regenerating only re-acquires the new machine's path; (2) path filters matched on absolute paths swallow their own scan root (every worktree path contains `/worktrees/`) — match relative, and this one returns EMPTY not an error. Diff regenerated artifacts by content, never mtime (llm#883/#889, 2026-08-03)
+
+## Deploy Trigger Excludes Vignette Data (see deploy-trigger-excludes-vignette-data.md)
+- A publish workflow's `paths:` filter can omit `inst/extdata/vignettes/**` — the data vignettes actually read — so a snapshot-only fix merges green and never deploys; check for a run AT your merge SHA, and check recent run history (3 consecutive failures = site pinned at last green, so the "live" defect may not be live at all) (llm#881, 2026-08-03)
+
 ## Pre-rendered docs/ ≠ Live (see feedback_prerendered-docs-deploy-verification.md)
 - Repos that commit pre-rendered `docs/` (deploy CI only publishes, renders nothing) — a source/.qmd fix is INERT until docs/ is re-rendered + committed. "PR merged + deploy green" ≠ live. Verify the DEPLOYED artifact (curl live HTML / git grep origin/main docs/**), not the source or deploy status. Shinylive: app embedded in rendered HTML. (origin: micromort quiz \d fix appeared merged+green but live app still broken, 2026-07-27)

--- a/.claude/memory/deploy-trigger-excludes-vignette-data.md
+++ b/.claude/memory/deploy-trigger-excludes-vignette-data.md
@@ -1,0 +1,25 @@
+---
+name: deploy-trigger-excludes-vignette-data
+description: "A publish workflow's `paths:` filter can omit the data files the vignettes actually read (inst/extdata/vignettes/**), so a data-only fix merges green and never deploys. Check the trigger paths AND recent run history before claiming a fix is live."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 92dd2058-9694-4ebc-a815-163d88d8b4de
+  modified: 2026-08-03T10:11:15.018Z
+---
+
+A repo can render in CI (so [[prerendered-docs-deploy-verification]]'s "committed `docs/`" tell is absent) and **still** strand a fix, because the publish workflow's `on.push.paths:` filter does not list the files that changed.
+
+In `llm`, `.github/workflows/quarto-publish.yaml` triggers on `vignettes/**`, `_quarto.yml`, `_brand.yml`, `_includes/**`, `index.qmd`, `R/ccusage.R`, `inst/extdata/ccusage_*.json`, `DESCRIPTION`. The telemetry vignettes read their plots and tables from `inst/extdata/vignettes/vig_*.rds` via `safe_tar_read()` — **and that path is not in the filter.** A snapshot-only fix therefore merges, goes green, and never publishes.
+
+**Why:** the trigger filter encodes an assumption that only `.qmd`/config changes affect output. Once vignettes read committed *data artifacts*, that assumption is false — the data is as much an input to the rendered page as the source is.
+
+**How to apply:**
+1. Before claiming any vignette/site fix is live, read the publish workflow's `paths:` list and ask whether the files you changed are in it. Merging is not deploying.
+2. Confirm empirically, not by inference: `gh run list --workflow <wf> --limit 5 --json headSha,conclusion` — check a run exists **at your merge SHA** and that it succeeded. No run at your SHA = the filter excluded you.
+3. Also check the *recent* run history, not just your own. Consecutive failures mean the live site is pinned at the last green SHA, so the defect you are "fixing" may not even be live yet — verify with `curl` + `grep` against the deployed URL before describing live symptoms.
+4. Fixes: add the data glob to `paths:`, or drop `paths:` entirely and rely on the render being cheap/cached.
+
+**Origin (2026-08-03, llm#881 / [PR #882](https://github.com/JohnGavin/llm/pull/882)):** the `qa_no_nulls` gate found `vig_codexbar_project_cost_plot.rds` committed as NULL and the PR body asserted "that chart is blank on the deployed site right now." Both halves needed correcting. The snapshot really was NULL (44 bytes), but the chart was **not live**: `quarto-publish` had failed three consecutive runs since 2026-08-02 with `path for html_dependency not found: /nix/store/…-r-DT-0.34.0/library/DT/htmlwidgets/lib/datatables`, so the site was pinned at 2026-08-01 — before the codexbar targets existed. `curl` of the live `session-efficiency.html` returned **0 matches** for "codexbar", proving the section had never shipped. Merging the fix also triggered **no** publish run, because only `.rds` files under `inst/extdata/vignettes/` changed.
+
+Related: [[prerendered-docs-deploy-verification]] (the committed-`docs/` variant of "merged ≠ live"), [[deploy-gap-stale-main-checkout]] (the stale-local-checkout variant).

--- a/.claude/memory/portable-build-artifacts.md
+++ b/.claude/memory/portable-build-artifacts.md
@@ -1,0 +1,27 @@
+---
+name: portable-build-artifacts
+description: "A committed artifact must not depend on the checkout that built it. Two shapes: absolute paths serialised inside objects (repair on READ, not by regenerating), and path filters matched against absolute paths that swallow their own scan root (match relative)."
+metadata:
+  node_type: memory
+  type: feedback
+---
+
+Any build that **writes a file which gets committed** and is later read by a different machine or checkout must produce a location-independent artifact. Two distinct failure shapes, both observed in `llm` within 48 hours, both merged green, both found days later.
+
+**Shape 1 — absolute paths serialised inside the object.** `saveRDS()` preserves internals verbatim. A `DT::datatable()` records its JS assets as an *absolute* `html_dependency` path, so the committed `.rds` carries the exporting machine's `/nix/store/…` prefix. Renders locally, dies in CI with `path for html_dependency not found`.
+
+**Why:** regenerating does NOT fix it — it only re-acquires whichever path the *new* exporting machine has, so it returns on the next export from anywhere else. Repair at **read** time: for each dependency whose path is absent, re-resolve `…/library/<PKG>/<rest>` → `system.file(<rest>, package = <PKG>)`. Must be a no-op when the path resolves, must skip `package`-relative deps, and must leave unresolvable paths intact so failure stays visible.
+
+**Shape 2 — a path filter matched against absolute paths.** An exclusion meant to skip *nested* subtrees (`grepl("/(archive|worktrees)/", files)`) also matches when the **scan root itself** contains the token. Every worktree path does — both `.claude/worktrees/` (dispatched agents) and `~/docs_gh/worktrees/` (manual, per [[worktree-location]]). So a target built anywhere but the main checkout scanned 377 files and kept 0.
+
+**Why it is worse than Shape 1:** it does not error. It returns a well-formed *empty* result that flows downstream and surfaces somewhere unrelated — here, a `facet_wrap()` in a vignette that killed the whole site build. Fix: `fs::path_rel(files, scan_root)` then match `(^|/)token/`.
+
+**How to apply:**
+1. Treat "regenerate the artifact" as a **suspect** fix for any path-not-found error — ask whether the path is environment-specific first.
+2. Before committing a regenerated artifact, **diff its content against the prior version** — row count, category coverage, non-NA share. Existence and mtime are not evidence. A regeneration that shrinks it by orders of magnitude is a defect until proven otherwise.
+3. Regenerate committed artifacts from the **main checkout** until the exporter is proven location-independent; otherwise have it print the checkout it ran from so a worktree build is visible in review.
+4. Grep for the Shape-2 pattern wherever a scan root is user- or environment-derived: `grepl("/<token>/", <absolute paths>)`.
+
+**Origin (2026-08-03):** [llm#883](https://github.com/JohnGavin/llm/issues/883)/[#885](https://github.com/JohnGavin/llm/pull/885) — 13 snapshots carried absolute DT paths, blocking all publishing for 2 days. [llm#889](https://github.com/JohnGavin/llm/issues/889)/[#890](https://github.com/JohnGavin/llm/pull/890) — [#868](https://github.com/JohnGavin/llm/pull/868) regenerated `vig_scrolly_config` from a worktree, replacing 222 rows with 0, and it shipped silently. Neither was visible to `qa_no_nulls` (tests NULL; a zero-row tibble passes) or `qa_rds_freshness` (compares mtimes, never content).
+
+Related: [[deploy-trigger-excludes-vignette-data]], [[prerendered-docs-deploy-verification]], [[worktree-location]], rule `portable-build-artifacts`.

--- a/.claude/rules/portable-build-artifacts.md
+++ b/.claude/rules/portable-build-artifacts.md
@@ -1,0 +1,160 @@
+---
+paths:
+  - "**/data-raw/**"
+  - "**/inst/extdata/**"
+  - "**/R/tar_plans/**"
+  - "**/_includes/**"
+  - "**/_targets.R"
+---
+
+# Rule: Portable Build Artifacts
+
+## When This Applies
+
+Any time a build **writes a file that gets committed** — a serialised object
+(`.rds`, `.parquet`, `.qs`), a rendered HTML page, a generated config — and that
+file is later read by a *different* machine (CI, a colleague, a deploy runner) or
+from a *different checkout* (a worktree, a fresh clone).
+
+## CRITICAL: The Checkout That Built It Must Not Leak Into It
+
+A committed artifact is only reproducible if it is **independent of where it was
+built**. Two failure modes, both observed in `llm` within 48 hours, both of which
+merged green and were only caught days later by a CI render log:
+
+| Leak | What gets baked in | Symptom |
+|---|---|---|
+| **Absolute paths inside serialised objects** | The builder's filesystem layout | Renders locally, dies in CI |
+| **Path filters matched against absolute paths** | The builder's checkout location | Silently produces *empty* output |
+
+The second is far more dangerous: it does not error, it returns nothing.
+
+---
+
+## Part 1: Serialised objects capture absolute paths
+
+`saveRDS()` preserves an object's internals verbatim, **including absolute
+filesystem paths the object captured at construction time**. The clearest case is
+`htmltools::htmlDependency()`, which every htmlwidget carries:
+
+```r
+x <- readRDS("inst/extdata/vignettes/vig_github_activity_table.rds")
+x$dependencies[[2]]$src$file
+#> "/nix/store/y630zvw…-r-DT-0.34.0/library/DT/htmlwidgets/lib/datatables"
+```
+
+That path exists on the machine that ran the export and **nowhere else**. CI
+installs the same package at a different prefix and the render aborts:
+
+```
+Error: path for html_dependency not found: /nix/store/y630zvw…/lib/datatables
+```
+
+### Required pattern — repair at READ time, never by regenerating
+
+Regenerating the artifact does **not** fix this. It only re-acquires whichever
+path the *new* exporting machine has, so the defect returns on the next export
+from anywhere else.
+
+Repair when the artifact is loaded:
+
+```r
+# For each dependency whose recorded path is absent on THIS machine,
+# re-resolve it from the installed package.
+if (!file.exists(f) && !dir.exists(f)) {
+  m <- regmatches(f, regexec("/library/([^/]+)/(.*)$", f))[[1]]
+  if (length(m) == 3L) {
+    resolved <- system.file(m[3], package = m[2])
+    if (nzchar(resolved)) dep$src$file <- resolved
+  }
+}
+```
+
+Three properties this must have:
+
+1. **No-op when the path already resolves** — so it changes nothing on the
+   machine that wrote the artifact.
+2. **Leave `package`-relative dependencies alone** — those are already portable.
+3. **Leave unresolvable paths at their original value** — do not blank them.
+   A visible failure beats a silently-missing asset.
+
+Same hazard class, worth checking for: fonts resolved to absolute paths, cached
+`system.file()` results, `here::here()` values captured into a stored object,
+open connections, and `environment()` captured by closures inside the object.
+
+---
+
+## Part 2: Path filters must match RELATIVE to the scan root
+
+An exclusion intended to skip *nested* subtrees must never be matched against the
+absolute path, because the **scan root itself** may contain the excluded token.
+
+```r
+# WRONG — the scan root can contain the token
+files <- files[!grepl("/(archive|worktrees)/", files)]
+
+# RIGHT — only genuinely nested subtrees are dropped
+rel   <- fs::path_rel(files, scan_root)
+files <- files[!grepl("(^|/)(archive|worktrees)/", rel)]
+```
+
+Why it matters here: **every** worktree path contains `/worktrees/` — both
+`.claude/worktrees/` (every dispatched agent) and `~/docs_gh/worktrees/` (every
+manual worktree, per `worktree-location`). So a target built anywhere except the
+main checkout scanned 377 files and kept **zero**.
+
+The result is not an error. It is a well-formed, empty result that flows
+downstream and only surfaces somewhere far away — in the observed case, a
+`facet_wrap()` call in a vignette that killed the entire site build.
+
+---
+
+## Part 3: Verify artifacts by content, not by existence
+
+Both incidents passed every gate in place at the time:
+
+| Gate | What it checked | Why it missed this |
+|---|---|---|
+| `qa_no_nulls` | value is not `NULL` | a zero-row tibble is not `NULL` |
+| `qa_rds_freshness` | snapshot mtime vs target mtime | never inspects content |
+| CI / deploy status | workflow exit code | the data path was not in `on.push.paths` |
+
+**Before committing a regenerated artifact, diff it against the previous
+version's content** — row count, category coverage, non-NA share — not just its
+existence or timestamp. A regeneration that shrinks an artifact by orders of
+magnitude is a defect until proven otherwise:
+
+```r
+old <- readRDS(...); new <- <rebuild>
+stopifnot(nrow(new) >= 0.5 * nrow(old))   # tune per artifact
+```
+
+---
+
+## Part 4: Prefer the canonical checkout for regeneration
+
+Until an exporter is proven location-independent, regenerate committed artifacts
+**from the project's main checkout**, not from a worktree. Where that cannot be
+guaranteed, have the exporter print the checkout path it ran from, so a
+worktree-built artifact is visible in review rather than silent.
+
+## Forbidden Patterns
+
+| Pattern | Why wrong | Fix |
+|---|---|---|
+| `saveRDS()` an htmlwidget and assume it is portable | Absolute asset paths baked in | Repair on read (Part 1) |
+| "Just regenerate it" to fix a path error | Re-acquires the new machine's path | Repair on read, not on write |
+| `grepl("/token/", absolute_path)` to skip subtrees | Matches the scan root too | Match relative to the root (Part 2) |
+| Accepting a regenerated artifact because it is non-NULL | Empty ≠ NULL | Compare content to the prior version (Part 3) |
+| Treating "CI green" as "artifact correct" | The data path may not even trigger CI | Verify the deployed artifact |
+
+## Origin
+
+- [llm#883](https://github.com/JohnGavin/llm/issues/883) / [#885](https://github.com/JohnGavin/llm/pull/885) — DT `html_dependency` absolute nix paths; 13 snapshots affected; blocked all publishing for 2 days
+- [llm#889](https://github.com/JohnGavin/llm/issues/889) / [#890](https://github.com/JohnGavin/llm/pull/890) — worktree-exclusion regex matched its own scan root; `vig_scrolly_config` regenerated 222 rows → 0 by [#868](https://github.com/JohnGavin/llm/pull/868) and shipped silently
+
+## Related
+
+- [`prerendered-docs-deploy-verification`](../memory/feedback_prerendered-docs-deploy-verification.md) — merged ≠ live; verify the deployed artifact
+- [`worktree-location`](worktree-location.md) — why every worktree path contains `/worktrees/`
+- [`data-validation-timeseries`](data-validation-timeseries.md) — content-level validation targets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Single trailing `\| head -N` / `\| tail -N` / `\| wc -l` / `\| sort -u` / `\| un
 - Quarto / vignettes: `dark-mode-completeness`, `narrative-evidence-block`, `narrative-colour-persistence`, `vignette-build-info-block`, `uniform-typography`
 - Dashboards / viz: `dashboard-table-styling`, `dashboard-filter-placement`, `mermaid-click-anchors`, `mermaid-dashboard-pattern`
 - Data / analysis: `cross-cutting-rename`, `data-glossary-and-entity-resolution`, `unified-observability-schema`, `survival-reporting`
+- Build artifacts: `portable-build-artifacts` (committed artifacts must not depend on which checkout built them — absolute paths in serialised objects; path filters matching their own scan root)
 - Tooling: `roborev-exclude-patterns`
 
 **Dark-mode contrast (every Quarto project):** Single global script at `~/docs_gh/llm/.claude/scripts/check_dark_contrast.sh` (public mirror: `https://raw.githubusercontent.com/JohnGavin/llm/main/.claude/scripts/check_dark_contrast.sh`). NEVER copy into a project. EVERY `_quarto.yml` MUST add this line under `project: post-render:` — `- /Users/johngavin/docs_gh/llm/.claude/scripts/quarto_post_render_contrast.sh`. Render fails on any uncovered light inline background. See `dark-mode-completeness` rule.


### PR DESCRIPTION
Encapsulates two lessons from today so every project inherits them, per the
request to make these reusable rather than leaving them in issue threads.

## Why one rule and not two

#885 and #890 look unrelated — one is a DT asset path, the other a regex. They
are the same bug: **the checkout that built a committed artifact leaked into the
artifact**. Both merged green. Both were only caught days later in a CI render
log. Framing them together is what makes the lesson portable.

| Shape | What leaks | Symptom |
|---|---|---|
| Absolute paths serialised inside objects | The builder's filesystem | Renders locally, dies in CI |
| Path filters matched against absolute paths | The builder's checkout location | Silently produces **empty** output |

Shape 2 is the dangerous one — it does not error. It returns a well-formed empty
result that surfaces somewhere unrelated. Here it was a `facet_wrap()` in a
vignette that killed the entire site build, two days after `vig_scrolly_config`
was quietly regenerated from 222 rows to 0.

## What the rule tells a future session

- **Repair environment-specific paths at READ time.** "Just regenerate it" is a
  *suspect* fix — regenerating only re-acquires whichever path the new exporting
  machine has, so the defect returns from the next machine.
- **Match path filters relative to the scan root.** Every worktree path contains
  `/worktrees/` — both `.claude/worktrees/` and `~/docs_gh/worktrees/` — so this
  is not a niche case, it is every checkout except main.
- **Verify regenerated artifacts by content.** Both defects passed every gate:
  `qa_no_nulls` tests for `NULL` and a zero-row tibble is not `NULL`;
  `qa_rds_freshness` compares mtimes and never reads content.
- **Regenerate from the canonical checkout** until an exporter is proven
  location-independent, or make it print the checkout it ran from so a
  worktree build is visible in review.

## Scoping

`paths:` limited to `data-raw/**`, `inst/extdata/**`, `R/tar_plans/**`,
`_includes/**`, `_targets.R` — it injects only where artifacts are produced or
consumed, per the llm#590 scoping requirement. Not a mandatory always-loaded
rule. Indexed in `AGENTS.md` under a new **Build artifacts** category.

## Also in this PR

The memory entries written earlier this session (`portable-build-artifacts`,
`deploy-trigger-excludes-vignette-data`) plus their `MEMORY.md` index lines.
They were sitting **uncommitted in the main checkout** via the `~/.claude/memory`
symlink — a dirty tree there jams the cron `--ff-only` auto-pull, so they needed
to land on a branch rather than linger.

Refs #883, #885, #889, #890, #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)