### PR TITLE
docs(rules): correct data_quality_incidents example window end date (llm#913)

### DIFF
--- a/.claude/rules/unified-observability-schema.md
+++ b/.claude/rules/unified-observability-schema.md
@@ -71,7 +71,7 @@ these before proposing a new table:
 
 `data_quality_incidents` records windows where an asset/column's values are
 known to be untrustworthy (imputed, estimated, or otherwise not observed) —
-e.g. `sessions.duration_min` between 2026-07-24 and 2026-08-04, backfilled by
+e.g. `sessions.duration_min` between 2026-07-24 and 2026-08-05, backfilled by
 `session_reaper.sql` (llm#803) when `session_stop.sh`'s DB write silently
 stopped firing (llm#913, llm#915). Add a row when you diagnose such a window;
 it is a one-time incident record, not a continuously-firing event table. Any


### PR DESCRIPTION
One-character-class fix: the `unified-observability-schema` rule's `data_quality_incidents` example cites the incident window as ending **2026-08-04**. That was the value from the first version of the seed in #917, corrected during review before merge.

The original end date was derived from `max(started_at)` of reaper-marked rows, which runs ~20h behind reality — `session_reaper.sql` only marks a session after >6h of abandonment, so the most recently affected rows are never marked yet. The seeded record now ends **2026-08-05 17:29:22**, the instant the llm#915 fix went live (the fast-forward pull, not the PR merge — `~/.claude/hooks/` symlinks into the main checkout, llm#510).

This aligns the always-loaded rule text with the record actually seeded into `unified.duckdb`, so the guidance does not understate the window by a day.

Verified against the live DB:

```
asset     column_name   window_start                  window_end
sessions  duration_min  2026-07-24 06:08:18.802979    2026-08-05 17:29:22
sessions  ended_at      2026-07-24 06:08:18.802979    2026-08-05 17:29:22
```

Refs llm#913, llm#915, #917.