### PR TITLE
docs(rules): snapshot before a migration that rewrites existing rows

### DIFF
--- a/.claude/rules/data-in-packages.md
+++ b/.claude/rules/data-in-packages.md
@@ -3,6 +3,12 @@ paths:
   - "inst/extdata/**"
   - "data/**"
   - "vignettes/data/**"
+  # The migration-snapshot section below is decided while editing ETL and
+  # pipeline code, not while editing the data directory it protects. A rule
+  # that loads only after the damage is done is a rule that never fires.
+  - "R/etl_*.R"
+  - "R/tar_plans/**"
+  - "_targets.R"
 ---
 # Data in R Packages
 
@@ -60,6 +66,62 @@ REFERENCE_MIN_DAYS_SPAN <- 90
 
 **MANDATORY:** Record in `data_provenance` target: content hash, timestamp, row count, date range.
 
+## Snapshot Before a Migration That Rewrites Existing Rows (MANDATORY)
+
+The table above covers *periodic* versioning. This is the *event-triggered*
+snapshot, and it is the one that gets skipped — because the run that needs it
+looks like every other pipeline run right up until it isn't.
+
+### Trigger
+
+Before any pipeline run that will **change rows that already exist**, rather
+than only appending new ones:
+
+| Change | Why it rewrites |
+|---|---|
+| Entity/component rename or merge | rows change identity; duplicates may collapse |
+| Parser fix affecting already-ingested values | stored values change under a stable key |
+| Regenerating source files from their origin | the inputs the store rebuilds from change |
+| Any run whose expected row-count delta is non-zero | by definition |
+
+NOT needed for pure appends, or for a store fully regenerable from committed
+inputs in minutes. **Say which of those applies** rather than skipping in
+silence — "it's regenerable" is a claim, and the time to test it is not
+after a bad run.
+
+### Name the snapshot for the CHANGE, not just the date
+
+```
+<store>.bak_YYYYMMDD_pre_<issue-or-change>
+mycare.duckdb.bak_20260806_pre_030_040
+```
+
+A date alone stops being enough at about the third one. The reader restoring
+in six months needs to know which snapshot predates the thing they want to
+undo — the filename is the rollback index, so put the change in it.
+
+### Predict the delta, then verify it
+
+A snapshot makes a run **recoverable**; it does not make it **correct**. State
+the expected row-count change and its reason before running, then check:
+
+```
+predicted  12,334 -> 12,324   (-10, all same-value same-date duplicates)
+actual     12,329             (-10 from the merge, +5 from a newly-routed source)
+```
+
+Both numbers were expected and each is attributable to a named change. An
+unexplained delta is a defect until reconciled — **including a delta of zero
+where one was expected**, which is the `zero-metric-evidence-or-defect` case:
+a migration that changed nothing usually means it did not run.
+
+### Prune
+
+Snapshots are large and accumulate quietly — `du -ch <store>.bak*` reached
+396 MB across 8 files in one project before anyone looked. Keep the ones that
+bracket a schema or identity change; delete the rest once the following run is
+verified.
+
 ## Checklist
 
 - [ ] No files > 5 MB in `inst/extdata/` without justification
@@ -69,3 +131,6 @@ REFERENCE_MIN_DAYS_SPAN <- 90
 - [ ] Fixed reference baseline for monotonic assertions
 - [ ] Large data via download functions, not shipped
 - [ ] Time-series has temporal coverage targets
+- [ ] Row-rewriting migration: snapshot taken FIRST, named for the change
+- [ ] Row-count delta predicted before the run and reconciled after
+- [ ] Stale snapshots pruned once the following run is verified


### PR DESCRIPTION
Rescued from an **unpushed commit sitting on the local main checkout** (`1ee862a`), found while deploying #938: `git merge --ff-only` refused because local main had diverged by one commit.

That is the llm#510 deploy-gap failure mode with a twist — the blocker wasn't a stale checkout, it was a commit made directly to local `main` that was never pushed. Until now it existed on exactly one disk, and `.claude/rules/data-in-packages.md` differed between the main checkout and every worktree.

No content changes; this is the original commit moved onto a branch so it can land through review, per #770 (route rule/memory edits through the PR flow). Local `main` was then reset to `origin/main` to unblock the deploy — the commit was branched **before** the reset, so nothing was at risk.

Worth noting the rule it adds is a good one: snapshot before any migration that rewrites existing rows, name the snapshot for the change rather than the date, predict the row-count delta and reconcile it afterwards — including treating an unexplained **zero** delta as a defect, which is the same principle as `zero-metric-evidence-or-defect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)