### PR TITLE
fix(roborev): run ALTER statements even when schema init skips (#941)

### DIFF
--- a/.claude/scripts/roborev_metrics_etl.R
+++ b/.claude/scripts/roborev_metrics_etl.R
@@ -2387,8 +2387,38 @@ existing_tables <- tolower(tryCatch(
   error = function(e) character(0)
 ))
 
+# ALTER statements must run even when the skip below fires (llm#941).
+#
+# The skip only inspects CREATE TABLE statements: if every table exists it
+# skips ALL statements, so an additive `ALTER TABLE ... ADD COLUMN IF NOT
+# EXISTS` could never reach an existing database. Any schema evolution after
+# first creation was silently unapplied, and the failure surfaced far away as
+#   INTERNAL Error: Column with name "jobs_failed" does not exist
+# mid-transaction, after the ETL had done all its work.
+#
+# Every ALTER in the schema file is idempotent (IF NOT EXISTS / IF EXISTS), so
+# running them unconditionally is safe and cheap.
+alter_stmts <- stmts[grepl("^[[:space:]]*[Aa][Ll][Tt][Ee][Rr][[:space:]]+[Tt][Aa][Bb][Ll][Ee]", stmts)]
+if (length(alter_stmts) > 0L) {
+  n_alter_ok <- 0L
+  for (stmt in alter_stmts) {
+    tryCatch({
+      dbExecute(duck_con, stmt)
+      n_alter_ok <- n_alter_ok + 1L
+    }, error = function(e) {
+      # Do not abort: a failed ALTER on one table must not block the run. Log
+      # loudly — a silent skip here is what llm#941 was.
+      log_msg("WARN: ALTER failed (schema evolution incomplete): ",
+              substr(gsub("[\n ]+", " ", stmt), 1L, 120L),
+              " — ", conditionMessage(e))
+    })
+  }
+  cat(sprintf("roborev_metrics_etl.R: applied %d/%d ALTER statement(s)\n",
+              n_alter_ok, length(alter_stmts)))
+}
+
 if (length(expected_tables) > 0L && all(expected_tables %in% existing_tables)) {
-  cat(sprintf("roborev_metrics_etl.R: schema init skipped — all %d tables present\n",
+  cat(sprintf("roborev_metrics_etl.R: schema init skipped — all %d tables present (ALTERs already applied above)\n",
               length(expected_tables)))
 } else {
   tryCatch({


### PR DESCRIPTION
Found deploying #933 to the live warehouse — the ETL aborted mid-transaction with `INTERNAL Error: Column with name "jobs_failed" does not exist`.

## Cause

Schema init guards on `CREATE TABLE` statements only, but its else-branch runs **all** statements:

```r
if (all(expected_tables %in% existing_tables)) { skip } else { run everything }
```

So on any database where the tables already exist — i.e. **every real one** — `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` was never executed. Additive schema evolution has never been able to reach an existing DB through the ETL.

## Fix

Extract ALTER statements and run them unconditionally, before the CREATE-skip logic. Every ALTER in the schema file is idempotent, so this is safe and cheap. A failing ALTER is logged loudly but doesn't abort — a silent skip is exactly what this bug was.

## Why #933's tests missed it

Worth recording, because the test *looked* end-to-end and wasn't.

I verified #933 three ways — schema file against an old-shape table, ETL end-to-end against a scratch DB, cross-validation of the numbers. All passed. But I had applied the schema **by hand** to that scratch DB first, so the ETL's own schema-application path was never exercised. The test rehearsed the deploy with the hard part already done.

General form: **when a fix has a migration step, the test must start from the un-migrated state**, not from whatever the setup script left behind.

## Verification

Reproduced the exact condition — 9 tables present, the 5 new columns dropped:

```
before   jobs_failed% columns = 0
run      applied 8/8 ALTER statement(s)
         schema init skipped — all 9 tables present (ALTERs already applied above)
         roborev_daily_metrics — upserted 22 rows        exit 0
after    jobs_failed% columns = 5
```

Before the fix, this same scenario produced the INTERNAL error.

Refs #941, #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)