### PR TITLE
fix(signal): un-pin signal-cli path and stop swallowing receive failures (#937)

### DIFF
--- a/.claude/scripts/signal_notes_sync.sh
+++ b/.claude/scripts/signal_notes_sync.sh
@@ -13,7 +13,19 @@ elif [ -e "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh" ]; then
 fi
 export PATH="$JAVA_HOME/bin:/opt/homebrew/bin:$PATH"
 
-SIGNAL_CLI="/opt/homebrew/Cellar/signal-cli/0.14.2/libexec/bin/signal-cli"
+# Version-STABLE path (llm#937). This was pinned to the 0.14.2 Cellar directory;
+# Homebrew upgraded signal-cli to 0.14.3_1 on 2026-05-10 12:03 and that directory
+# ceased to exist. The `receive` below is wrapped in `2>/dev/null || echo ""`, so
+# "command not found" became an empty message list — indistinguishable from "no
+# new messages". Capture stopped silently at 11:54 the same morning; the job kept
+# exiting 0 for three months.
+# Never pin a Cellar version here: /opt/homebrew/bin/signal-cli is the symlink
+# Homebrew repoints on upgrade.
+SIGNAL_CLI="${SIGNAL_CLI:-/opt/homebrew/bin/signal-cli}"
+if [ ! -x "$SIGNAL_CLI" ]; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') FATAL: signal-cli not executable at $SIGNAL_CLI" >> "$HOME/.claude/logs/signal_sync.log"
+  exit 1
+fi
 ACCOUNT="+447521254904"
 DUMP_DIR="$HOME/docs_gh/llm/knowledge/raw/braindumps"
 ATTACH_DIR="$HOME/.local/share/signal-cli/attachments"
@@ -30,7 +42,19 @@ mkdir -p "$DUMP_DIR"
 touch "$PROCESSED_LOG"
 
 # Receive messages (timeout 30s)
-MESSAGES=$(timeout 30 "$SIGNAL_CLI" -a "$ACCOUNT" --output=json receive 2>/dev/null || echo "")
+# llm#937: distinguish "receive failed" from "no new messages". These were
+# previously the same empty string, which is how a dead binary path masqueraded
+# as three months of silence. stderr is captured rather than discarded so the
+# reason survives into the log.
+_recv_err=$(mktemp)
+MESSAGES=$(timeout 30 "$SIGNAL_CLI" -a "$ACCOUNT" --output=json receive 2>"$_recv_err") || _recv_rc=$?
+_recv_rc=${_recv_rc:-0}
+if [ "$_recv_rc" -ne 0 ]; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') RECEIVE FAILED rc=$_recv_rc: $(head -c 300 "$_recv_err" | tr '\n' ' ')" >> "$LOG"
+  rm -f "$_recv_err"
+  exit "$_recv_rc"
+fi
+rm -f "$_recv_err"
 
 if [ -z "$MESSAGES" ]; then
   # Even with no new messages, check for unprocessed voice attachments


### PR DESCRIPTION
Signal notes stopped reaching `braindumps` on **2026-05-10 11:54:42**. Homebrew upgraded signal-cli **0.14.2 → 0.14.3_1 at 12:03 the same morning** — nine minutes later.

The script hardcoded the version-pinned Cellar path, which ceased to exist. Combined with `2>/dev/null || echo ""`, "command not found" produced an empty message list — byte-identical to "no new messages". The launchd job exited 0 every 5 minutes for **three months** and `signal_sync.log` stayed **0 bytes**.

## Changes

- Use `/opt/homebrew/bin/signal-cli` — the symlink Homebrew repoints on upgrade — overridable via `$SIGNAL_CLI`, with an `-x` guard that exits 1 and logs FATAL rather than proceeding with a missing binary.
- Capture `receive`'s stderr **and** exit code instead of discarding both; log `RECEIVE FAILED rc=N: <reason>` and exit non-zero.

## Verification

The first run after the change logged:

```
2026-08-09 19:12:21 RECEIVE FAILED rc=124: INFO Shutdown - Received SIGTERM...
```

The old code would have logged nothing and reported success. `bash -n` clean.

## Not fixed here — see #937

The daemon writes every received message to `StandardOutPath=/tmp/signal_cli_daemon_stdout.log`, which macOS had **already unlinked**. `lsof` on the live daemon showed 9,900 bytes on an inode with no directory entry:

```
signal-cl 5011 1u REG 1,17 9900 533942863 /private/tmp/signal_cli_daemon_stdout.log
```

That destroyed the messages sent 2026-08-09. The daemon and this script also race for the same once-only delivery, and the daemon's RPC `receive` — the path the script is meant to use — returns `NullPointerException` under `--receive-mode on-start`.

**Recommend running the sync job alone until both are addressed.** The daemon is currently stopped.

Refs #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)