### PR TITLE
feat(roborev): capture failure reasons in the ETL — job failures were invisible (#928)

### DIFF
--- a/.claude/scripts/roborev_metrics_etl.R
+++ b/.claude/scripts/roborev_metrics_etl.R
@@ -223,6 +223,20 @@ has_source_col <- tryCatch({
   log_msg("WARN: cannot introspect review_jobs columns: ", conditionMessage(e))
   FALSE
 })
+
+# ── Guard: review_jobs.error (llm#928) ────────────────────────────────────────
+# The ETL previously selected `status` but not `error`, so a job's failure was
+# recorded while the REASON was discarded. That made llm#923 undiagnosable from
+# our own metrics: 1,121 of 1,137 failures were phantom (reviews enqueued
+# against deleted temp dirs) and 16 were genuine quota exhaustion, and nothing
+# downstream could tell the two apart. Same guard pattern as `source` above —
+# absent column degrades to NULL rather than throwing.
+has_error_col <- tryCatch({
+  "error" %in% names(dbGetQuery(read_con, "SELECT * FROM src.review_jobs LIMIT 0"))
+}, error = function(e) FALSE)
+if (!has_error_col) {
+  log_msg("WARN: review_jobs.error column absent — failure_category will be 'unknown' for all rows (llm#928)")
+}
 if (!has_source_col) {
   log_msg("WARN: review_jobs.source column absent — using NULL AS source in sql_jobs (llm#706 Cause-1 guard)")
 }
@@ -238,13 +252,16 @@ sql_jobs <- sprintf("
     rj.enqueued_at,
     rj.started_at,
     rj.finished_at,
-    %s             AS source
+    %s             AS source,
+    %s             AS error
   FROM src.review_jobs rj
   JOIN src.repos rp ON rp.id = rj.repo_id
   WHERE date(rj.enqueued_at) >= DATE '%s'
   %s
   ORDER BY rj.id
-", if (has_source_col) "rj.source" else "NULL", since_str, repo_clause)
+", if (has_source_col) "rj.source" else "NULL",
+   if (has_error_col) "rj.error" else "NULL",
+   since_str, repo_clause)
 
 jobs_raw <- tryCatch(
   dbGetQuery(read_con, sql_jobs),
@@ -454,6 +471,55 @@ parse_max_severity <- function(text) {
   }, error = function(e) NA_character_)
 }
 
+# ── Classify a job failure from review_jobs.error (llm#928) ──────────────────
+#
+# Vocabulary (4 values). Deliberately coarse: the question these answer is
+# "is roborev working?", and that only needs to separate our-fault, their-fault,
+# and real.
+#
+#   ephemeral  — review enqueued against a temp dir that no longer exists.
+#                Not a roborev failure at all: a repo under /tmp, /private/tmp,
+#                /var/folders or /private/var/folders was registered by a test
+#                fixture inheriting the global core.hooksPath, then deleted
+#                (llm#923). 1,121 of 1,137 failures in the 16 days to
+#                2026-08-06 were this. Should be ~0 now the guard is deployed;
+#                a non-zero count means the guard has regressed.
+#   quota      — agent spend/quota/rate limit. NOT an agent-quality signal:
+#                billing state. Currently terminal, so the commit is dropped
+#                entirely (llm#927), and misfiled as `crash` by
+#                `roborev summary --json` (llm#904).
+#   agent      — the agent ran and failed (crash, stream error, timeout).
+#                The only category that says anything about agent reliability.
+#   other      — anything unmatched. A rising `other` means this vocabulary
+#                needs extending, so it is kept as an explicit bucket rather
+#                than folded into `agent`.
+#
+# NA for non-failed jobs. Order matters: ephemeral is tested first because a
+# deleted-tempdir error also mentions git, and quota before agent because a
+# quota rejection arrives as a stream error.
+classify_failure <- function(status, error) {
+  n <- length(status)
+  out <- rep(NA_character_, n)
+  if (n == 0L) return(out)
+
+  is_failed <- !is.na(status) & status == "failed"
+  if (!any(is_failed)) return(out)
+
+  err <- ifelse(is.na(error), "", as.character(error))
+
+  ephemeral <- grepl("(/private)?/tmp/|(/private)?/var/folders/", err)
+  quota     <- grepl("spend limit|quota|rate limit|too many requests|429",
+                     err, ignore.case = TRUE)
+  agent     <- grepl("agent:|stream error|exit status|timeout|panic",
+                     err, ignore.case = TRUE)
+
+  out[is_failed]                          <- "other"
+  out[is_failed & agent]                  <- "agent"
+  out[is_failed & quota]                  <- "quota"
+  out[is_failed & ephemeral]              <- "ephemeral"
+  out
+}
+
 # ── Build roborev_daily_metrics ────────────────────────────────────────────
 
 build_daily_metrics <- function(jobs, reviews) {
@@ -468,6 +534,13 @@ build_daily_metrics <- function(jobs, reviews) {
     parse_fail_count            = integer(),
     threshold_effective         = character(),
     etl_run_at                  = as.POSIXct(character()),
+    # llm#928 — additive; see the schema file's FROZEN note. `reviews_failed`
+    # is verdict-failed and is NOT renamed (llmtelemetry#144 reads it by name).
+    jobs_failed                 = integer(),
+    jobs_failed_ephemeral       = integer(),
+    jobs_failed_quota           = integer(),
+    jobs_failed_agent           = integer(),
+    jobs_failed_other           = integer(),
     stringsAsFactors            = FALSE
   )
 
@@ -498,6 +571,14 @@ build_daily_metrics <- function(jobs, reviews) {
     job_ids   <- day_jobs$job_id
     day_rv    <- rv_slim[rv_slim$job_id %in% job_ids, ]
 
+    # llm#928. "none" rather than NA so the sums below need no na.rm and a
+    # miscount cannot hide behind it.
+    day_fail_cat <- classify_failure(
+      day_jobs$status,
+      if ("error" %in% names(day_jobs)) day_jobs$error else NA_character_
+    )
+    day_fail_cat[is.na(day_fail_cat)] <- "none"
+
     data.frame(
       date                        = as.Date(d),
       repo                        = rep,
@@ -509,6 +590,16 @@ build_daily_metrics <- function(jobs, reviews) {
       parse_fail_count            = get_parse_fail(d, rep),
       threshold_effective         = get_threshold_effective(d, rep),
       etl_run_at                  = etl_run_at,
+      # llm#928 — job-level failure, which `reviews_passed`/`reviews_failed`
+      # cannot express: those come from `verdict_bool`, and a job that fails
+      # never produces a review row, so it lands in `reviews_created` and in
+      # neither of the other two. On 2026-08-03 that read as
+      # `reviews_failed = 5` for llm against 582 actually-failed jobs.
+      jobs_failed                 = sum(day_fail_cat != "none"),
+      jobs_failed_ephemeral       = sum(day_fail_cat == "ephemeral"),
+      jobs_failed_quota           = sum(day_fail_cat == "quota"),
+      jobs_failed_agent           = sum(day_fail_cat == "agent"),
+      jobs_failed_other           = sum(day_fail_cat == "other"),
       stringsAsFactors            = FALSE
     )
   })

--- a/.claude/scripts/roborev_metrics_schema.sql
+++ b/.claude/scripts/roborev_metrics_schema.sql
@@ -32,6 +32,28 @@ CREATE TABLE IF NOT EXISTS roborev_daily_metrics (
   PRIMARY KEY (date, repo)
 );
 
+-- ADDITIVE columns (llm#928, 2026-08-06) — safe under the FROZEN note above:
+-- nothing is renamed or retyped, and downstream selects by name.
+--
+-- WHY: `reviews_passed`/`reviews_failed` are derived from `reviews.verdict_bool`,
+-- which only exists once a job produced a review. A job that FAILS never
+-- produces one, so it counts in `reviews_created` and in neither of the other
+-- two — job-level failure had no column at all. On 2026-08-03 this table read
+-- `reviews_failed = 5` for llm while 582 jobs actually failed that day.
+--
+-- `reviews_failed` keeps its meaning (verdict failed) and its name;
+-- llmtelemetry#144 reads it. The new columns sit alongside it.
+--
+-- ALTER ... ADD COLUMN IF NOT EXISTS is idempotent in DuckDB and backfills
+-- existing rows with the DEFAULT. Note DuckDB rejects NOT NULL in ADD COLUMN
+-- ("Adding columns with constraints not yet supported"), so these carry
+-- DEFAULT 0 only — matching the intent without the constraint.
+ALTER TABLE roborev_daily_metrics ADD COLUMN IF NOT EXISTS jobs_failed           INTEGER DEFAULT 0;
+ALTER TABLE roborev_daily_metrics ADD COLUMN IF NOT EXISTS jobs_failed_ephemeral INTEGER DEFAULT 0;
+ALTER TABLE roborev_daily_metrics ADD COLUMN IF NOT EXISTS jobs_failed_quota     INTEGER DEFAULT 0;
+ALTER TABLE roborev_daily_metrics ADD COLUMN IF NOT EXISTS jobs_failed_agent     INTEGER DEFAULT 0;
+ALTER TABLE roborev_daily_metrics ADD COLUMN IF NOT EXISTS jobs_failed_other     INTEGER DEFAULT 0;
+
 -- ── roborev_review_lifecycle ──────────────────────────────────────────────
 -- Per-review timeline. One row per review (keyed on review_id from reviews.id).
 -- PK: review_id

--- a/tests/testthat/_snaps/roborev-failure-category.md
+++ b/tests/testthat/_snaps/roborev-failure-category.md
@@ -1,0 +1,7 @@
+# snapshot: the category vocabulary is stable
+
+    Code
+      print(cf(rep("failed", length(errs)), errs))
+    Output
+      [1] "ephemeral" "quota"     "agent"     "other"    
+

--- a/tests/testthat/test-roborev-failure-category.R
+++ b/tests/testthat/test-roborev-failure-category.R
@@ -1,0 +1,110 @@
+# test-roborev-failure-category.R — classify_failure() from roborev_metrics_etl.R (llm#928)
+#
+# The ETL is a standalone Rscript, not a package function, so the classifier is
+# extracted by parsing the file and evaluating just that one assignment. This
+# keeps the test honest: it exercises the code that actually ships, rather than
+# a copy that can drift.
+
+library(testthat)
+
+etl_path <- function() {
+  # tests/testthat/ -> repo root
+  candidates <- c(
+    file.path(testthat::test_path("..", ".."), ".claude", "scripts", "roborev_metrics_etl.R"),
+    file.path(getwd(), ".claude", "scripts", "roborev_metrics_etl.R")
+  )
+  for (p in candidates) if (file.exists(p)) return(normalizePath(p))
+  ""
+}
+
+load_classifier <- function() {
+  p <- etl_path()
+  skip_if_not(nzchar(p) && file.exists(p), "roborev_metrics_etl.R not found")
+  env <- new.env(parent = globalenv())
+  exprs <- parse(p)
+  found <- FALSE
+  for (x in exprs) {
+    if (is.call(x) && identical(as.character(x[[1]]), "<-") &&
+        identical(as.character(x[[2]]), "classify_failure")) {
+      eval(x, env); found <- TRUE
+    }
+  }
+  skip_if_not(found, "classify_failure() not found in roborev_metrics_etl.R")
+  env$classify_failure
+}
+
+test_that("failed jobs are categorised and non-failed jobs are NA", {
+  cf <- load_classifier()
+
+  # Non-failed statuses must never acquire a category, even when an error
+  # string is present (a retried job can carry a stale error).
+  expect_true(is.na(cf("done",   NA)))
+  expect_true(is.na(cf("done",   "agent: something went wrong")))
+  expect_true(is.na(cf("queued", NA)))
+
+  # A failed job always gets a category, never NA — that is what makes
+  # jobs_failed reconcilable against the source count.
+  expect_false(is.na(cf("failed", NA)))
+})
+
+test_that("the four categories match real error strings", {
+  cf <- load_classifier()
+
+  # Verbatim shapes taken from ~/.roborev/reviews.db (llm#923 / llm#927).
+  expect_equal(
+    cf("failed", "build prompt: get commit info: git log: chdir /private/tmp/nix-shell-12159-0/RtmpgJFwZN/config_digest_git_fixture_x: no such file or directory"),
+    "ephemeral"
+  )
+  expect_equal(
+    cf("failed", "build prompt: get commit info: git log: chdir /private/var/folders/hn/T/tmp.A7TY377RFq: no such file or directory"),
+    "ephemeral"
+  )
+  expect_equal(
+    cf("failed", "agent: claude-code failed stream: stream errors: You've hit your monthly spend limit · raise it at claude.ai/settings/usage: exit status 1"),
+    "quota"
+  )
+  expect_equal(
+    cf("failed", "agent: gemini failed stream: stream errors: panic: runtime error"),
+    "agent"
+  )
+  expect_equal(cf("failed", "something entirely unrecognised"), "other")
+})
+
+test_that("precedence holds — quota beats agent, ephemeral beats both", {
+  cf <- load_classifier()
+
+  # The real quota string contains BOTH "agent:" and "stream error", so without
+  # ordering it would be filed as an agent failure — which is exactly the
+  # misclassification llm#904 reports (quota counted as a crash, dragging
+  # claude-code's pass rate to 0.14 on billing state rather than quality).
+  expect_equal(
+    cf("failed", "agent: claude-code failed stream: stream errors: You've hit your monthly spend limit"),
+    "quota"
+  )
+  # A deleted-tempdir failure is not roborev's failure at all.
+  expect_equal(cf("failed", "agent: x failed: chdir /tmp/foo: no such file"), "ephemeral")
+})
+
+test_that("vectorised over rows, and handles empty input", {
+  cf <- load_classifier()
+
+  expect_equal(
+    cf(c("failed", "done", "failed", "failed"),
+       c("chdir /tmp/x", NA, "monthly spend limit", "totally unknown")),
+    c("ephemeral", NA, "quota", "other")
+  )
+  expect_length(cf(character(0), character(0)), 0L)
+  # A NULL/absent error column degrades to "other", never to an error.
+  expect_equal(cf("failed", NA_character_), "other")
+})
+
+test_that("snapshot: the category vocabulary is stable", {
+  cf <- load_classifier()
+  errs <- c(
+    "build prompt: get commit info: git log: chdir /private/tmp/x: no such file or directory",
+    "agent: claude-code failed stream: stream errors: You've hit your monthly spend limit",
+    "agent: gemini failed stream: stream errors: panic: runtime error",
+    "fork/exec /opt/homebrew/bin/git: no such file or directory"
+  )
+  expect_snapshot(print(cf(rep("failed", length(errs)), errs)))
+})


### PR DESCRIPTION
First P0 item (#932), and the one the rest of #928 depends on: without `error` in the warehouse, #904 and #927 cannot be measured at all.

## The gap

The ETL selected `rj.status` but **not `rj.error`** — a job's failure was recorded, the reason discarded. So `roborev_daily_metrics` had **no job-failure column at all**: `reviews_passed`/`reviews_failed` derive from `verdict_bool`, which only exists once a job produced a review, and a failed job never produces one. It lands in `reviews_created` and in neither of the others.

Now visible in the new columns:

| date | repo | reviews_created | reviews_passed | **reviews_failed** | **jobs_failed** | quota |
|---|---|---|---|---|---|---|
| 2026-08-03 | llmtelemetry | 200 | 196 | **0** | **4** | 4 |

`reviews_failed = 0` while four jobs failed on quota. A reader concludes perfect health — the exact shape `zero-metric-evidence-or-defect` exists to prevent.

## Changes

- Select `rj.error`, guarded by a `has_error_col` introspection mirroring the existing `has_source_col` pattern (llm#706) — an older roborev schema degrades to NULL rather than throwing.
- New `classify_failure()` → `ephemeral | quota | agent | other`, NA for non-failed.
- Five **additive** columns on `roborev_daily_metrics`: `jobs_failed` plus the four per-category counts.

**Precedence is load-bearing.** The real quota string contains *both* `agent:` and `stream error`, so without ordering it files as an agent failure — which is exactly the misclassification #904 reports, where claude-code's pass rate reads 0.14 on billing state rather than quality.

**`reviews_failed` is deliberately not renamed** despite the misleading name. The schema header says `SCHEMAS FROZEN` and llmtelemetry#144 reads these columns by name (llm#226); a rename is a coordinated cross-repo change, left to #928.

DuckDB rejects `NOT NULL` in `ADD COLUMN` ("Adding columns with constraints not yet supported"), so the new columns carry `DEFAULT 0` only.

## Verification

**Classifier over all 12,319 jobs** in the pre-cleanup backup:

| category | n |
|---|---|
| ephemeral | 2,410 |
| agent | 391 |
| quota | 89 |
| other | 5 (4 distinct patterns) |

NA count 9,424 — **exactly** the non-failed row count. Every failed row categorised.

**Migration**: applied to a table with the *old* shape holding a row → columns added, row backfilled with 0, re-apply idempotent.

**End-to-end**: full ETL against a scratch `UNIFIED_DB`, exit 0, 89 rows upserted.

**Cross-validation against source of truth** — the point of the whole exercise:

```
mirror  SUM(jobs_failed) since 2026-07-20 = 25
sqlite  COUNT(*) status='failed'          = 25
```

Breakdown `quota=24 agent=0 ephemeral=0 other=1`. `ephemeral=0` independently confirms the #923 guard is holding; `other=1` is a stray test repo of mine, already noted on #928.

**Tests**: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 15 ]`, snapshot stable on re-run. The test parses the shipping ETL and extracts the function rather than copying it, so it cannot drift from the code.

## Not in this PR

#928's remaining items — mirror repair (720 dead repo names), the dropped-review metric, and the `zero-metric-evidence` guard. This one unblocks them by putting the evidence in the warehouse.

Refs #928, #932, #904, #927, #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)