### PR TITLE
fix(hooks): gate telemetry export + mem_pr on /bye sentinel (#910)

### DIFF
--- a/.claude/hooks/session_stop.sh
+++ b/.claude/hooks/session_stop.sh
@@ -174,10 +174,15 @@ fi
 # ── Telemetry data export + deploy (Calibration + Sessions tabs) ────
 # Background the export so /bye returns instantly. Output to dated log
 # for post-hoc inspection. See llm#381.
+# IMPORTANT: The Stop hook fires after EVERY Claude response, not only /bye.
+# This block runs a full R export + git commit + push to the llmtelemetry
+# repo and triggers a Shinylive deploy — expensive if run per-response.
+# Gated on the same one-shot `_bye_detected` sentinel used elsewhere in this
+# file (see llm#910).
 EXPORT_SCRIPT="$CLAUDE_DIR/scripts/export_and_deploy_data.sh"
 EXPORT_LOG_DIR="$CLAUDE_DIR/logs"
 EXPORT_LOG="$EXPORT_LOG_DIR/export_and_deploy.$(date +%Y%m%d).log"
-if [ -x "$EXPORT_SCRIPT" ]; then
+if [ "$_bye_detected" -eq 1 ] && [ -x "$EXPORT_SCRIPT" ]; then
   mkdir -p "$EXPORT_LOG_DIR"
   nohup timeout 180 "$EXPORT_SCRIPT" > "$EXPORT_LOG" 2>&1 &
   disown
@@ -301,11 +306,15 @@ fi
 # here so the checkout returns to clean between sessions. Never blocks
 # session end (non-fatal, bounded by timeout); never pushes to main
 # directly — always opens a PR (pr-shipping-discipline rule).
+# IMPORTANT: The Stop hook fires after EVERY Claude response, not only /bye.
+# mem_pr.sh creates a branch, commits, and opens a PR — a per-response PR
+# storm if left ungated. Gated on the same one-shot `_bye_detected` sentinel
+# used elsewhere in this file (see llm#910).
 # Opt-out: SKIP_MEM_PR=1.
 _MEM_PR_SCRIPT="$CLAUDE_DIR/scripts/mem_pr.sh"
 _MEM_PR_REPO="${CLAUDE_PROJECT_DIR:-$HOME/docs_gh/llm}"
 _MEM_PR_LOG="$CLAUDE_RUNTIME_ROOT/logs/mem_pr.log"
-if [ -x "$_MEM_PR_SCRIPT" ]; then
+if [ "$_bye_detected" -eq 1 ] && [ -x "$_MEM_PR_SCRIPT" ]; then
   mkdir -p "$(dirname "$_MEM_PR_LOG")"
   timeout 60 "$_MEM_PR_SCRIPT" "$_MEM_PR_REPO" >> "$_MEM_PR_LOG" 2>&1 || true
 fi


### PR DESCRIPTION
## Summary

The Stop hook (`.claude/hooks/session_stop.sh`) fires after **every**
assistant response, not only `/bye`. The script already computes a one-shot
`_bye_detected` sentinel and correctly gates the DB-stop write (line 118) and
the pattern-detection block (line 227) on it. Two other side-effecting blocks
were left ungated:

1. **Telemetry export + deploy** (primary defect, llm#910): runs a full R
   export, `git commit` + `git push` to the `llmtelemetry` repo, and
   triggers a Shinylive deploy. Ungated, this fired on every response
   (observed ~11x/day/session), with each new deploy cancelling the previous
   one via the concurrency group.
2. **`mem_pr.sh`** (defense in depth, same defect class): creates a branch,
   commits, and opens a PR. Documented as a "session-end batch PR" but was
   running per-response. It has not actually fired in practice — it also
   requires dirty prose files AND being on `main`, and I verified there are
   0 `chore/memory-*` branches and the log is entirely "nothing to route".
   Still latent risk if both conditions ever coincide on a multi-turn
   main-checkout session, so it's gated for consistency with the other
   sentinel-gated blocks.

## Changes

- `EXPORT_SCRIPT` block: `if [ -x "$EXPORT_SCRIPT" ]` → `if [ "$_bye_detected" -eq 1 ] && [ -x "$EXPORT_SCRIPT" ]`
- `_MEM_PR_SCRIPT` block: `if [ -x "$_MEM_PR_SCRIPT" ]` → `if [ "$_bye_detected" -eq 1 ] && [ -x "$_MEM_PR_SCRIPT" ]`
- Comments updated on both blocks to note the fire-on-every-response hazard and the `_bye_detected` gate, matching the style already used at the other two gated blocks.

Left untouched per orchestrator instruction: the session-index-log block
(same defect class, but has a separate design trade-off being handled
elsewhere) and all echo-only reminder blocks (no side effects).

## Test plan

- [x] `bash -n .claude/hooks/session_stop.sh` passes
- [x] `grep -n '_bye_detected'` confirms exactly 4 gated `if` blocks (lines 118, 185, 227, 317)
- [x] Diff confirms only the two intended blocks changed; session-index block untouched

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)