### PR TITLE
fix(canonical): guard was silently dropping 9 live repos from the warehouse (#652)

### DIFF
--- a/.claude/data/canonical_projects.csv
+++ b/.claude/data/canonical_projects.csv
@@ -19,3 +19,10 @@ rix.setup,rix Setup,JohnGavin/rix.setup,meta-config,true,
 urban_planning,Urban Planning,JohnGavin/urban_planning,analysis,true,
 eis6,EIS 6,,analysis,true,SENSITIVE — local git only; NEVER push to GitHub
 t-demos,T-lang demos (archived),,analysis,false,defunct; archived to proj/data/tlang/t_demos.zip 2026-06-20
+knowledge,Knowledge Base,,other,true,llm#652 — kind=knowledge-base but CHECK allows only r-package/quarto-website/dashboard/analysis/meta-config/other; path docs_gh/llm/knowledge; LOCAL git only per wiki-storage-policy; 526 roborev jobs were being dropped
+travel,Travel,,analysis,true,llm#652 — path docs_gh/proj/pers/travel; 42 roborev jobs dropped; still active 2026-08-06
+tennis,Tennis,,analysis,true,llm#652 — path docs_gh/proj/pers/tennis; NB a second repo row also named tennis at docs_gh/tennis — verify which is live
+ideas,Ideas,,analysis,true,llm#652 — path docs_gh/proj/stats/ideas
+content,LLM Content Cache,,other,true,llm#652 — kind=cache but CHECK allows only the six listed kinds; path docs_gh/proj/data/llm/content; pkgctx external-context cache
+hello_t,T-lang hello (archived),,analysis,false,llm#652 — path docs_gh/proj/data/tlang/hello_t; same defunct family as t-demos
+my_t_project,T-lang my_t_project (archived),,analysis,false,llm#652 — path docs_gh/proj/data/tlang/my_t_project; same defunct family as t-demos

--- a/.claude/scripts/canonical_projects_migrate.sh
+++ b/.claude/scripts/canonical_projects_migrate.sh
@@ -10,7 +10,10 @@
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-LIVE_DB="$HOME/.claude/logs/unified.duckdb"
+# UNIFIED_DB override (llm#652) so the migration can be exercised end-to-end
+# against a copy before touching the live warehouse. Same variable name the
+# ETL already honours (roborev_metrics_etl.R), so one export covers both.
+LIVE_DB="${UNIFIED_DB:-$HOME/.claude/logs/unified.duckdb}"
 PROJECTS_CSV="$REPO_ROOT/.claude/data/canonical_projects.csv"
 ALIASES_CSV="$REPO_ROOT/.claude/data/canonical_project_aliases.csv"
 NIX_DEFAULT="$REPO_ROOT/default.nix"
@@ -143,22 +146,32 @@ if [ "$MODE" = "selftest" ]; then
     result=$(duck_query "$FIXTURE_DB" "SELECT COUNT(*) FROM information_schema.tables WHERE table_name IN ('canonical_projects','canonical_project_aliases');")
     assert_eq "DDL creates both tables" "2" "$result"
 
-    # Test 2 — UPSERT loads 18 projects
+    # Expected counts are DERIVED from the CSVs, not hardcoded (llm#652).
+    # They were previously fixed at 18 and 1, and had silently rotted to
+    # failing against 20 and 12 — a test that asserts a constant against a
+    # file designed to grow will always end up asserting the past. Deriving
+    # them keeps the real property under test: every CSV row lands exactly
+    # once, and a second run changes nothing.
+    expect_projects=$(($(grep -c '' "$PROJECTS_CSV") - 1))
+    expect_aliases=$(($(grep -c '' "$ALIASES_CSV") - 1))
+
+    # Test 2 — UPSERT loads every project row
     duck_query "$FIXTURE_DB" "$(upsert_sql "$PROJECTS_CSV" "$ALIASES_CSV")" > /dev/null
     count_projects=$(duck_query "$FIXTURE_DB" "SELECT COUNT(*) FROM canonical_projects;")
-    assert_eq "18 projects after first UPSERT" "18" "$count_projects"
+    assert_eq "all $expect_projects CSV projects after first UPSERT" "$expect_projects" "$count_projects"
 
-    # Test 3 — UPSERT loads 1 alias
+    # Test 3 — UPSERT loads every alias row
     count_aliases=$(duck_query "$FIXTURE_DB" "SELECT COUNT(*) FROM canonical_project_aliases;")
-    assert_eq "1 alias after first UPSERT" "1" "$count_aliases"
+    assert_eq "all $expect_aliases CSV aliases after first UPSERT" "$expect_aliases" "$count_aliases"
 
     # Test 4 — idempotency: second UPSERT leaves counts unchanged
     duck_query "$FIXTURE_DB" "$(upsert_sql "$PROJECTS_CSV" "$ALIASES_CSV")" > /dev/null
     count_projects2=$(duck_query "$FIXTURE_DB" "SELECT COUNT(*) FROM canonical_projects;")
-    assert_eq "18 projects after second UPSERT (idempotency)" "18" "$count_projects2"
+    assert_eq "$expect_projects projects after second UPSERT (idempotency)" "$expect_projects" "$count_projects2"
 
-    # Test 5 — alias slug exists (coMMpass → commpass)
-    alias_check=$(duck_query "$FIXTURE_DB" "SELECT alias FROM canonical_project_aliases WHERE slug='coMMpass';")
+    # Test 5 — a known alias resolves. coMMpass has several aliases, so match
+    # the one under test rather than taking whichever row comes back first.
+    alias_check=$(duck_query "$FIXTURE_DB" "SELECT alias FROM canonical_project_aliases WHERE slug='coMMpass' AND alias='commpass';")
     assert_eq "alias commpass exists for coMMpass" "commpass" "$alias_check"
 
     rm -f "$FIXTURE_DB"


### PR DESCRIPTION
P0 (#932). Found while scoping #928's mirror cleanup — **and it stopped that cleanup**, which would have deleted real data.

## What was happening

The #536 guard filters the roborev ETL to repos in `canonical_projects`, keeping test fixtures out of the warehouse. It works — fixture pollution stops dead at 2026-06-26.

But the CSV was missing **nine live repos**, so the guard dropped those too, silently, to `canonical_producer_skip.log`:

| repo | skips | roborev jobs | newest |
|---|---|---|---|
| knowledge | 52 | **526** | 2026-08-01 |
| travel | 56 | 42 | **2026-08-06 (today)** |
| tennis | 13 | 10 | 2026-07-21 |
| my_t_project | 4 | 7 | 2026-04-06 |
| ideas | 8 | 2 | 2026-07-21 |
| content, hello_t, tlang-clone, fix-ci-shallow-clone | 4/4/4/17 | 1 each | — |

**591 jobs across 9 repos, invisible to every metric, dashboard and rollup.**

This is exactly why the planned "delete non-canonical rows from the mirror" is **not** in this PR: run against the current list, it would have destroyed real history for these projects.

## Changes

**`canonical_projects.csv`** — +7 rows. `knowledge`, `travel`, `tennis`, `ideas`, `content` active; `hello_t`, `my_t_project` inactive (same defunct T-lang family as the existing `t-demos`).

Deliberately **not** added: `tlang-clone` and `fix-ci-shallow-clone` — both are worktree paths, not projects. The guard is right to drop those.

`repo` left blank on all seven: their GitHub slugs are unknown to me and inventing them would be fabrication. Same pattern as the existing `eis6` row. Worth a look when you have a moment — that column is the one thing here I couldn't derive.

**`canonical_projects_migrate.sh`** — selftest expectations now derived from the CSVs rather than hardcoded `18`/`1`. They had rotted to failing against the real 20/12: a test asserting a constant against a file designed to grow asserts the past. Also fixed test 5 (coMMpass has several aliases; it was taking whichever row came back first) and added a `UNIFIED_DB` override so the migration is testable against a copy.

## One trap worth recording

`canonical_projects` has `CHECK(kind IN ('r-package','quarto-website','dashboard','analysis','meta-config','other'))`. My first attempt used `kind=knowledge-base` and `kind=cache`. The INSERT failed wholesale, the aliases INSERT then failed its FK, and the selftest reported **"0 projects"** — which reads as an empty CSV rather than a rejected value, because `duck_query` sends stderr to `/dev/null`.

Four wrong hypotheses before I stopped guessing and instrumented. That stderr suppression is itself a zero-metric-evidence defect and deserves a follow-up.

## Verification

- selftest **5/5** (was **1/5 on main** — pre-existing rot, not caused here)
- Migration applied to a **copy** of live `unified.duckdb`: all 7 slugs present
- Full ETL against that copy, `--since 2026-07-01`, exit 0, 168 daily rows:

| repo | days | reviews | newest |
|---|---|---|---|
| travel | 18 | 42 | 2026-08-06 |
| knowledge | 6 | 11 | 2026-08-01 |
| tennis | 4 | 10 | — |
| ideas | 1 | 2 | — |

Previously **zero rows** for all of them. `content` correctly shows none — its only job predates the window.

## Deploy step (llm#510)

The live DB is untouched. After merge, the fix takes effect only once the migration runs against it:

```bash
bash .claude/scripts/canonical_projects_migrate.sh
```

Then a normal ETL run backfills the previously-dropped history.

Refs #652, #932, #928, #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)