### PR TITLE
fix(roborev): self-test read a hardcoded worktree path, not its own hook (#923)

### DIFF
--- a/git-hooks/test-post-commit-guard.sh
+++ b/git-hooks/test-post-commit-guard.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 # Two-sided test of the post-commit ephemeral-path guard (llm#923).
+#
+# HOOK resolves from this script's OWN directory. It must never be an absolute
+# path to a particular checkout: the first version of this file hardcoded a
+# worktree path, so running it from the main checkout silently tested the
+# worktree's copy of the hook instead of its own. It reported 3/3 PASS while
+# that worktree happened to hold the fixed hook, then FAILed once the worktree
+# moved to a branch predating it -- a green result that was never evidence
+# about the file shipped alongside it (portable-build-artifacts).
 set -u
-HOOK="/Users/johngavin/docs_gh/worktrees/llm/feat/cc-20260802-120510/git-hooks/post-commit"
+HOOK="$(cd "$(dirname "$0")" && pwd)/post-commit"
 WORK=$(mktemp -d)
 MARKER="$WORK/roborev_was_called"
 


### PR DESCRIPTION
Found by pulling the main checkout after #924 merged, and re-running the self-test from its deployed location.

## What happened

`test-post-commit-guard.sh` hardcoded an absolute worktree path:

```bash
HOOK="/Users/johngavin/docs_gh/worktrees/llm/feat/cc-20260802-120510/git-hooks/post-commit"
```

So it tested whatever that worktree contained, not the hook beside it. Run from the main checkout it reported:

```
FAIL case 1: roborev was invoked from a temp repo
```

**The deployed guard is fine** — present, correct, and unchanged by this PR. The failure was the test reading a worktree that had since moved to a branch predating the guard.

The uncomfortable part: the `3/3 PASS` reported in #924 was *true when I ran it* and was still never evidence about the file it shipped alongside. It passed because that worktree happened to hold the fixed hook at that moment. On any other machine the path wouldn't exist at all.

Textbook `portable-build-artifacts`: a committed artifact must not depend on the checkout that built it.

## Fix

```bash
HOOK="$(cd "$(dirname "$0")" && pwd)/post-commit"
```

## Verification — two-sided, which the original could not be

| Setup | Result |
|---|---|
| Beside the fixed hook | **3/3 PASS** |
| Beside the pre-guard hook (`935088f`, copied to a scratch dir) | **FAILURES** |

The second case is the one that matters — it proves the test now reads its neighbour rather than a fixed path. A test that can't fail when the thing it tests is broken isn't a test.

Refs #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)