### PR TITLE
feat(housekeeping): sweep orphaned session sentinels + rotate oversized logs (#884 steps 2-3)

### DIFF
--- a/.claude/scripts/sentinel_log_sweep.sh
+++ b/.claude/scripts/sentinel_log_sweep.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# sentinel_log_sweep.sh — pure helper functions for JohnGavin/llm#884 steps 2-3:
+#   sweep_stale_sentinels() — delete orphaned session sentinels older than N days
+#   rotate_log_file()/rotate_logs() — copy-truncate oversized log files
+#
+# Sourced by worktree_gc.sh (the existing daily housekeeping job, per the
+# housekeeping-framework rule) so these run for real once a day, gated by the
+# SAME --apply flag as worktree removal (dry-run by default; only the
+# launchd-scheduled invocation passes --apply). This file has NO top-level
+# side effects when sourced — `source sentinel_log_sweep.sh` only defines
+# functions, so tests can source it directly against a fixture directory
+# without ever touching the real ~/.claude/.
+#
+# Tracks: JohnGavin/llm#884
+
+# ── Sentinel sweep (Finding 2) ────────────────────────────────────────────────
+# session_init.sh writes ~/.claude/.session_start_sha_<slug> at every session
+# start, keyed by PROJECT SLUG (not session id) — two concurrent sessions on
+# the same project share one file, so deleting it on consume (in
+# session_end_refine.sh) would break the other session. Same story for
+# .bye-requested(.<sid>) / .bye-session-end-refine(.<sid>), written by
+# session_stop.sh at every /bye. Nothing ever deletes any of these; they are
+# fully re-derivable state (session_init.sh recreates them every session
+# start), so an AGE-BASED sweep is the safe cleanup — anything untouched for
+# the threshold is orphaned regardless of "consumed" status.
+#
+# args: dir age_days [dry_run=0]
+# Sets global SENTINELS_SWEPT to the count removed (or, in dry-run, the count
+# that would be removed). Never fails the caller — internal errors are
+# swallowed and treated as "0 swept".
+sweep_stale_sentinels() {
+  local _dir="$1" _age_days="$2" _dry="${3:-0}"
+  SENTINELS_SWEPT=0
+  [ -d "$_dir" ] || return 0
+
+  local _f _count=0
+  while IFS= read -r -d '' _f; do
+    if [ "$_dry" = "1" ]; then
+      _count=$(( _count + 1 ))
+    elif rm -f -- "$_f" 2>/dev/null; then
+      _count=$(( _count + 1 ))
+    fi
+  done < <(find "$_dir" -maxdepth 1 -type f \
+             \( -name '.session_start_sha_*' -o -name '.bye-requested*' \
+                -o -name '.bye-session-end-refine*' \) \
+             -mtime "+${_age_days}" -print0 2>/dev/null || true)
+
+  SENTINELS_SWEPT=$_count
+  return 0
+}
+
+# ── Log rotation (Finding 3) ──────────────────────────────────────────────────
+# Size-based, not age-based — the llm#884 audit found 0 logs older than 30
+# days (everything is actively written), so the only lever is truncate-to-
+# tail. Copy-truncate IN PLACE (never mv/rename): `cat tmp > path` truncates
+# the existing inode's contents rather than swapping the inode, so a writer
+# that already has the file open (append mode) keeps a valid file descriptor
+# pointing at the same (now-truncated) file. DuckDB files are matched by
+# extension and skipped unconditionally — never touch logs/*.duckdb.
+
+# args: path threshold_bytes keep_lines [dry_run=0]
+# Sets global _ROTATED_ONE to 1 if the file was (or, in dry-run, would be)
+# rotated, 0 otherwise.
+rotate_log_file() {
+  local _path="$1" _threshold="$2" _keep_lines="$3" _dry="${4:-0}"
+  _ROTATED_ONE=0
+  [ -f "$_path" ] || return 0
+  case "$_path" in
+    *.duckdb) return 0 ;;
+  esac
+
+  local _size
+  _size=$(wc -c < "$_path" 2>/dev/null | tr -d '[:space:]')
+  [ -z "$_size" ] && _size=0
+  [ "$_size" -le "$_threshold" ] && return 0
+
+  if [ "$_dry" = "1" ]; then
+    _ROTATED_ONE=1
+    return 0
+  fi
+
+  local _tmp
+  _tmp=$(mktemp "${_path}.XXXXXX.tmp" 2>/dev/null) || return 0
+  if ! tail -n "$_keep_lines" "$_path" > "$_tmp" 2>/dev/null; then
+    rm -f "$_tmp"
+    return 0
+  fi
+
+  # Keep exactly one prior generation (overwrites any earlier .1).
+  cp -f "$_path" "${_path}.1" 2>/dev/null || true
+
+  # Copy-truncate IN PLACE — see header comment. Never mv/rename here.
+  if cat "$_tmp" > "$_path" 2>/dev/null; then
+    rm -f "$_tmp"
+    _ROTATED_ONE=1
+  else
+    rm -f "$_tmp"
+  fi
+  return 0
+}
+
+# args: dir threshold_bytes keep_lines [dry_run=0] [logger_fn]
+# logger_fn, if given, is called as: "$logger_fn" "<message>" once per file
+# that was (or would be) rotated — lets the caller reuse its own log()
+# implementation instead of this file owning any logging/output policy.
+# Sets global LOGS_ROTATED to the count rotated (or would-rotate in dry-run).
+rotate_logs() {
+  local _dir="$1" _threshold="$2" _keep_lines="$3" _dry="${4:-0}" _logger_fn="${5:-}"
+  LOGS_ROTATED=0
+  [ -d "$_dir" ] || return 0
+
+  local _f _count=0
+  while IFS= read -r -d '' _f; do
+    rotate_log_file "$_f" "$_threshold" "$_keep_lines" "$_dry"
+    if [ "${_ROTATED_ONE:-0}" = "1" ]; then
+      _count=$(( _count + 1 ))
+      if [ -n "$_logger_fn" ]; then
+        if [ "$_dry" = "1" ]; then
+          "$_logger_fn" "[log-rotate-dryrun] $_f exceeds threshold — would truncate to last ${_keep_lines} lines"
+        else
+          "$_logger_fn" "[log-rotate] $_f truncated to last ${_keep_lines} lines (prior generation: ${_f}.1)"
+        fi
+      fi
+    fi
+  done < <(find "$_dir" -maxdepth 1 -type f \
+             \( -name '*.log' -o -name '*.err' -o -name '*.out' \) \
+             -print0 2>/dev/null || true)
+
+  LOGS_ROTATED=$_count
+  return 0
+}
+
+# ── Standalone CLI (only runs when executed directly, never when sourced) ────
+# Dry-run by default, matching worktree_gc.sh's own UX; --apply performs the
+# real operation. Lets the helper be exercised/debugged without going through
+# worktree_gc.sh.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  set -euo pipefail
+  _cli_apply=0
+  _cli_args=()
+  for _a in "$@"; do
+    if [ "$_a" = "--apply" ]; then
+      _cli_apply=1
+    else
+      _cli_args+=("$_a")
+    fi
+  done
+  _cli_dry=$(( 1 - _cli_apply ))
+
+  case "${_cli_args[0]:-}" in
+    sweep)
+      sweep_stale_sentinels "${_cli_args[1]:?dir required}" "${_cli_args[2]:-7}" "$_cli_dry"
+      echo "swept=$SENTINELS_SWEPT dry_run=$_cli_dry"
+      ;;
+    rotate)
+      rotate_logs "${_cli_args[1]:?dir required}" "${_cli_args[2]:-10485760}" "${_cli_args[3]:-2000}" "$_cli_dry"
+      echo "rotated=$LOGS_ROTATED dry_run=$_cli_dry"
+      ;;
+    *)
+      echo "Usage: $0 {sweep <dir> [age_days]|rotate <dir> [threshold_bytes] [keep_lines]} [--apply]" >&2
+      exit 64
+      ;;
+  esac
+fi

--- a/.claude/scripts/worktree_gc.sh
+++ b/.claude/scripts/worktree_gc.sh
@@ -41,6 +41,17 @@ set -euo pipefail
 # ─── launchd-safe PATH ───────────────────────────────────────────────────────
 export PATH="/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
+# ─── Sentinel sweep + log rotation helpers (JohnGavin/llm#884 steps 2-3) ─────
+# Pure functions, sourced rather than duplicated so tests can exercise them
+# directly against a fixture directory. sweep_stale_sentinels()/rotate_logs()
+# defined there are called near the end of this script's main flow, gated on
+# the SAME --apply flag as worktree removal (see APPLY below).
+_gc_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+if [ -f "${_gc_script_dir}/sentinel_log_sweep.sh" ]; then
+  # shellcheck source=./sentinel_log_sweep.sh
+  source "${_gc_script_dir}/sentinel_log_sweep.sh"
+fi
+
 # ─── Timeout wrapper (macOS lacks GNU `timeout` by default) ─────────────────
 # Used by is_squash_merged() to bound the `gh pr list` network call. Prefers
 # GNU timeout, falls back to homebrew coreutils' gtimeout, falls back to no
@@ -90,6 +101,12 @@ WORKTREES_BASE_LEGACY="${WORKTREES_BASE_LEGACY:-$HOME/worktrees}"
 UNIFIED_DB="${UNIFIED_DB_PATH:-$HOME/.claude/logs/unified.duckdb}"
 LOG_FILE="$HOME/.claude/logs/worktree_gc.log"
 APPLY=0
+
+# ─── Sentinel sweep + log rotation config (JohnGavin/llm#884) ───────────────
+CLAUDE_RUNTIME_ROOT="${CLAUDE_RUNTIME_ROOT:-$HOME/.claude}"
+SENTINEL_AGE_DAYS="${SENTINEL_AGE_DAYS:-7}"
+LOG_ROTATE_THRESHOLD_BYTES="${LOG_ROTATE_THRESHOLD_BYTES:-10485760}"  # 10 MB
+LOG_ROTATE_KEEP_LINES="${LOG_ROTATE_KEEP_LINES:-2000}"
 
 # Sweep patterns: "glob|age_days_var_name"
 SWEEP_PATTERNS=(
@@ -531,7 +548,26 @@ if [ "$APPLY" = "1" ] && [ "${#CONVENTION_PARENTS[@]}" -gt 0 ]; then
   done
 fi
 
-log "[done] candidates=$CANDIDATES would-remove=$WOULD_REMOVE would-remove-squash=$WOULD_REMOVE_SQUASH removed=$REMOVED removed-squash=$REMOVED_SQUASH kept=$KEPT events=$EVENTS_WRITTEN apply=$APPLY soak-past=$_past_soak squash-soak-past=$_squash_past_soak"
+# ─── Sentinel sweep + log rotation (JohnGavin/llm#884 steps 2-3) ─────────────
+# Gated on the same --apply flag as worktree removal: dry-run by default (so
+# manual/test invocations of this script never mutate ~/.claude/), the real
+# sweep/rotation only runs when --apply is passed (the launchd job always
+# passes --apply — see bin/launchd-recorders/worktree-gc).
+SENTINELS_SWEPT=0
+LOGS_ROTATED=0
+if [ "$APPLY" = "1" ]; then
+  sweep_stale_sentinels "$CLAUDE_RUNTIME_ROOT" "$SENTINEL_AGE_DAYS" 0 || true
+  log "[sentinel-sweep] dir=$CLAUDE_RUNTIME_ROOT age_days=$SENTINEL_AGE_DAYS swept=$SENTINELS_SWEPT"
+  rotate_logs "$CLAUDE_RUNTIME_ROOT/logs" "$LOG_ROTATE_THRESHOLD_BYTES" "$LOG_ROTATE_KEEP_LINES" 0 log || true
+  log "[log-rotate] dir=$CLAUDE_RUNTIME_ROOT/logs threshold_bytes=$LOG_ROTATE_THRESHOLD_BYTES keep_lines=$LOG_ROTATE_KEEP_LINES rotated=$LOGS_ROTATED"
+else
+  sweep_stale_sentinels "$CLAUDE_RUNTIME_ROOT" "$SENTINEL_AGE_DAYS" 1 || true
+  log "[sentinel-sweep-dryrun] dir=$CLAUDE_RUNTIME_ROOT age_days=$SENTINEL_AGE_DAYS would_sweep=$SENTINELS_SWEPT"
+  rotate_logs "$CLAUDE_RUNTIME_ROOT/logs" "$LOG_ROTATE_THRESHOLD_BYTES" "$LOG_ROTATE_KEEP_LINES" 1 log || true
+  log "[log-rotate-dryrun] dir=$CLAUDE_RUNTIME_ROOT/logs threshold_bytes=$LOG_ROTATE_THRESHOLD_BYTES keep_lines=$LOG_ROTATE_KEEP_LINES would_rotate=$LOGS_ROTATED"
+fi
+
+log "[done] candidates=$CANDIDATES would-remove=$WOULD_REMOVE would-remove-squash=$WOULD_REMOVE_SQUASH removed=$REMOVED removed-squash=$REMOVED_SQUASH kept=$KEPT events=$EVENTS_WRITTEN apply=$APPLY soak-past=$_past_soak squash-soak-past=$_squash_past_soak sentinels-swept=$SENTINELS_SWEPT logs-rotated=$LOGS_ROTATED"
 
 # Stamp for cron_catchup.sh catch-up detection
 mkdir -p "${HOME}/.claude/logs/stamps"
@@ -672,6 +708,77 @@ if [ "${SELFTEST:-0}" = "1" ]; then
   mkdir -p "$_conv_parent"
   rmdir "$_conv_parent" 2>/dev/null && _rmdir_ok=1 || _rmdir_ok=0
   _check "empty convention parent can be rmdir'd" "1" "$_rmdir_ok"
+
+  # --- Tests: sweep_stale_sentinels (JohnGavin/llm#884 Finding 2) ────────────
+  if command -v sweep_stale_sentinels >/dev/null 2>&1; then
+    _sentinel_dir="$tmpdir/sentinels"
+    mkdir -p "$_sentinel_dir"
+    touch -t 202601010000 "$_sentinel_dir/.session_start_sha_old_proj"
+    touch -t 202601010000 "$_sentinel_dir/.bye-requested.oldsid"
+    touch -t 202601010000 "$_sentinel_dir/.bye-session-end-refine.oldsid"
+    touch "$_sentinel_dir/.session_start_sha_new_proj"
+    touch "$_sentinel_dir/.bye-requested"
+
+    sweep_stale_sentinels "$_sentinel_dir" 7 1
+    _check "sentinel dry-run counts 3 stale files" "3" "$SENTINELS_SWEPT"
+    _check "sentinel dry-run leaves all 5 files in place" "5" "$(ls -A "$_sentinel_dir" | wc -l | tr -d '[:space:]')"
+
+    sweep_stale_sentinels "$_sentinel_dir" 7 0
+    _check "sentinel real sweep removes 3 stale files" "3" "$SENTINELS_SWEPT"
+    _check "sentinel real sweep leaves the 2 fresh files" "2" "$(ls -A "$_sentinel_dir" | wc -l | tr -d '[:space:]')"
+
+    sweep_stale_sentinels "$tmpdir/does_not_exist" 7 0
+    _check "sentinel sweep on missing dir is a silent no-op" "0" "$SENTINELS_SWEPT"
+
+    mkdir -p "$tmpdir/empty_sentinels"
+    sweep_stale_sentinels "$tmpdir/empty_sentinels" 7 0
+    _check "sentinel sweep on empty dir is a no-op" "0" "$SENTINELS_SWEPT"
+  else
+    echo "SKIP: sweep_stale_sentinels not sourced (sentinel_log_sweep.sh missing?)"
+  fi
+
+  # --- Tests: rotate_log_file / rotate_logs (JohnGavin/llm#884 Finding 3) ────
+  if command -v rotate_logs >/dev/null 2>&1; then
+    _logs_dir="$tmpdir/logs"
+    mkdir -p "$_logs_dir"
+    python3 -c "
+for i in range(3000):
+    print('line %d ' % i + 'x' * 50)
+" > "$_logs_dir/big.log"
+    echo "small" > "$_logs_dir/small.log"
+    python3 -c "
+for i in range(3000):
+    print('line %d ' % i + 'x' * 50)
+" > "$_logs_dir/unified.duckdb"
+
+    _rot_thresh=10000
+    _rot_keep=10
+
+    rotate_logs "$_logs_dir" "$_rot_thresh" "$_rot_keep" 1
+    _check "log-rotate dry-run counts 1 oversized file" "1" "$LOGS_ROTATED"
+    _check "log-rotate dry-run leaves big.log untouched" "3000" "$(wc -l < "$_logs_dir/big.log" | tr -d '[:space:]')"
+    _check "log-rotate dry-run never touches .duckdb" "3000" "$(wc -l < "$_logs_dir/unified.duckdb" | tr -d '[:space:]')"
+
+    rotate_logs "$_logs_dir" "$_rot_thresh" "$_rot_keep" 0
+    _check "log-rotate real run rotates 1 file" "1" "$LOGS_ROTATED"
+    _check "log-rotate truncates big.log to keep_lines" "10" "$(wc -l < "$_logs_dir/big.log" | tr -d '[:space:]')"
+    _check "log-rotate keeps exactly one .1 generation with full prior content" "3000" "$(wc -l < "$_logs_dir/big.log.1" | tr -d '[:space:]')"
+    _check "log-rotate leaves small.log under threshold untouched" "1" "$(wc -l < "$_logs_dir/small.log" | tr -d '[:space:]')"
+    _check "log-rotate NEVER touches .duckdb files" "3000" "$(wc -l < "$_logs_dir/unified.duckdb" | tr -d '[:space:]')"
+    _check "log-rotate never creates a .duckdb.1 generation" "0" "$([ -f "$_logs_dir/unified.duckdb.1" ] && echo 1 || echo 0)"
+
+    rotate_logs "$_logs_dir" "$_rot_thresh" "$_rot_keep" 0
+    _check "log-rotate is idempotent (second run is a no-op)" "0" "$LOGS_ROTATED"
+
+    mkdir -p "$tmpdir/empty_logs"
+    rotate_logs "$tmpdir/empty_logs" "$_rot_thresh" "$_rot_keep" 0
+    _check "log-rotate on empty dir is a no-op" "0" "$LOGS_ROTATED"
+
+    rotate_logs "$tmpdir/does_not_exist_logs" "$_rot_thresh" "$_rot_keep" 0
+    _check "log-rotate on missing dir is a silent no-op" "0" "$LOGS_ROTATED"
+  else
+    echo "SKIP: rotate_logs not sourced (sentinel_log_sweep.sh missing?)"
+  fi
 
   echo ""
   echo "$_pass PASS, $_fail FAIL"

--- a/tests/testthat/test-sentinel-log-sweep.R
+++ b/tests/testthat/test-sentinel-log-sweep.R
@@ -1,0 +1,376 @@
+# test-sentinel-log-sweep.R — Regression tests for the llm#884 steps 2-3
+# fix: age-based sentinel sweep + size-based log rotation, wired into the
+# existing daily worktree_gc.sh housekeeping job.
+#
+# Follows the shell-helper test pattern used in test-self-review-stage1.R and
+# test-staleness-collect.R (bash -n syntax check via system2(), executable-bit
+# regression guard, --selftest / SELFTEST=1 invocation checking "0 FAIL").
+#
+# All behaviour tests run against temp fixture directories created with
+# touch -t controlled mtimes — never against the real ~/.claude/. Both the
+# main script (worktree_gc.sh) and the sourced pure-function helper
+# (sentinel_log_sweep.sh) are exercised: the helper directly (sourced in a
+# bash subprocess against a fixture dir) and the wiring end-to-end (via
+# worktree_gc.sh's own SELFTEST=1 harness, run against an isolated fake
+# HOME/DOCS_GH so it never touches real state).
+
+library(testthat)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+repo_root <- function() {
+  this_file <- tryCatch(
+    normalizePath(sys.frame(0)$ofile, mustWork = FALSE),
+    error = function(e) ""
+  )
+  if (nzchar(this_file) && file.exists(this_file)) {
+    candidate <- dirname(dirname(this_file))
+    if (file.exists(file.path(candidate, ".git"))) return(candidate)
+  }
+  tp <- tryCatch(testthat::test_path(), error = function(e) "")
+  if (nzchar(tp)) {
+    candidate <- normalizePath(file.path(tp, "..", ".."), mustWork = FALSE)
+    if (file.exists(file.path(candidate, ".git"))) return(candidate)
+  }
+  path <- getwd()
+  for (i in seq_len(10L)) {
+    if (file.exists(file.path(path, ".git"))) return(path)
+    parent <- dirname(path)
+    if (parent == path) break
+    path <- parent
+  }
+  getwd()
+}
+
+gc_sh <- normalizePath(
+  file.path(repo_root(), ".claude", "scripts", "worktree_gc.sh"),
+  mustWork = FALSE
+)
+sweep_sh <- normalizePath(
+  file.path(repo_root(), ".claude", "scripts", "sentinel_log_sweep.sh"),
+  mustWork = FALSE
+)
+
+# Run a small bash snippet that sources sentinel_log_sweep.sh, so behaviour
+# tests exercise the real sourced functions rather than a re-implementation.
+# Written to a temp script file (not passed inline via `bash -c`) because
+# system2() does not shell-quote its args vector, and R's system() always
+# routes through /bin/sh -c to launch the child — an unquoted multi-line
+# string breaks across that outer shell's own parsing.
+run_helper_snippet <- function(body) {
+  script <- paste0(
+    "set -euo pipefail\n",
+    "source ", shQuote(sweep_sh), "\n",
+    body, "\n"
+  )
+  tmp_script <- tempfile(fileext = ".sh")
+  writeLines(script, tmp_script)
+  on.exit(unlink(tmp_script), add = TRUE)
+  system2("bash", args = tmp_script, stdout = TRUE, stderr = TRUE)
+}
+
+# ── Shell syntax checks ────────────────────────────────────────────────────────
+
+test_that("worktree_gc.sh passes bash -n syntax check", {
+  skip_if_not(file.exists(gc_sh), "worktree_gc.sh not found")
+  exit_code <- system2("bash", args = c("-n", gc_sh), stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L, info = "worktree_gc.sh has bash syntax errors")
+})
+
+test_that("sentinel_log_sweep.sh passes bash -n syntax check", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+  exit_code <- system2("bash", args = c("-n", sweep_sh), stdout = FALSE, stderr = FALSE)
+  expect_equal(exit_code, 0L, info = "sentinel_log_sweep.sh has bash syntax errors")
+})
+
+# ── Executable-bit regression guard (llm#886 failure mode) ───────────────────
+# worktree_gc.sh sources sentinel_log_sweep.sh by path (not by invoking it),
+# so a missing exec bit would not break sourcing directly — but the file also
+# carries its own standalone CLI (guarded by a BASH_SOURCE check) intended to
+# be run directly for manual debugging, so it should stay executable like its
+# sibling scripts.
+
+test_that("sentinel_log_sweep.sh is executable", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+  expect_equal(file.access(sweep_sh, mode = 1)[[1]], 0L,
+               info = "sentinel_log_sweep.sh is missing the executable bit (llm#886 failure mode)")
+})
+
+# ── sweep_stale_sentinels() — direct behaviour tests against a fixture dir ───
+
+test_that("sweep_stale_sentinels removes only files older than the threshold", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+
+  dir <- tempfile("sentinels_")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  old_sha  <- file.path(dir, ".session_start_sha_old_proj")
+  old_bye  <- file.path(dir, ".bye-requested.oldsid")
+  old_ref  <- file.path(dir, ".bye-session-end-refine.oldsid")
+  new_sha  <- file.path(dir, ".session_start_sha_new_proj")
+  new_bye  <- file.path(dir, ".bye-requested")
+  file.create(old_sha, old_bye, old_ref, new_sha, new_bye)
+
+  # Backdate the "old" trio to well past the 7-day threshold.
+  system2("touch", args = c("-t", "202601010000", shQuote(old_sha)))
+  system2("touch", args = c("-t", "202601010000", shQuote(old_bye)))
+  system2("touch", args = c("-t", "202601010000", shQuote(old_ref)))
+
+  out <- run_helper_snippet(sprintf(
+    "sweep_stale_sentinels %s 7 0\necho \"SWEPT=$SENTINELS_SWEPT\"",
+    shQuote(dir)
+  ))
+  expect_true(any(grepl("^SWEPT=3$", out)),
+              info = paste("expected SWEPT=3, got:", paste(out, collapse = "\n")))
+
+  remaining <- list.files(dir, all.files = TRUE, no.. = TRUE)
+  expect_setequal(remaining, c(".session_start_sha_new_proj", ".bye-requested"))
+  expect_false(file.exists(old_sha))
+  expect_false(file.exists(old_bye))
+  expect_false(file.exists(old_ref))
+})
+
+test_that("sweep_stale_sentinels dry-run mode never deletes", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+
+  dir <- tempfile("sentinels_dry_")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  old_sha <- file.path(dir, ".session_start_sha_old_proj")
+  file.create(old_sha)
+  system2("touch", args = c("-t", "202601010000", shQuote(old_sha)))
+
+  out <- run_helper_snippet(sprintf(
+    "sweep_stale_sentinels %s 7 1\necho \"SWEPT=$SENTINELS_SWEPT\"",
+    shQuote(dir)
+  ))
+  expect_true(any(grepl("^SWEPT=1$", out)))
+  expect_true(file.exists(old_sha), info = "dry-run must not delete anything")
+})
+
+test_that("sweep_stale_sentinels is a silent no-op on an empty directory", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+
+  dir <- tempfile("sentinels_empty_")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  out <- run_helper_snippet(sprintf(
+    "sweep_stale_sentinels %s 7 0\necho \"SWEPT=$SENTINELS_SWEPT\"",
+    shQuote(dir)
+  ))
+  expect_true(any(grepl("^SWEPT=0$", out)))
+})
+
+test_that("sweep_stale_sentinels is a silent no-op on a missing directory", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+
+  missing_dir <- tempfile("sentinels_missing_")
+
+  out <- run_helper_snippet(sprintf(
+    "sweep_stale_sentinels %s 7 0\necho \"SWEPT=$SENTINELS_SWEPT\"",
+    shQuote(missing_dir)
+  ))
+  expect_true(any(grepl("^SWEPT=0$", out)))
+})
+
+# ── rotate_log_file() / rotate_logs() — direct behaviour tests ───────────────
+
+make_big_log <- function(path, n_lines = 3000L) {
+  lines <- paste0("line ", seq_len(n_lines), " ", strrep("x", 50))
+  writeLines(lines, path)
+}
+
+test_that("rotate_logs truncates a file over the size threshold and keeps a .1 generation", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+
+  dir <- tempfile("logs_")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  big <- file.path(dir, "big.log")
+  small <- file.path(dir, "small.log")
+  make_big_log(big, 3000L)
+  writeLines("small", small)
+
+  out <- run_helper_snippet(sprintf(
+    "rotate_logs %s 10000 10 0\necho \"ROTATED=$LOGS_ROTATED\"",
+    shQuote(dir)
+  ))
+  expect_true(any(grepl("^ROTATED=1$", out)),
+              info = paste("expected ROTATED=1, got:", paste(out, collapse = "\n")))
+
+  expect_equal(length(readLines(big)), 10L,
+               info = "big.log must be truncated to keep_lines")
+  expect_true(file.exists(paste0(big, ".1")),
+              info = "a .1 generation must be kept")
+  expect_equal(length(readLines(paste0(big, ".1"))), 3000L,
+               info = ".1 generation must hold the full pre-rotation content")
+  expect_equal(length(readLines(small)), 1L,
+               info = "a file under threshold must be left untouched")
+})
+
+test_that("rotate_logs never touches .duckdb files even when oversized", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+
+  dir <- tempfile("logs_duckdb_")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  db <- file.path(dir, "unified.duckdb")
+  make_big_log(db, 3000L)
+
+  out <- run_helper_snippet(sprintf(
+    "rotate_logs %s 10000 10 0\necho \"ROTATED=$LOGS_ROTATED\"",
+    shQuote(dir)
+  ))
+  expect_true(any(grepl("^ROTATED=0$", out)),
+              info = paste("expected ROTATED=0 (duckdb must be skipped), got:",
+                            paste(out, collapse = "\n")))
+  expect_equal(length(readLines(db)), 3000L,
+               info = "a .duckdb file must NEVER be rotated regardless of size")
+  expect_false(file.exists(paste0(db, ".1")))
+})
+
+test_that("rotate_logs dry-run mode never truncates", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+
+  dir <- tempfile("logs_dry_")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  big <- file.path(dir, "big.log")
+  make_big_log(big, 3000L)
+
+  out <- run_helper_snippet(sprintf(
+    "rotate_logs %s 10000 10 1\necho \"ROTATED=$LOGS_ROTATED\"",
+    shQuote(dir)
+  ))
+  expect_true(any(grepl("^ROTATED=1$", out)))
+  expect_equal(length(readLines(big)), 3000L,
+               info = "dry-run must not truncate anything")
+  expect_false(file.exists(paste0(big, ".1")))
+})
+
+test_that("rotate_logs is idempotent — a second run over an already-rotated file is a no-op", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+
+  dir <- tempfile("logs_idem_")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  big <- file.path(dir, "big.log")
+  make_big_log(big, 3000L)
+
+  out <- run_helper_snippet(sprintf(
+    paste0(
+      "rotate_logs %s 10000 10 0\n",
+      "rotate_logs %s 10000 10 0\n",
+      "echo \"ROTATED=$LOGS_ROTATED\""
+    ),
+    shQuote(dir), shQuote(dir)
+  ))
+  expect_true(any(grepl("^ROTATED=0$", out)),
+              info = "second rotation pass must be a no-op once the file is under threshold")
+})
+
+test_that("rotate_logs is a silent no-op on an empty or missing directory", {
+  skip_if_not(file.exists(sweep_sh), "sentinel_log_sweep.sh not found")
+
+  empty_dir <- tempfile("logs_empty_")
+  dir.create(empty_dir)
+  on.exit(unlink(empty_dir, recursive = TRUE), add = TRUE)
+  missing_dir <- tempfile("logs_missing_")
+
+  out_empty <- run_helper_snippet(sprintf(
+    "rotate_logs %s 10000 10 0\necho \"ROTATED=$LOGS_ROTATED\"",
+    shQuote(empty_dir)
+  ))
+  expect_true(any(grepl("^ROTATED=0$", out_empty)))
+
+  out_missing <- run_helper_snippet(sprintf(
+    "rotate_logs %s 10000 10 0\necho \"ROTATED=$LOGS_ROTATED\"",
+    shQuote(missing_dir)
+  ))
+  expect_true(any(grepl("^ROTATED=0$", out_missing)))
+})
+
+# ── End-to-end wiring — worktree_gc.sh SELFTEST=1 against an isolated fake
+#    HOME/DOCS_GH (never the real ~/.claude/) ────────────────────────────────
+
+test_that("worktree_gc.sh --selftest suite (incl. sentinel-sweep + log-rotate tests) passes", {
+  skip_if_not(file.exists(gc_sh), "worktree_gc.sh not found")
+
+  fake_home <- tempfile("gc_selftest_home_")
+  dir.create(file.path(fake_home, ".claude", "logs"), recursive = TRUE)
+  dir.create(file.path(fake_home, "docs_gh"), recursive = TRUE)
+  on.exit(unlink(fake_home, recursive = TRUE), add = TRUE)
+
+  env <- c(
+    paste0("SELFTEST=1"),
+    paste0("HOME=", fake_home),
+    paste0("DOCS_GH=", file.path(fake_home, "docs_gh")),
+    paste0("WORKTREES_BASE=", file.path(fake_home, "docs_gh", "worktrees")),
+    paste0("WORKTREES_BASE_LEGACY=", file.path(fake_home, "worktrees_legacy")),
+    paste0("UNIFIED_DB_PATH=", file.path(fake_home, ".claude", "logs", "unified.duckdb")),
+    paste0("CLAUDE_RUNTIME_ROOT=", file.path(fake_home, ".claude"))
+  )
+
+  out <- withr::with_envvar(
+    setNames(sub("^[^=]+=", "", env), sub("=.*$", "", env)),
+    system2("bash", args = gc_sh, stdout = TRUE, stderr = TRUE)
+  )
+  combined <- paste(out, collapse = "\n")
+
+  expect_true(
+    grepl("0 FAIL", combined),
+    info = paste0("worktree_gc.sh --selftest reported failures:\n", combined)
+  )
+  expect_true(
+    grepl("sentinel dry-run counts 3 stale files", combined),
+    info = "sentinel-sweep selftest checks did not run — wiring may be broken"
+  )
+  expect_true(
+    grepl("log-rotate real run rotates 1 file", combined),
+    info = "log-rotate selftest checks did not run — wiring may be broken"
+  )
+})
+
+test_that("worktree_gc.sh dry-run never mutates a fixture ~/.claude/ (no --apply)", {
+  skip_if_not(file.exists(gc_sh), "worktree_gc.sh not found")
+
+  fake_home <- tempfile("gc_dryrun_home_")
+  dir.create(file.path(fake_home, ".claude", "logs"), recursive = TRUE)
+  dir.create(file.path(fake_home, "docs_gh"), recursive = TRUE)
+  on.exit(unlink(fake_home, recursive = TRUE), add = TRUE)
+
+  old_sha <- file.path(fake_home, ".claude", ".session_start_sha_old_proj")
+  file.create(old_sha)
+  system2("touch", args = c("-t", "202601010000", shQuote(old_sha)))
+  big <- file.path(fake_home, ".claude", "logs", "big_test.log")
+  make_big_log(big, 3000L)
+
+  env <- setNames(
+    c(fake_home,
+      file.path(fake_home, "docs_gh"),
+      file.path(fake_home, "docs_gh", "worktrees"),
+      file.path(fake_home, "worktrees_legacy"),
+      file.path(fake_home, ".claude", "logs", "unified.duckdb"),
+      file.path(fake_home, ".claude"),
+      "10000", "10"),
+    c("HOME", "DOCS_GH", "WORKTREES_BASE", "WORKTREES_BASE_LEGACY",
+      "UNIFIED_DB_PATH", "CLAUDE_RUNTIME_ROOT",
+      "LOG_ROTATE_THRESHOLD_BYTES", "LOG_ROTATE_KEEP_LINES")
+  )
+
+  withr::with_envvar(env, {
+    system2("bash", args = gc_sh, stdout = FALSE, stderr = FALSE)
+  })
+
+  expect_true(file.exists(old_sha),
+              info = "dry-run (no --apply) must not delete stale sentinels")
+  expect_equal(length(readLines(big)), 3000L,
+               info = "dry-run (no --apply) must not rotate oversized logs")
+})


### PR DESCRIPTION
Steps 2–3 of #884. Step 1 (DuckDB compaction, 7.37 GB → 0.021 GB) is already
done — see [that comment](https://github.com/JohnGavin/llm/issues/884#issuecomment-5182956114).

These two changes stop `~/.claude/` refilling.

## 1. Orphaned session sentinels

`session_init.sh` writes `~/.claude/.session_start_sha_<slug>` at every session
start; `session_end_refine.sh` reads it at `/bye`. **Nothing ever deleted it** —
476 had accumulated, oldest 2026-05-20, covering deleted worktrees, one-off agent
sandboxes and even test fixtures (`kb_fixture_*`, `tmp.IZoOBNm33e`). Same for
`.bye-requested.*` / `.bye-session-end-refine.*` (zero-byte, ~58 stale).

**Deliberately an age-based sweep, not delete-on-consume.** The state file is
keyed by *project slug*, not session id, so two concurrent sessions on the same
project share one file — deleting it when the first ends would break the second.
That is why the existing code comments it "non-destructive". A `>7d` sweep gets
the same result without that hazard.

## 2. Size-based log rotation

`~/.claude/logs/` holds 123 `.log`/`.err`/`.out` files and the audit found **zero
older than 30 days** — everything is actively written. So this is rotation by
**size**, not retention by age.

Copy-truncate in place (`tail` to temp, then `cat tmp > path`) rather than
`mv`/rename, so an appending writer's file descriptor stays valid. One `.1`
generation kept. `logs/*.duckdb` skipped unconditionally.

## Verification — independent of the agent's own tests

Ran against fixture directories, never the real `~/.claude/`:

| check | result |
|---|---|
| dry-run changes nothing (default) | ✅ |
| sentinels >7d removed | ✅ |
| sentinels <7d **kept** | ✅ |
| oversized log truncated | ✅ 65.6 MB → 146 KB, exactly 2000 lines |
| `.1` generation kept | ✅ |
| small log untouched | ✅ |
| **`.duckdb` untouched** | ✅ byte-identical, no `.1` created |
| idempotent / no-op re-run | ✅ exit 0 |

`bash -n` clean on both `sentinel_log_sweep.sh` and `worktree_gc.sh` — the latter
matters because it runs daily under launchd and a syntax error would silently
kill it, exactly the #886 failure mode.

New test file: **31 pass, 0 fail**.

### One limitation found while verifying

Rotation is **line-based** (`tail -n`), so a log consisting of one enormous line
will not shrink. My first fixture hit this by accident — macOS `base64` emits a
single line, so a 16 MB file was "not rotated" and briefly looked like a bug. It
is not: real logs are line-oriented. Worth knowing if a future writer emits
single-line JSON blobs; a byte-based fallback would close it.

## Not fixed here

`roborev_poll_merges.log` at 75 MB is a **symptom** of
[#887](https://github.com/JohnGavin/llm/issues/887) — roborev's `repos` table
holds 1,653 entries of which only 22 are live, so the poller emits ~1,390 `SKIP`
lines per run. Rotation caps the file; it does not stop the noise. #887 remains
open for the root fix.

## Provenance

Implemented by a dispatched fixer agent (Dispatch-Id 7c418fb7) that committed
incrementally — the mitigation added to `feedback_agent-salvage-unlanded-work`
this morning after 7/7 agents stopped before committing. It still stopped before
pushing, but the work survived in a clean commit rather than a dirty worktree, so
salvage was reduced to verify-and-push. Tier-3 post-verify clean.

Refs #884, #886, #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)