### PR TITLE
fix(secrets): load ~/.config/secrets.env in launchd wrappers — launchd runs no shell (#791, #936)

### DIFF
--- a/.claude/scripts/roborev_auto_refine.sh
+++ b/.claude/scripts/roborev_auto_refine.sh
@@ -11,6 +11,38 @@
 
 set -euo pipefail
 
+# ── Secrets (llm#791 / llm#936) ───────────────────────────────────────────────
+# ~/.config/secrets.env is the single source of truth and ~/.zshenv already
+# sources it — but ONLY for zsh. launchd does not run a shell at all, so a
+# launchd-started daemon gets exactly what its plist's EnvironmentVariables
+# block provides, which here is PATH and nothing else.
+#
+# This daemon ran fine for days purely because it had been started once from an
+# interactive shell and KeepAlive kept that process alive. When it finally died
+# on 2026-08-06 22:34 launchd respawned it with the plist environment, gemini
+# lost GEMINI_API_KEY, and every review failed for two days — 13 jobs, zero
+# successes, no alert. The key never moved; the daemon's parent did.
+#
+# Do NOT put secrets in the plist instead: .claude/launchd/*.plist is
+# version-controlled, so that would commit them to git.
+if [ -r "$HOME/.config/secrets.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$HOME/.config/secrets.env"
+  set +a
+fi
+
+# Fail loud rather than failing 13 times in silence. A daemon that cannot
+# authenticate should not start.
+_missing=""
+for _v in GEMINI_API_KEY; do
+  [ -n "${!_v:-}" ] || _missing="$_missing $_v"
+done
+if [ -n "$_missing" ]; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') FATAL: missing secret(s):$_missing — expected in ~/.config/secrets.env (llm#791)" >&2
+  exit 78   # EX_CONFIG
+fi
+
 # Mark session as scheduled/automated for llmtelemetry_emit.sh (#322 Phase 2).
 # Propagates to any claude process spawned by roborev refine so the Stop hook
 # emits "trigger":"scheduled" without requiring a /bye sentinel.

--- a/bin/launchd_run_record.sh
+++ b/bin/launchd_run_record.sh
@@ -21,6 +21,26 @@
 
 set -euo pipefail
 
+# ── Secrets (llm#791 / llm#936) ───────────────────────────────────────────────
+# Every job that runs through this wrapper inherits the environment loaded here.
+# ~/.config/secrets.env is the single source of truth; ~/.zshenv sources it for
+# zsh, but launchd does not run a shell, so without this line a launchd job sees
+# only its plist's EnvironmentVariables (typically just PATH).
+#
+# This is the one edit point that covers every job using the recorder. Daemons
+# started outside it — e.g. com.roborev.auto-refine — must load it themselves.
+#
+# Deliberately NOT fail-loud here: this wrapper is generic and most jobs need no
+# secrets at all. Jobs with a hard requirement assert their own (see
+# roborev_auto_refine.sh). Missing-file is silent by design; the file is
+# optional on a machine that has no secrets.
+if [ -r "$HOME/.config/secrets.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$HOME/.config/secrets.env"
+  set +a
+fi
+
 # ── Arg parsing ────────────────────────────────────────────────────────────────
 
 if [[ $# -lt 3 ]]; then


### PR DESCRIPTION
## The centralised solution already existed

`~/.config/secrets.env` (mode 600, 10 keys) is sourced by `~/.zshenv` line 2, covering interactive **and** non-interactive zsh. I was about to propose building this; #791 already did.

## The real gap is narrower than #936 said

**launchd does not run a shell at all.** No rc file — `.zshenv` included — can reach a launchd job. It sees only its plist's `EnvironmentVariables`, which for `com.roborev.auto-refine` is `PATH` and nothing else.

That is the entire cause of the 2-day gemini outage: the daemon had been started once from an interactive shell, and `KeepAlive` kept *that process* alive for days. When it died 2026-08-06 22:34, launchd respawned it with the plist environment, `GEMINI_API_KEY` vanished, and 13 consecutive jobs failed — zero successes, no alert. **The key never moved; the daemon's parent did.** `KeepAlive: true` guarantees recurrence on every future respawn.

## Two edit points

| file | why |
|---|---|
| `bin/launchd_run_record.sh` | The shared recorder every plist-with-a-recorder routes through — one line covers all of them. **Not** fail-loud: it's generic, most jobs need no secrets. |
| `.claude/scripts/roborev_auto_refine.sh` | Its plist invokes it **directly**, bypassing the recorder. Loads secrets itself *and* asserts what it needs — exit 78 (`EX_CONFIG`) with a logged FATAL rather than starting and failing silently 13 times. |

**Deliberately not done:** secrets in plist `EnvironmentVariables`. `.claude/launchd/*.plist` is version-controlled — that would commit credentials to git.

## Verification — two-sided, reproducing the launchd condition

```
env -u GEMINI_API_KEY HOME=/tmp/nonexistent  auto_refine status
  -> exit 78 + "FATAL: missing secret(s): GEMINI_API_KEY — expected in ~/.config/secrets.env"

env -u GEMINI_API_KEY                        auto_refine status
  -> exit 0   (loader supplied it from secrets.env)

env -u GEMINI_API_KEY launchd_run_record.sh ... -> child sees GEMINI_API_KEY:LOADED
```

`bash -n` clean on both.

## Follow-up

`~/.zshenv` still defines `GMAIL_APP_PASSWORD`, `FRED_API_KEY` and `AlphaVantage_API_KEY` inline rather than in `secrets.env` — the migration to a single source is partial.

Refs #791, #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)