### PR TITLE
feat(dashboard): repository-coverage summary on the Reviews tab (#923)

### DIFF
--- a/inst/shiny/dashboard/app.R
+++ b/inst/shiny/dashboard/app.R
@@ -201,6 +201,42 @@ roborev_status <- function() {
   }, error = function(e) "roborev not available")
 }
 
+# Repository-coverage counts, read from roborev's own SQLite DB (llm#923).
+#
+# `roborev repo list` has no --json flag and no created_at, so the counts below
+# come straight from the DB. sqlite3 ships with macOS; if it or the DB is
+# missing every field returns NA and the UI renders "n/a" rather than a
+# misleading 0 (see zero-metric-evidence-or-defect rule).
+#
+# `deleted` is deliberately absent: `repos` has no tombstone, so a removed repo
+# leaves no trace and a decrease is NOT observable. `active_7d` is the honest
+# substitute -- repos that actually saw a review in the window.
+roborev_repo_stats <- function() {
+  na_result <- list(total = NA_integer_, new_7d = NA_integer_,
+                    active_7d = NA_integer_, ephemeral = NA_integer_)
+  db <- Sys.getenv("ROBOREV_DB", unset = path.expand("~/.roborev/reviews.db"))
+  if (!file.exists(db) || !nzchar(Sys.which("sqlite3"))) return(na_result)
+
+  sql <- paste(
+    "SELECT (SELECT count(*) FROM repos),",
+    "(SELECT count(*) FROM repos WHERE created_at >= date('now','-7 days')),",
+    "(SELECT count(DISTINCT repo_id) FROM review_jobs",
+    " WHERE enqueued_at >= date('now','-7 days')),",
+    "(SELECT count(*) FROM repos WHERE root_path LIKE '/tmp/%'",
+    " OR root_path LIKE '/private/tmp/%' OR root_path LIKE '/var/folders/%'",
+    " OR root_path LIKE '/private/var/folders/%');"
+  )
+  tryCatch({
+    raw <- system2("sqlite3", c("-readonly", shQuote(db), shQuote(sql)),
+                   stdout = TRUE, stderr = FALSE)
+    if (length(raw) == 0L || !nzchar(raw[1])) return(na_result)
+    parts <- as.integer(strsplit(raw[1], "|", fixed = TRUE)[[1]])
+    if (length(parts) != 4L || anyNA(parts)) return(na_result)
+    list(total = parts[1], new_7d = parts[2],
+         active_7d = parts[3], ephemeral = parts[4])
+  }, error = function(e) na_result)
+}
+
 # ---- UI ---------------------------------------------------------------------
 
 ui <- bslib::page_sidebar(
@@ -358,7 +394,15 @@ ui <- bslib::page_sidebar(
       shiny::fluidRow(
         shiny::column(
           12,
-          shiny::h6("roborev status", style = "color:#aaa; margin-top:8px;"),
+          shiny::h6("Repository coverage", style = "color:#aaa; margin-top:8px;"),
+          shiny::uiOutput("roborev_repo_metrics_ui")
+        )
+      ),
+
+      shiny::fluidRow(
+        shiny::column(
+          12,
+          shiny::h6("roborev status", style = "color:#aaa; margin-top:16px;"),
           shiny::uiOutput("roborev_status_ui")
         )
       ),
@@ -989,6 +1033,43 @@ server <- function(input, output, session) {
         "max-height:140px; overflow-y:auto;"
       ),
       txt
+    )
+  })
+
+  output$roborev_repo_metrics_ui <- shiny::renderUI({
+    roborev_refresh()
+    s <- roborev_repo_stats()
+    fmt <- function(x) if (is.na(x)) "n/a" else as.character(x)
+
+    metrics <- data.frame(
+      metric = c("Repositories tracked", "New (7d)", "Active (7d)"),
+      value  = c(fmt(s$total), fmt(s$new_7d), fmt(s$active_7d)),
+      stringsAsFactors = FALSE
+    )
+    # Ephemeral repos are the llm#923 phantom class: throwaway temp-dir repos
+    # that inherited the global core.hooksPath. Steady state is 0; anything
+    # above that means the guard has regressed, so surface it only when non-zero.
+    if (!is.na(s$ephemeral) && s$ephemeral > 0L) {
+      metrics <- rbind(metrics, data.frame(
+        metric = "Ephemeral (should be 0)",
+        value  = as.character(s$ephemeral),
+        stringsAsFactors = FALSE
+      ))
+    }
+    value_colors <- c(
+      "#ffffff", "#ffffff", "#ffffff",
+      if (!is.na(s$ephemeral) && s$ephemeral > 0L) "#f08080"
+    )
+    shiny::tagList(
+      metric_table_ui(metrics, value_colors),
+      shiny::p(
+        style = "color:#aaa; margin-top:6px;",
+        paste(
+          "Repository deletions are not observable -- `repos` keeps no",
+          "tombstone -- so only increases are reported. \"Active\" counts",
+          "repos with a review enqueued in the window."
+        )
+      )
     )
   })
 


### PR DESCRIPTION
After #923 removed 1,723 phantom repos, the real repo count wasn't visible anywhere. Adds a compact **Repository coverage** block at the top of the Reviews tab.

| Metric | Value |
|---|---|
| Repositories tracked | 27 |
| New (7d) | 1 |
| Active (7d) | 9 |

Read from roborev's SQLite DB via a new `roborev_repo_stats()` helper — `roborev repo list` has neither a `--json` flag nor `created_at`, so the CLI can't supply the deltas. `sqlite3` ships with macOS.

## Design decisions worth flagging

**No "deleted" metric.** You asked for a decrease count if we track one. We can't, honestly: `repos` has no tombstone, so a removed repo leaves no trace and a decrease is genuinely unobservable from the schema. Rather than invent a number, the block reports increases only and says so in a caption. **"Active (7d)"** — repos with a review enqueued in the window — is the honest substitute for churn, and is arguably the more useful of the two anyway.

**A fourth row appears only when it should never appear.** "Ephemeral (should be 0)" renders in red *only* when non-zero. Steady state after #923 is 0; anything above that means the post-commit guard has regressed. This makes the dashboard surface that regression instead of relying on someone remembering to check — the failure mode that let 1,723 rows accumulate unnoticed.

**Missing DB → `n/a`, never `0`.** Every field returns `NA` when the DB or `sqlite3` is absent. A hard `0` would read as "no repositories tracked" — the exact inversion `zero-metric-evidence-or-defect` exists to prevent.

Compact 2-col `metric_table_ui`, not `value_box` (AGENTS.md Shiny UI ban).

## Verification

- `parse()` clean — 15 expressions
- Live DB: `total=27 new_7d=1 active_7d=9 ephemeral=0`
- `ROBOREV_DB=/nonexistent/nope.db`: all four fields `NA` → renders `n/a`

`ROBOREV_DB` exists so that failure branch is testable, matching the same override in `cleanup_ephemeral_repos.sh`.

Refs #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)