### PR TITLE
feat(staleness): consolidated fact table + out-of-band collector heartbeat (#893 steps 1-2)

### DIFF
--- a/.claude/hooks/session_init.sh
+++ b/.claude/hooks/session_init.sh
@@ -1646,6 +1646,32 @@ if [ "${CLAUDE_ETL_FRESHNESS_CHECK:-1}" != "0" ]; then
   fi
 fi
 
+# ── Phase 15d: Consolidated Staleness Heartbeat — BACKGROUND (DuckDB query ≤5s) ─
+# Out-of-band check for llm#893 defect 3: every existing freshness checker
+# (Phase 15a/15c above, launchd_health_events) was itself a launchd job, so a
+# total launchd outage (llm#886, all 25 jobs dead for 2 days) silenced the
+# monitor along with everything it watched. This phase fires on session
+# start — a different trigger class from launchd — so a dead collector
+# (.claude/scripts/staleness_collect.sh, com.claude.staleness-collect) is
+# visible the next time a session opens, not after days of silence.
+# staleness_banner.sh itself implements the priority rule: if the collector's
+# own heartbeat is stale, print ONLY that (nothing else in the table is
+# trustworthy); otherwise print a capped summary of other stale assets;
+# otherwise silent. See that script and staleness_schema.sql for detail.
+# Skippable: CLAUDE_STALENESS_CHECK=0
+_staleness_cache="${HOME}/.claude/logs/session_init_staleness_cache.txt"
+if [ "${CLAUDE_STALENESS_CHECK:-1}" != "0" ]; then
+  if [ -f "$_staleness_cache" ]; then
+    _staleness_cached=$(cat "$_staleness_cache" 2>/dev/null) || true
+    [ -n "$_staleness_cached" ] && echo "$_staleness_cached"
+  fi
+  _staleness_script="${CLAUDE_DIR}/scripts/staleness_banner.sh"
+  if [ -x "$_staleness_script" ]; then
+    mkdir -p "$(dirname "$_staleness_cache")"
+    nohup bash -c "timeout 5 '$_staleness_script' 2>/dev/null > '$_staleness_cache' || printf '' > '$_staleness_cache'" > /dev/null 2>&1 &
+  fi
+fi
+
 # ── Phase 14: Record session-start SHA (for session-end refine) ───────────────
 # Writes HEAD SHA to ~/.claude/.session_start_sha_<project> so that
 # session_end_refine.sh can bound a roborev refine to commits from this session.

--- a/.claude/launchd/com.claude.staleness-collect.plist
+++ b/.claude/launchd/com.claude.staleness-collect.plist
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Populate the unified `staleness` fact table daily (llm#893 step 2):   -->
+    <!-- carries over etl_freshness rows (assigning a mandatory cadence to    -->
+    <!-- the sources that previously had none), derives one row per deployed  -->
+    <!-- com.claude.* launchd job from its own schedule, and writes this      -->
+    <!-- script's own heartbeat row. session_init.sh Phase 15d reads the      -->
+    <!-- resulting staleness_status view out-of-band (a different trigger     -->
+    <!-- class than launchd) so a dead collector is visible at next session   -->
+    <!-- start, not after days of silence (the llm#886 failure mode).        -->
+    <!--                                                                       -->
+    <!-- 08:15 deliberately follows launchd-health-weekly (08:00) and         -->
+    <!-- precedes the 09:00 peak (worktree-gc, roborev-poll-merges,           -->
+    <!-- roborev-project-backlog, config-pulse) — same contention-avoidance   -->
+    <!-- reasoning as that job's plist comment.                               -->
+    <!--                                                                       -->
+    <!-- This collector's own expected_cadence_hours (24, see                 -->
+    <!-- staleness_collect.sh's collect_self_heartbeat()) assumes this daily  -->
+    <!-- schedule — keep the two in sync if this changes.                     -->
+    <!--                                                                       -->
+    <!-- Install / reload:                                                    -->
+    <!--   launchctl bootout gui/$(id -u)/com.claude.staleness-collect 2>/dev/null -->
+    <!--   cp .claude/launchd/com.claude.staleness-collect.plist               -->
+    <!--        ~/Library/LaunchAgents/                                        -->
+    <!--   launchctl bootstrap gui/$(id -u)                                   -->
+    <!--        ~/Library/LaunchAgents/com.claude.staleness-collect.plist     -->
+
+    <key>Label</key>
+    <string>com.claude.staleness-collect</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/johngavin/docs_gh/llm/bin/launchd-recorders/staleness-collect</string>
+    </array>
+
+    <!-- launchd's default PATH omits Homebrew/nix dirs; duckdb resolution is -->
+    <!-- handled inside staleness_collect.sh's duck_run() (direct binary,     -->
+    <!-- else nix-shell fallback), so only HOME is needed here. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/johngavin</string>
+    </dict>
+
+    <!-- Daily 08:15 -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>15</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/johngavin/.claude/logs/staleness_collect.out</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/johngavin/.claude/logs/staleness_collect.err</string>
+
+    <key>TimeOut</key>
+    <integer>60</integer>
+
+    <!-- Do NOT run on load — only on the schedule. -->
+    <key>RunAtLoad</key>
+    <false/>
+
+</dict>
+</plist>

--- a/.claude/scripts/staleness_banner.sh
+++ b/.claude/scripts/staleness_banner.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# staleness_banner.sh — session-start banner for the consolidated staleness table.
+#
+# Reads the `staleness_status` view (llm#893 steps 1-2; populated by
+# .claude/scripts/staleness_collect.sh) and implements the out-of-band check
+# that fixes defect 3: every prior checker was itself a launchd job, so a
+# total launchd outage (llm#886) silenced the monitor along with everything
+# it watched. This script is wired into session_init.sh — a different
+# trigger class from launchd — so a dead collector becomes visible the next
+# time a session starts, not after days of silence.
+#
+# Rule, in priority order:
+#   1. If the collector's own heartbeat row is missing or stale, print ONLY
+#      that — when the collector is dead, no other row in the table is
+#      trustworthy, so nothing else is worth printing.
+#   2. Otherwise, if any other asset is stale, print a capped one-line
+#      summary naming up to STALENESS_BANNER_MAX assets.
+#   3. Otherwise, silent.
+#
+# Usage:
+#   staleness_banner.sh
+#   STALENESS_DB=/path/to/scratch.duckdb staleness_banner.sh   # testing
+#
+# Fail-open: a missing duckdb binary, a missing DB, a missing `staleness`
+# table/view, or any query error all print nothing and exit 0. Never aborts
+# the caller under `set -euo pipefail` (hook-pipefail-no-stderr lesson,
+# llm#695) — every command substitution below is guarded with `|| true` or a
+# preceding existence check.
+#
+# Tracked in llm#893 step 2.
+
+set -uo pipefail
+
+DB="${STALENESS_DB:-${HOME}/.claude/logs/unified.duckdb}"
+MAX_NAMED="${STALENESS_BANNER_MAX:-6}"
+
+command -v duckdb >/dev/null 2>&1 || exit 0
+[ -f "$DB" ] || exit 0
+
+# ─── Collector heartbeat check (priority 1) ──────────────────────────────────
+# NULL-safe: if the `staleness` table/view doesn't exist yet, or the
+# collector has never written a row, this query returns nothing — treated
+# the same as "collector stale" (fail-safe, not silent-benign).
+_collector_row=$(duckdb -init /dev/null "$DB" -noheader -list -c "
+  SELECT status || '|' ||
+         COALESCE(CAST(FLOOR(EXTRACT(EPOCH FROM (current_timestamp - last_seen_ts)) / 3600.0) AS BIGINT)::VARCHAR, '')
+  FROM staleness_status
+  WHERE asset_kind = 'collector' AND asset_id = 'staleness_collect';
+" 2>/dev/null) || exit 0
+
+if [ -z "$_collector_row" ]; then
+  echo "staleness: COLLECTOR STALE (never observed) — all staleness data untrustworthy"
+  exit 0
+fi
+
+_collector_status="${_collector_row%%|*}"
+_collector_hours="${_collector_row#*|}"
+
+if [ "$_collector_status" = "stale" ]; then
+  if [ -n "$_collector_hours" ]; then
+    echo "staleness: COLLECTOR STALE (last ran ${_collector_hours}h ago) — all staleness data untrustworthy"
+  else
+    echo "staleness: COLLECTOR STALE — all staleness data untrustworthy"
+  fi
+  exit 0
+fi
+
+# ─── Compact summary of other stale assets (priority 2) ─────────────────────
+_stale_rows=$(duckdb -init /dev/null "$DB" -noheader -list -c "
+  SELECT asset_kind || ':' || asset_id
+  FROM staleness_status
+  WHERE status = 'stale' AND asset_kind != 'collector'
+  ORDER BY asset_kind, asset_id;
+" 2>/dev/null) || exit 0
+
+[ -n "$_stale_rows" ] || exit 0
+
+_total=$(printf '%s\n' "$_stale_rows" | grep -c . || true)
+_named=$(printf '%s\n' "$_stale_rows" | head -n "$MAX_NAMED" | paste -sd, -)
+_extra=$(( _total - MAX_NAMED ))
+
+if [ "$_extra" -gt 0 ]; then
+  echo "staleness: ${_total} stale (${_named}, +${_extra} more)"
+else
+  echo "staleness: ${_total} stale (${_named})"
+fi
+
+exit 0

--- a/.claude/scripts/staleness_collect.sh
+++ b/.claude/scripts/staleness_collect.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+# staleness_collect.sh — populate the unified `staleness` fact table (llm#893 step 2)
+#
+# One out-of-band collector for "when did this last run/produce data, and how
+# often should it?" across three asset kinds:
+#
+#   etl_source   — carried over from the existing etl_freshness table
+#   launchd_job  — derived from a deployed plist's schedule + launchctl state
+#   collector    — this script's own heartbeat row (asset_id='staleness_collect')
+#
+# This table stores FACTS only (last_seen_ts, expected_cadence_hours) — never
+# a computed status. Status is the `staleness_status` VIEW (see
+# staleness_schema.sql), recomputed at every read. That directly fixes
+# llm#893 defect 1: a stored status can go stale itself (roborev's row read
+# 'fresh' while 38h old against a 24h cadence, because nothing recomputed it
+# after the writer that set it died).
+#
+# expected_cadence_hours is NOT NULL for every row this script writes — no
+# 'unknown' escape hatch (defect 2). See _etl_cadence_override() below for
+# the per-source reasoning on the 5 etl_freshness sources that currently
+# carry a NULL cadence (sessions, skill_usage, command_usage, agent_runs,
+# llmtelemetry — one more than the 4 the issue named; llmtelemetry was added
+# to etl_freshness after the issue was filed).
+#
+# Read out-of-band, from a different trigger class than launchd (defect 3):
+# see staleness_banner.sh, wired into session_init.sh — a total launchd
+# outage (llm#886) is then visible at the next session start, not silent.
+#
+# Usage:
+#   .claude/scripts/staleness_collect.sh [--db PATH]
+#   .claude/scripts/staleness_collect.sh --selftest
+#
+# Env:
+#   STALENESS_DB          override target DB (default ~/.claude/logs/unified.duckdb)
+#   STALENESS_PLIST_DIR   override plist dir to scan (default ~/Library/LaunchAgents)
+#
+# Follows housekeeping-framework: writes a housekeeping_runs start row, and
+# updates it at the end with status ('ok'|'partial'|'failed') + rows_written.
+#
+# Fail-partial, not fail-silent: a single source failing to collect (missing
+# table, unparseable plist, launchctl unavailable) logs a WARN and is
+# skipped — it does not abort collection of the remaining sources. Only a
+# missing duckdb binary or missing DB aborts the whole run (recorded as
+# 'failed' in housekeeping_runs, non-zero exit).
+#
+# Tracked in llm#893 (step 2 of the Sequencing plan). Steps 3-5 (repointing
+# the email/dashboard, content/unusual-activity checks, retiring
+# launchd_runs.duckdb) are out of scope for this script.
+
+set -uo pipefail
+
+# ─── PATH (launchd runs with a minimal PATH) ─────────────────────────────────
+export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# ─── Paths ────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NIX_DEFAULT="$(cd "${SCRIPT_DIR}/../.." 2>/dev/null && pwd)/default.nix"
+DB="${STALENESS_DB:-${HOME}/.claude/logs/unified.duckdb}"
+PLIST_DIR="${STALENESS_PLIST_DIR:-${HOME}/Library/LaunchAgents}"
+LOG_DIR_DEFAULT="${HOME}/.claude/logs"
+SCHEMA_APPLY="${SCRIPT_DIR}/staleness_schema_apply.sh"
+SCHEMA_SQL="${SCRIPT_DIR}/staleness_schema.sql"
+PLUTIL=/usr/bin/plutil
+PYTHON3=/usr/bin/python3
+
+# ─── Argument parsing ─────────────────────────────────────────────────────────
+MODE="normal"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --db)       DB="${2:-}"; shift 2 ;;
+    --selftest) MODE="selftest"; shift ;;
+    *)
+      echo "Usage: $0 [--db PATH] [--selftest]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ─── duckdb invocation (prefer direct; fall back to nix-shell wrapper) ───────
+duck_run() {
+  if command -v duckdb >/dev/null 2>&1; then
+    duckdb -init /dev/null "$@"
+  elif command -v nix-shell >/dev/null 2>&1 && [ -f "${NIX_DEFAULT}" ]; then
+    local q="" a
+    for a in "$@"; do q+=" $(printf '%q' "$a")"; done
+    nix-shell "${NIX_DEFAULT}" --run "duckdb -init /dev/null${q}"
+  else
+    echo "staleness_collect: duckdb not found" >&2
+    return 1
+  fi
+}
+
+# ─── SQL string escaping ──────────────────────────────────────────────────────
+_esc() { printf '%s' "$1" | sed "s/'/''/g"; }
+
+# ─── Counters (global; functions below mutate these directly) ───────────────
+ROWS_WRITTEN=0
+WARN_COUNT=0
+FAIL_COUNT=0
+
+# ─── Cadence overrides for etl_freshness sources with NULL cadence ──────────
+# (llm#893 defect 2: NULL degraded to status='unknown', which read as benign
+# — 'sessions' sat stale 11 days reporting 'unknown', not 'stale'.)
+#
+# Values derived from observed inter-row-gap statistics in unified.duckdb on
+# 2026-08-03 (WITH s AS (SELECT ts, LAG(ts) OVER (ORDER BY ts) AS prev FROM
+# <table>) SELECT MAX(...), QUANTILE_CONT(..., 0.9|0.95) ...):
+#   sessions       p95 gap ~1.5h during active use. 72h (3d) tolerates a full
+#                  weekend-plus-a-day of inactivity before flagging — the
+#                  observed 11-day real staleness incident clears this by 3.5x.
+#   skill_usage    event-driven, sparse. Observed max gap 335h (~14d). 336h
+#                  sits just above the noisiest real gap seen so far.
+#   command_usage  observed p90 gap ~112h, max ~165h. 168h (7d) rounds up.
+#   agent_runs     observed p90 gap ~21h. Agents run near-daily in active
+#                  development; 48h (2d) catches genuine dead periods without
+#                  false-alarming on a single quiet day.
+#   llmtelemetry   written by a separate project's pipeline, outside this
+#                  repo's read scope — no in-repo history to derive a cadence
+#                  from. Documented default: 24h, matching its sibling
+#                  cron-fed sources (roborev, burn_rate) in the same table.
+_etl_cadence_override() {
+  case "$1" in
+    sessions)      echo "72" ;;
+    skill_usage)   echo "336" ;;
+    command_usage) echo "168" ;;
+    agent_runs)    echo "48" ;;
+    llmtelemetry)  echo "24" ;;
+    *)             echo "" ;;
+  esac
+}
+
+# ─── collect_etl_sources: carry rows from etl_freshness into staleness ──────
+collect_etl_sources() {
+  local rows
+  rows="$(duck_run "$DB" -noheader -list -c "
+    SELECT source_name || '|' ||
+           COALESCE(last_row_ts::VARCHAR, '') || '|' ||
+           COALESCE(last_etl_run_ts::VARCHAR, '') || '|' ||
+           COALESCE(expected_cadence_hours::VARCHAR, '')
+    FROM etl_freshness;
+  " 2>/dev/null)"
+  if [ $? -ne 0 ]; then
+    echo "staleness_collect: WARN could not read etl_freshness (missing table?)" >&2
+    WARN_COUNT=$((WARN_COUNT + 1))
+    return
+  fi
+  [ -z "$rows" ] && return
+
+  local _name _lrt _let _cad
+  while IFS='|' read -r _name _lrt _let _cad; do
+    [ -z "$_name" ] && continue
+
+    local _last_seen="$_lrt"
+    [ -z "$_last_seen" ] && _last_seen="$_let"
+
+    local _cadence="$_cad"
+    if [ -z "$_cadence" ]; then
+      _cadence="$(_etl_cadence_override "$_name")"
+    fi
+    if [ -z "$_cadence" ]; then
+      echo "staleness_collect: WARN no cadence for etl_source '${_name}' (not in override table) — skipping" >&2
+      WARN_COUNT=$((WARN_COUNT + 1))
+      continue
+    fi
+
+    local _last_seen_sql="NULL"
+    [ -n "$_last_seen" ] && _last_seen_sql="TIMESTAMPTZ '$(_esc "$_last_seen")'"
+
+    if duck_run "$DB" -c "
+      INSERT OR REPLACE INTO staleness
+        (asset_kind, asset_id, project, last_seen_ts, expected_cadence_hours, last_exit_code, observed_at)
+      VALUES (
+        'etl_source', '$(_esc "$_name")', NULL,
+        ${_last_seen_sql}, ${_cadence}, NULL, current_timestamp
+      );
+    " >/dev/null 2>&1; then
+      ROWS_WRITTEN=$((ROWS_WRITTEN + 1))
+    else
+      echo "staleness_collect: WARN upsert failed for etl_source '${_name}'" >&2
+      WARN_COUNT=$((WARN_COUNT + 1))
+    fi
+  done <<< "$rows"
+}
+
+# ─── _launchd_cadence_hours: derive cadence from a plist's schedule keys ────
+# Adapted from bin/launchd_health_audit.sh's expected_cadence_seconds(). Falls
+# back to a documented default of 86400s (24h, "assume daily") when the
+# schedule is unparseable or absent — never NULL.
+_launchd_cadence_hours() {
+  local json="$1"
+  local seconds
+  seconds="$(printf '%s' "$json" | "$PYTHON3" -c "
+import sys, json
+d = json.load(sys.stdin)
+si = d.get('StartInterval')
+if si:
+    print(int(si))
+    sys.exit()
+sci = d.get('StartCalendarInterval')
+if sci is None:
+    print(86400)  # no declared schedule -> documented default: assume daily
+    sys.exit()
+if isinstance(sci, list):
+    # Multiple entries commonly repeat the same Hour:Minute across different
+    # Weekdays (e.g. Mon/Tue/Wed all at 09:00) — sorting by minute-of-day
+    # alone then yields adjacent duplicates and a diff of 0, which would make
+    # the cadence 0h (=> permanently 'stale'). Only strictly-positive diffs
+    # between distinct minute-of-day slots count; an all-duplicate list falls
+    # back to the documented daily default, same as a single-entry list.
+    entries = sorted(sci, key=lambda x: x.get('Hour', 0) * 60 + x.get('Minute', 0))
+    diffs = []
+    for i in range(1, len(entries)):
+        a = entries[i-1].get('Hour', 0) * 60 + entries[i-1].get('Minute', 0)
+        b = entries[i].get('Hour', 0) * 60 + entries[i].get('Minute', 0)
+        d = (b - a) * 60
+        if d > 0:
+            diffs.append(d)
+    print(min(diffs) if diffs else 86400)
+    sys.exit()
+if isinstance(sci, dict):
+    wd = sci.get('Weekday')
+    print(604800 if wd is not None else 86400)
+" 2>/dev/null)"
+  case "$seconds" in
+    ''|*[!0-9]*) seconds=86400 ;;
+  esac
+  awk -v s="$seconds" 'BEGIN { printf "%.4f", s / 3600.0 }'
+}
+
+# ─── _launchd_log_file: find the log used as a "last fired" proxy ───────────
+# Priority: StandardOutPath from the plist, else derived <suffix>.out/.log
+# under ~/.claude/logs (same derivation as launchd_health_audit.sh).
+_launchd_log_file() {
+  local label="$1" out_path="$2"
+  if [ -n "$out_path" ] && [ -f "$out_path" ]; then
+    echo "$out_path"
+    return
+  fi
+  local suffix
+  suffix="$(printf '%s' "$label" | sed 's/^com\.claude\.//' | tr '-' '_')"
+  if [ -f "${LOG_DIR_DEFAULT}/${suffix}.out" ]; then
+    echo "${LOG_DIR_DEFAULT}/${suffix}.out"
+    return
+  fi
+  if [ -f "${LOG_DIR_DEFAULT}/${suffix}.log" ]; then
+    echo "${LOG_DIR_DEFAULT}/${suffix}.log"
+    return
+  fi
+  echo ""
+}
+
+# ─── collect_launchd_jobs: one row per deployed com.claude.* plist ──────────
+collect_launchd_jobs() {
+  if [ "$(uname -s)" != "Darwin" ]; then
+    echo "staleness_collect: SKIP launchd_job collection (not macOS)" >&2
+    return
+  fi
+  if ! command -v launchctl >/dev/null 2>&1; then
+    echo "staleness_collect: WARN launchctl not found" >&2
+    WARN_COUNT=$((WARN_COUNT + 1))
+    return
+  fi
+  if [ ! -x "$PLUTIL" ] || [ ! -x "$PYTHON3" ]; then
+    echo "staleness_collect: WARN plutil/python3 not found — cannot parse plists" >&2
+    WARN_COUNT=$((WARN_COUNT + 1))
+    return
+  fi
+  if [ ! -d "$PLIST_DIR" ]; then
+    echo "staleness_collect: WARN plist dir not found: ${PLIST_DIR}" >&2
+    WARN_COUNT=$((WARN_COUNT + 1))
+    return
+  fi
+
+  # Single `launchctl list` call, tab-delimited "PID\tStatus\tLabel" rows.
+  # Deliberately NOT using `launchctl list <label>` per-label — that output is
+  # a JSON5-like dump (unquoted keys, '=' not ':'), not valid JSON; python3's
+  # json.load() fails on it silently (see launchd_health_audit.sh's lc_pid/
+  # lc_exit, which both always fall back to '-' for this exact reason).
+  local _lc_list
+  _lc_list="$(launchctl list 2>/dev/null | grep 'com\.claude\.' || true)"
+
+  shopt -s nullglob
+  local plist
+  for plist in "$PLIST_DIR"/com.claude.*.plist; do
+    case "$plist" in *.bak*) continue ;; esac
+
+    local json
+    json="$("$PLUTIL" -convert json -o - "$plist" 2>/dev/null)"
+    if [ $? -ne 0 ] || [ -z "$json" ]; then
+      echo "staleness_collect: WARN could not parse plist ${plist}" >&2
+      WARN_COUNT=$((WARN_COUNT + 1))
+      continue
+    fi
+
+    local label
+    label="$(printf '%s' "$json" | "$PYTHON3" -c "import sys, json; print(json.load(sys.stdin).get('Label', ''))" 2>/dev/null)"
+    [ -z "$label" ] && continue
+
+    local out_path
+    out_path="$(printf '%s' "$json" | "$PYTHON3" -c "import sys, json; print(json.load(sys.stdin).get('StandardOutPath', ''))" 2>/dev/null)"
+
+    local cadence_hours
+    cadence_hours="$(_launchd_cadence_hours "$json")"
+
+    local log_file
+    log_file="$(_launchd_log_file "$label" "$out_path")"
+
+    local last_seen_epoch=0
+    if [ -n "$log_file" ] && [ -f "$log_file" ]; then
+      last_seen_epoch="$(/usr/bin/stat -f '%m' "$log_file" 2>/dev/null || echo 0)"
+    fi
+
+    local last_seen_sql="NULL"
+    if [ "${last_seen_epoch:-0}" -gt 0 ] 2>/dev/null; then
+      local last_seen_iso
+      last_seen_iso="$(/bin/date -r "$last_seen_epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "")"
+      [ -n "$last_seen_iso" ] && last_seen_sql="TIMESTAMPTZ '$(_esc "$last_seen_iso")'"
+    fi
+
+    local exit_code_sql="NULL"
+    local _status
+    _status="$(printf '%s\n' "$_lc_list" | awk -F'\t' -v l="$label" '$3 == l { print $2; exit }')"
+    case "$_status" in
+      ''|*[!0-9-]*) exit_code_sql="NULL" ;;
+      *)            exit_code_sql="$_status" ;;
+    esac
+
+    if duck_run "$DB" -c "
+      INSERT OR REPLACE INTO staleness
+        (asset_kind, asset_id, project, last_seen_ts, expected_cadence_hours, last_exit_code, observed_at)
+      VALUES (
+        'launchd_job', '$(_esc "$label")', NULL,
+        ${last_seen_sql}, ${cadence_hours}, ${exit_code_sql}, current_timestamp
+      );
+    " >/dev/null 2>&1; then
+      ROWS_WRITTEN=$((ROWS_WRITTEN + 1))
+    else
+      echo "staleness_collect: WARN upsert failed for launchd_job '${label}'" >&2
+      WARN_COUNT=$((WARN_COUNT + 1))
+    fi
+  done
+  shopt -u nullglob
+}
+
+# ─── collect_self_heartbeat: this script's own row ──────────────────────────
+# Cadence (24h) matches com.claude.staleness-collect's daily 08:15 schedule
+# (.claude/launchd/com.claude.staleness-collect.plist) — keep the two in sync
+# if the schedule ever changes.
+collect_self_heartbeat() {
+  if duck_run "$DB" -c "
+    INSERT OR REPLACE INTO staleness
+      (asset_kind, asset_id, project, last_seen_ts, expected_cadence_hours, last_exit_code, observed_at)
+    VALUES (
+      'collector', 'staleness_collect', NULL,
+      current_timestamp, 24, 0, current_timestamp
+    );
+  " >/dev/null 2>&1; then
+    ROWS_WRITTEN=$((ROWS_WRITTEN + 1))
+  else
+    echo "staleness_collect: WARN could not write collector heartbeat" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ─── SELFTEST ─────────────────────────────────────────────────────────────────
+selftest() {
+  local pass=0 fail=0 pid=$$
+
+  _assert() {
+    local label="$1" result="$2" expected="$3"
+    if [ "$result" = "$expected" ]; then
+      echo "PASS: ${label}"
+      pass=$((pass + 1))
+    else
+      echo "FAIL: ${label} (got='${result}', want='${expected}')"
+      fail=$((fail + 1))
+    fi
+  }
+
+  _assert "override-sessions" "$(_etl_cadence_override sessions)" "72"
+  _assert "override-skill_usage" "$(_etl_cadence_override skill_usage)" "336"
+  _assert "override-command_usage" "$(_etl_cadence_override command_usage)" "168"
+  _assert "override-agent_runs" "$(_etl_cadence_override agent_runs)" "48"
+  _assert "override-llmtelemetry" "$(_etl_cadence_override llmtelemetry)" "24"
+  _assert "override-unknown-source-empty" "$(_etl_cadence_override some_new_source)" ""
+
+  if ! command -v duckdb >/dev/null 2>&1; then
+    if ! (command -v nix-shell >/dev/null 2>&1 && [ -f "${NIX_DEFAULT}" ]); then
+      echo "SKIP: duckdb not reachable; skipping fixture-based tests"
+      echo "─────────────────────────────"
+      echo "Selftest: ${pass} PASS, ${fail} FAIL"
+      [ "$fail" -eq 0 ]
+      return
+    fi
+  fi
+
+  # Fixture DB: etl_freshness with a mix of cadenced + NULL-cadence rows.
+  local fixture_db="/tmp/staleness_collect_selftest_${pid}.duckdb"
+  rm -f "$fixture_db"
+  duck_run "$fixture_db" -c "
+    CREATE TABLE etl_freshness (
+      source_name VARCHAR PRIMARY KEY,
+      last_row_ts TIMESTAMP,
+      last_etl_run_ts TIMESTAMP,
+      expected_cadence_hours DOUBLE,
+      status VARCHAR
+    );
+    INSERT INTO etl_freshness VALUES
+      ('roborev', current_timestamp, current_timestamp, 24.0, 'fresh'),
+      ('sessions', current_timestamp - INTERVAL 40 DAY, NULL, NULL, 'unknown'),
+      ('mystery_source', current_timestamp, current_timestamp, NULL, 'unknown');
+  " >/dev/null 2>&1
+
+  DB="$fixture_db"
+  ROWS_WRITTEN=0
+  WARN_COUNT=0
+  FAIL_COUNT=0
+  duck_run "$fixture_db" < "$SCHEMA_SQL" >/dev/null 2>&1
+  collect_etl_sources
+
+  local r_roborev r_sessions r_mystery
+  r_roborev="$(duck_run "$fixture_db" -noheader -list -c "SELECT expected_cadence_hours FROM staleness WHERE asset_id='roborev'" 2>/dev/null)"
+  _assert "carried-cadence-roborev" "$r_roborev" "24.0"
+
+  r_sessions="$(duck_run "$fixture_db" -noheader -list -c "SELECT expected_cadence_hours FROM staleness WHERE asset_id='sessions'" 2>/dev/null)"
+  _assert "override-applied-sessions" "$r_sessions" "72.0"
+
+  r_mystery="$(duck_run "$fixture_db" -noheader -list -c "SELECT COUNT(*) FROM staleness WHERE asset_id='mystery_source'" 2>/dev/null)"
+  _assert "no-override-skipped-mystery_source" "$r_mystery" "0"
+  _assert "warn-count-for-skipped-source" "$WARN_COUNT" "1"
+
+  local r_sessions_status
+  r_sessions_status="$(duck_run "$fixture_db" -noheader -list -c "SELECT status FROM staleness_status WHERE asset_id='sessions'" 2>/dev/null)"
+  _assert "sessions-40d-stale-vs-72h-cadence" "$r_sessions_status" "stale"
+
+  local r_roborev_status
+  r_roborev_status="$(duck_run "$fixture_db" -noheader -list -c "SELECT status FROM staleness_status WHERE asset_id='roborev'" 2>/dev/null)"
+  _assert "roborev-fresh-vs-24h-cadence" "$r_roborev_status" "fresh"
+
+  rm -f "$fixture_db"
+
+  echo "─────────────────────────────"
+  echo "Selftest: ${pass} PASS, ${fail} FAIL"
+  [ "$fail" -eq 0 ]
+}
+
+# ─── Dispatch ─────────────────────────────────────────────────────────────────
+if [ "$MODE" = "selftest" ]; then
+  selftest
+  exit $?
+fi
+
+if ! command -v duckdb >/dev/null 2>&1 && ! (command -v nix-shell >/dev/null 2>&1 && [ -f "${NIX_DEFAULT}" ]); then
+  echo "staleness_collect: ERROR duckdb not available" >&2
+  exit 1
+fi
+if [ ! -f "$DB" ]; then
+  echo "staleness_collect: ERROR DB not found at ${DB}" >&2
+  exit 1
+fi
+
+# Ensure schema exists (idempotent).
+if [ -x "$SCHEMA_APPLY" ]; then
+  bash "$SCHEMA_APPLY" --db "$DB" >/dev/null 2>&1 || {
+    echo "staleness_collect: WARN schema apply failed" >&2
+    WARN_COUNT=$((WARN_COUNT + 1))
+  }
+else
+  duck_run "$DB" < "$SCHEMA_SQL" >/dev/null 2>&1 || true
+fi
+
+# housekeeping_runs start row (see housekeeping-framework rule).
+RUN_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+SCRIPT_ABS="${SCRIPT_DIR}/staleness_collect.sh"
+duck_run "$DB" -c "
+  INSERT OR IGNORE INTO housekeeping_runs
+    (id, task, source_script, started_at, status, rows_written)
+  VALUES ('${RUN_ID}', 'staleness_collect', '$(_esc "$SCRIPT_ABS")', current_timestamp, 'ok', 0);
+" >/dev/null 2>&1 || true
+
+collect_etl_sources
+collect_launchd_jobs
+collect_self_heartbeat
+
+STATUS="ok"
+[ "$WARN_COUNT" -gt 0 ] && STATUS="partial"
+[ "$FAIL_COUNT" -gt 0 ] && STATUS="failed"
+
+duck_run "$DB" -c "
+  UPDATE housekeeping_runs
+  SET ended_at = current_timestamp,
+      rows_written = ${ROWS_WRITTEN},
+      status = '$(_esc "$STATUS")'
+  WHERE id = '${RUN_ID}';
+" >/dev/null 2>&1 || true
+
+echo "staleness_collect: rows_written=${ROWS_WRITTEN} warnings=${WARN_COUNT} failures=${FAIL_COUNT} status=${STATUS}"
+
+[ "$FAIL_COUNT" -eq 0 ]

--- a/.claude/scripts/staleness_schema.sql
+++ b/.claude/scripts/staleness_schema.sql
@@ -1,0 +1,63 @@
+-- staleness_schema.sql
+-- Unified staleness fact table + computed-status view for unified.duckdb.
+--
+-- llm#893 step 1: consolidates three overlapping stores (etl_freshness,
+-- launchd_health_events, launchd_runs.duckdb) into one fact table with a
+-- `asset_kind` discriminator, and fixes three defects present in the current
+-- design:
+--
+--   1. `status` was STORED in etl_freshness, so the freshness table could go
+--      stale itself (a row could read 'fresh' while the writer that set it
+--      had not run in days). Here status is a VIEW (staleness_status) —
+--      recomputed at every read, never cached.
+--   2. `expected_cadence_hours` could be NULL, degrading to status='unknown'
+--      which reads as benign. Here it is NOT NULL — every asset MUST have a
+--      real cadence assigned by its writer (see staleness_collect.sh for the
+--      reasoning behind each source's assigned value).
+--   3. Every existing checker was itself a launchd job, so a total launchd
+--      outage (llm#886) silenced the monitor along with everything else.
+--      staleness_status is read out-of-band from session_init.sh (a
+--      different trigger class — see staleness_banner.sh), not from another
+--      launchd job.
+--
+-- `observation_age` in the view is what makes a stale *observation* visible:
+-- even if last_seen_ts looks fresh, an old observed_at means the collector
+-- itself hasn't run recently and the row should not be trusted at face value.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + CREATE OR REPLACE VIEW. Safe to
+-- run multiple times.
+--
+-- Apply with:
+--   bash .claude/scripts/staleness_schema_apply.sh
+--
+-- Tracked in llm#893 (steps 1-2 of the Sequencing plan). Steps 3-5
+-- (repointing the email/dashboard, content checks, retiring
+-- launchd_runs.duckdb) are out of scope for this migration.
+
+CREATE TABLE IF NOT EXISTS staleness (
+  asset_kind              TEXT NOT NULL,   -- etl_source | launchd_job | artifact | collector
+  asset_id                TEXT NOT NULL,   -- e.g. 'roborev', 'com.claude.worktree-gc', 'staleness_collect'
+  project                 TEXT,            -- canonical project (NULL = global)
+  last_seen_ts            TIMESTAMPTZ,     -- the FACT: when it last produced/ran (NULL = never observed)
+  expected_cadence_hours  DOUBLE NOT NULL, -- MANDATORY — no 'unknown' escape hatch (defect 2)
+  last_exit_code          INTEGER,
+  observed_at             TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (asset_kind, asset_id)
+);
+
+-- staleness_status: status computed at READ time, not stored (defect 1 fix).
+-- A NULL last_seen_ts (never observed) is treated as 'stale' — fail-safe, not
+-- benign like the old 'unknown' vocabulary.
+CREATE OR REPLACE VIEW staleness_status AS
+SELECT
+  *,
+  CASE
+    WHEN last_seen_ts IS NULL
+      OR now() - last_seen_ts > (expected_cadence_hours * INTERVAL '1 hour')
+      THEN 'stale'
+    ELSE 'fresh'
+  END AS status,
+  now() - observed_at AS observation_age
+FROM staleness;
+
+CREATE INDEX IF NOT EXISTS idx_staleness_asset_kind ON staleness(asset_kind);

--- a/.claude/scripts/staleness_schema_apply.sh
+++ b/.claude/scripts/staleness_schema_apply.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# staleness_schema_apply.sh — apply the staleness fact-table schema to unified.duckdb
+#
+# Idempotent: CREATE TABLE IF NOT EXISTS + CREATE OR REPLACE VIEW + CREATE
+# INDEX IF NOT EXISTS. Safe to run multiple times — will not drop or alter
+# existing data.
+#
+# Usage:
+#   bash .claude/scripts/staleness_schema_apply.sh
+#   bash .claude/scripts/staleness_schema_apply.sh --db /path/to/scratch.duckdb
+#
+# Tracked in llm#893 step 1.
+
+set -euo pipefail
+
+DB="${UNIFIED_DB_PATH:-${HOME}/.claude/logs/unified.duckdb}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --db) DB="${2:-}"; shift 2 ;;
+    *) echo "Usage: $0 [--db PATH]" >&2; exit 1 ;;
+  esac
+done
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+SQL="${SCRIPT_DIR}/staleness_schema.sql"
+
+if [ ! -f "$SQL" ]; then
+  echo "ERROR: SQL file not found: $SQL" >&2
+  exit 1
+fi
+
+if [ ! -f "$DB" ]; then
+  echo "ERROR: DuckDB not found at $DB" >&2
+  echo "  Create it first with: duckdb $DB < .claude/scripts/unified_log_init.sql" >&2
+  exit 1
+fi
+
+if ! command -v duckdb >/dev/null 2>&1; then
+  echo "ERROR: duckdb not found in PATH" >&2
+  exit 1
+fi
+
+duckdb "$DB" < "$SQL"
+echo "staleness schema applied to $DB"

--- a/bin/launchd-recorders/staleness-collect
+++ b/bin/launchd-recorders/staleness-collect
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /Users/johngavin/docs_gh/llm/bin/launchd_run_record.sh "com.claude.staleness-collect" -- "/bin/bash" "/Users/johngavin/docs_gh/llm/.claude/scripts/staleness_collect.sh"

--- a/tests/testthat/test-staleness-collect.R
+++ b/tests/testthat/test-staleness-collect.R
@@ -1,0 +1,270 @@
+# test-staleness-collect.R — Regression tests for the llm#893 staleness
+# consolidation (steps 1-2: schema + view, collector, session_init banner).
+#
+# Follows the shell-helper test pattern already used in
+# tests/testthat/test-self-review-stage1.R (bash -n syntax check via
+# system2()) and extends it with:
+#   - executable-bit checks on every new script + launcher (regression guard
+#     for llm#886: a missing exec bit on exactly this class of path silently
+#     killed all 25 launchd jobs for two days)
+#   - schema content checks (NOT NULL cadence, computed-not-stored status view)
+#   - staleness_collect.sh --selftest invocation
+#   - staleness_banner.sh phase logic tested directly against fixture DBs
+#     (collector-stale / other-stale-summary / all-fresh-silent / missing-DB),
+#     per llm#893's explicit ask to test the session_init.sh phase logic
+#     directly rather than by launching a session.
+#
+# DuckDB CLI is required for the schema/selftest/banner tests; they are
+# skipped where it is unavailable (matches test-self-review-stage1.R).
+
+library(testthat)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+repo_root <- function() {
+  this_file <- tryCatch(
+    normalizePath(sys.frame(0)$ofile, mustWork = FALSE),
+    error = function(e) ""
+  )
+  if (nzchar(this_file) && file.exists(this_file)) {
+    candidate <- dirname(dirname(this_file))
+    if (file.exists(file.path(candidate, ".git"))) return(candidate)
+  }
+  tp <- tryCatch(testthat::test_path(), error = function(e) "")
+  if (nzchar(tp)) {
+    candidate <- normalizePath(file.path(tp, "..", ".."), mustWork = FALSE)
+    if (file.exists(file.path(candidate, ".git"))) return(candidate)
+  }
+  path <- getwd()
+  for (i in seq_len(10L)) {
+    if (file.exists(file.path(path, ".git"))) return(path)
+    parent <- dirname(path)
+    if (parent == path) break
+    path <- parent
+  }
+  getwd()
+}
+
+scripts_dir <- function() file.path(repo_root(), ".claude", "scripts")
+
+duckdb_available <- function() nzchar(Sys.which("duckdb"))
+
+collect_sh <- normalizePath(
+  file.path(repo_root(), ".claude", "scripts", "staleness_collect.sh"),
+  mustWork = FALSE
+)
+banner_sh <- normalizePath(
+  file.path(repo_root(), ".claude", "scripts", "staleness_banner.sh"),
+  mustWork = FALSE
+)
+schema_apply_sh <- normalizePath(
+  file.path(repo_root(), ".claude", "scripts", "staleness_schema_apply.sh"),
+  mustWork = FALSE
+)
+schema_sql <- normalizePath(
+  file.path(repo_root(), ".claude", "scripts", "staleness_schema.sql"),
+  mustWork = FALSE
+)
+launcher <- normalizePath(
+  file.path(repo_root(), "bin", "launchd-recorders", "staleness-collect"),
+  mustWork = FALSE
+)
+
+# ── Shell syntax checks ────────────────────────────────────────────────────────
+
+test_that("staleness_collect.sh passes bash -n syntax check", {
+  skip_if_not(file.exists(collect_sh), "staleness_collect.sh not found")
+  exit_code <- system2("bash", args = c("-n", collect_sh), stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L, info = "staleness_collect.sh has bash syntax errors")
+})
+
+test_that("staleness_banner.sh passes bash -n syntax check", {
+  skip_if_not(file.exists(banner_sh), "staleness_banner.sh not found")
+  exit_code <- system2("bash", args = c("-n", banner_sh), stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L, info = "staleness_banner.sh has bash syntax errors")
+})
+
+test_that("staleness_schema_apply.sh passes bash -n syntax check", {
+  skip_if_not(file.exists(schema_apply_sh), "staleness_schema_apply.sh not found")
+  exit_code <- system2("bash", args = c("-n", schema_apply_sh), stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L, info = "staleness_schema_apply.sh has bash syntax errors")
+})
+
+# ── Executable-bit regression guard (llm#886) ─────────────────────────────────
+# A missing exec bit on a script invoked from a launchd ProgramArguments array
+# (or its launcher) silently kills the job with no readable error — this is
+# exactly what killed all 25 jobs for two days. Assert the bit directly so a
+# future accidental `chmod -x` or a non-executable re-commit fails CI/tests,
+# not just a manual `git ls-files -s` check.
+
+test_that("staleness_collect.sh is executable", {
+  skip_if_not(file.exists(collect_sh), "staleness_collect.sh not found")
+  expect_equal(file.access(collect_sh, mode = 1)[[1]], 0L,
+               info = "staleness_collect.sh is missing the executable bit (llm#886 failure mode)")
+})
+
+test_that("staleness_banner.sh is executable", {
+  skip_if_not(file.exists(banner_sh), "staleness_banner.sh not found")
+  expect_equal(file.access(banner_sh, mode = 1)[[1]], 0L,
+               info = "staleness_banner.sh is missing the executable bit (llm#886 failure mode)")
+})
+
+test_that("staleness_schema_apply.sh is executable", {
+  skip_if_not(file.exists(schema_apply_sh), "staleness_schema_apply.sh not found")
+  expect_equal(file.access(schema_apply_sh, mode = 1)[[1]], 0L,
+               info = "staleness_schema_apply.sh is missing the executable bit (llm#886 failure mode)")
+})
+
+test_that("bin/launchd-recorders/staleness-collect launcher is executable", {
+  skip_if_not(file.exists(launcher), "launcher not found")
+  expect_equal(file.access(launcher, mode = 1)[[1]], 0L,
+               info = "staleness-collect launcher is missing the executable bit (llm#886 failure mode)")
+})
+
+# ── Schema content ─────────────────────────────────────────────────────────────
+
+test_that("staleness_schema.sql exists and is non-empty", {
+  expect_true(file.exists(schema_sql), info = "staleness_schema.sql not found")
+  lines <- readLines(schema_sql, warn = FALSE)
+  expect_gt(length(lines), 10L, label = "SQL file appears empty")
+})
+
+test_that("staleness_schema.sql makes expected_cadence_hours NOT NULL (defect 2 fix)", {
+  skip_if_not(file.exists(schema_sql), "staleness_schema.sql not found")
+  sql_text <- paste(readLines(schema_sql, warn = FALSE), collapse = "\n")
+  expect_true(
+    grepl("expected_cadence_hours\\s+DOUBLE\\s+NOT\\s+NULL", sql_text, ignore.case = TRUE),
+    info = "expected_cadence_hours is not NOT NULL — llm#893 defect 2 (silent 'unknown' escape hatch) may have regressed"
+  )
+})
+
+test_that("staleness_schema.sql computes status via a VIEW, not a stored column (defect 1 fix)", {
+  skip_if_not(file.exists(schema_sql), "staleness_schema.sql not found")
+  sql_text <- paste(readLines(schema_sql, warn = FALSE), collapse = "\n")
+  expect_true(
+    grepl("CREATE\\s+OR\\s+REPLACE\\s+VIEW\\s+staleness_status", sql_text, ignore.case = TRUE),
+    info = "staleness_status is not a CREATE OR REPLACE VIEW — llm#893 defect 1 (stored status can go stale) may have regressed"
+  )
+  expect_false(
+    grepl("^\\s*status\\s+(VARCHAR|TEXT)", sql_text, ignore.case = TRUE, perl = TRUE),
+    info = "the `staleness` TABLE appears to have its own stored status column — status must live only in the view"
+  )
+})
+
+# ── staleness_collect.sh --selftest ────────────────────────────────────────────
+
+test_that("staleness_collect.sh --selftest passes", {
+  skip_if_not(file.exists(collect_sh), "staleness_collect.sh not found")
+  skip_if_not(duckdb_available(), "duckdb not available")
+  out <- system2("bash", args = c(collect_sh, "--selftest"), stdout = TRUE, stderr = TRUE)
+  combined <- paste(out, collapse = "\n")
+  expect_true(
+    grepl("0 FAIL", combined),
+    info = paste0("staleness_collect.sh --selftest reported failures:\n", combined)
+  )
+})
+
+# ── staleness_banner.sh phase logic — tested directly, not via a session ─────
+# Builds three fixture DBs and asserts the exact priority-order behaviour
+# required by llm#893 step 2: a stale collector row suppresses every other
+# line; otherwise stale non-collector assets are summarised; otherwise silent.
+
+make_fixture_db <- function(sql) {
+  db <- tempfile("staleness_banner_test_", fileext = ".duckdb")
+  writeLines(sql, tmp <- tempfile(fileext = ".sql"))
+  on.exit(unlink(tmp), add = TRUE)
+  system2("duckdb", args = c("-init", "/dev/null", db), stdin = tmp,
+          stdout = FALSE, stderr = FALSE)
+  db
+}
+
+run_banner <- function(db) {
+  old <- Sys.getenv("STALENESS_DB", unset = NA)
+  Sys.setenv(STALENESS_DB = db)
+  on.exit({
+    if (is.na(old)) Sys.unsetenv("STALENESS_DB") else Sys.setenv(STALENESS_DB = old)
+  }, add = TRUE)
+  system2("bash", args = banner_sh, stdout = TRUE, stderr = TRUE)
+}
+
+schema_and_data <- function(rows_sql) {
+  base <- paste(readLines(schema_sql, warn = FALSE), collapse = "\n")
+  paste(base, rows_sql, sep = "\n")
+}
+
+test_that("staleness_banner.sh prints ONLY the collector-stale line when the collector is stale", {
+  skip_if_not(file.exists(schema_sql), "staleness_schema.sql not found")
+  skip_if_not(file.exists(banner_sh), "staleness_banner.sh not found")
+  skip_if_not(duckdb_available(), "duckdb not available")
+
+  sql <- schema_and_data("
+    INSERT INTO staleness VALUES
+      ('collector', 'staleness_collect', NULL, current_timestamp - INTERVAL 72 HOUR, 24, 0, current_timestamp),
+      ('launchd_job', 'com.claude.worktree-gc', NULL, current_timestamp - INTERVAL 100 HOUR, 24, 0, current_timestamp);
+  ")
+  db <- make_fixture_db(sql)
+  on.exit(unlink(db), add = TRUE)
+
+  out <- run_banner(db)
+  expect_length(out, 1L)
+  expect_true(grepl("^staleness: COLLECTOR STALE", out[1]))
+  expect_false(grepl("worktree-gc", paste(out, collapse = "\n")),
+               info = "banner must print ONLY the collector-stale line, nothing else")
+})
+
+test_that("staleness_banner.sh summarises other stale assets when the collector is fresh", {
+  skip_if_not(file.exists(schema_sql), "staleness_schema.sql not found")
+  skip_if_not(file.exists(banner_sh), "staleness_banner.sh not found")
+  skip_if_not(duckdb_available(), "duckdb not available")
+
+  sql <- schema_and_data("
+    INSERT INTO staleness VALUES
+      ('collector', 'staleness_collect', NULL, current_timestamp, 24, 0, current_timestamp),
+      ('launchd_job', 'com.claude.worktree-gc', NULL, current_timestamp - INTERVAL 100 HOUR, 24, 0, current_timestamp),
+      ('etl_source', 'sessions', NULL, current_timestamp - INTERVAL 300 HOUR, 72, NULL, current_timestamp);
+  ")
+  db <- make_fixture_db(sql)
+  on.exit(unlink(db), add = TRUE)
+
+  out <- run_banner(db)
+  combined <- paste(out, collapse = "\n")
+  expect_true(grepl("^staleness: 2 stale", combined))
+  expect_true(grepl("launchd_job:com\\.claude\\.worktree-gc", combined))
+  expect_true(grepl("etl_source:sessions", combined))
+})
+
+test_that("staleness_banner.sh is silent when everything is fresh", {
+  skip_if_not(file.exists(schema_sql), "staleness_schema.sql not found")
+  skip_if_not(file.exists(banner_sh), "staleness_banner.sh not found")
+  skip_if_not(duckdb_available(), "duckdb not available")
+
+  sql <- schema_and_data("
+    INSERT INTO staleness VALUES
+      ('collector', 'staleness_collect', NULL, current_timestamp, 24, 0, current_timestamp),
+      ('launchd_job', 'com.claude.worktree-gc', NULL, current_timestamp, 24, 0, current_timestamp);
+  ")
+  db <- make_fixture_db(sql)
+  on.exit(unlink(db), add = TRUE)
+
+  out <- run_banner(db)
+  expect_length(out, 0L)
+})
+
+test_that("staleness_banner.sh fails open (prints nothing, exits 0) when the DB is missing", {
+  skip_if_not(file.exists(banner_sh), "staleness_banner.sh not found")
+
+  missing_db <- tempfile("staleness_banner_missing_", fileext = ".duckdb")
+  old <- Sys.getenv("STALENESS_DB", unset = NA)
+  Sys.setenv(STALENESS_DB = missing_db)
+  on.exit({
+    if (is.na(old)) Sys.unsetenv("STALENESS_DB") else Sys.setenv(STALENESS_DB = old)
+  }, add = TRUE)
+
+  out <- suppressWarnings(
+    system2("bash", args = banner_sh, stdout = TRUE, stderr = TRUE)
+  )
+  exit_code <- attr(out, "status")
+  if (is.null(exit_code)) exit_code <- 0L
+  expect_equal(exit_code, 0L, info = "banner must fail open on a missing DB")
+  expect_length(out, 0L)
+})


### PR DESCRIPTION
Implements **steps 1–2** of #893. Steps 3–5 (repointing email/dashboard, content
checks, retiring `launchd_runs.duckdb`) are deliberately out of scope.

## The three defects, and how each is fixed

| Defect | Fix | Verified by |
|---|---|---|
| `status` was **stored**, so the freshness table went stale itself (`roborev` read `fresh` at 38 h against a 24 h cadence) | `status` is a **view**, recomputed every read; `observation_age` exposes a stale *observation* | Backdated `observed_at` 5 days → `observation_age` grew while `status` stayed independently computed from `last_seen_ts` |
| NULL cadence → `status='unknown'`, which reads as benign (`sessions` stale **11 days**, reporting `unknown`) | `expected_cadence_hours DOUBLE **NOT NULL**` — no escape hatch | A cadence-less `INSERT` is **rejected** by the constraint |
| Every checker was itself a launchd job, so #886 silenced the monitor along with everything it watched | Banner reads out-of-band from `session_init.sh` — a different trigger class | Stale collector printed **only** `COLLECTOR STALE … all staleness data untrustworthy`, suppressing all other rows |

A NULL `last_seen_ts` is treated as **stale**, not benign — fail-safe, unlike the
old `unknown` vocabulary.

## End-to-end, against a copy of the live DB

The collector populated **35 assets** across 3 kinds and the banner rendered:

```
staleness: 16 stale (etl_source:sessions, launchd_job:com.claude.branch-gc, … +10 more)
```

`etl_source:sessions` is the payoff — the source that sat 11 days stale reporting
`unknown` now reads `stale`.

## Cadences for the previously-NULL sources

Derived from observed inter-row-gap quantiles in `unified.duckdb`, with the
reasoning recorded inline rather than guessed:

| source | cadence | basis |
|---|---|---|
| `sessions` | 72 h | p95 gap ~1.5 h when active; tolerates a long weekend |
| `skill_usage` | 336 h | event-driven, sparse; observed max gap 335 h |
| `command_usage` | 168 h | p90 ~112 h, max ~165 h |
| `agent_runs` | 48 h | p90 ~21 h |
| `llmtelemetry` | 24 h | **documented default** — writer lives in another repo, no in-repo history to derive from |

(Five, not the issue's four — `llmtelemetry` was added to `etl_freshness` after
the issue was filed.)

## Bug fixed en route

The launchd cadence derivation, adapted from `bin/launchd_health_audit.sh`,
produced a nonsensical **0 h** cadence for jobs with multiple
`StartCalendarInterval` entries sharing a Hour:Minute across different Weekdays
(e.g. `roborev-poll-merges` at 09:00/13:00/17:00 × 5 weekdays) — which would have
marked them permanently stale. Fixed by considering only strictly-positive
minute-of-day diffs. The same bug remains unfixed in `launchd_health_audit.sh`.

## Guards drawn from this session's own failures

- **File modes.** All four `.sh` files and the launcher are committed `100755`,
  with **regression tests asserting it** — a missing `+x` on exactly this kind of
  path is what killed all 25 jobs in #886.
- **Hook safety.** `bash -n` clean on `session_init.sh` (a syntax error there
  breaks *every* session start); `set -uo pipefail` without `-e`; fail-open on
  missing binary / DB / table; `grep -c . || true` per the #695 pipefail lesson.
- **`/bin/bash` 3.2 portability** — `case` rather than `declare -A`, since the
  launchd launcher runs under macOS's ancient bash where associative arrays
  misbehave silently.

## Test status — read this before merging

`[ FAIL 1 | WARN 3 | SKIP 5 | PASS 714 ]`, all 22 new tests passing.

The 1 failure is `test-kb-digest.R:824`
(`"wiki_referenced" %in% names(row1) is not TRUE`) and is **pre-existing and
unrelated**, verified two ways rather than assumed:

1. Run directly against `origin/main` (`7ee1d75`) with this branch absent —
   fails identically: `[ FAIL 1 | WARN 1 | SKIP 0 | PASS 33 ]`.
2. `git log` shows kb-digest code last touched 2026-08-01 in #851, before any of
   today's work.

Worth a separate look: it may be downstream of #886, since the kb-digest cron
jobs were dead for two days and the missing column comes from data they feed.
Not investigated here.

## Not done

The plist is **not installed** to `~/Library/LaunchAgents` — that is a
system-level write outside the worktree sandbox. Installing it is a manual step
after merge, otherwise the collector never runs and the banner will correctly
report `COLLECTOR STALE`.

Refs #893, #886, #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)